### PR TITLE
Add feed verify-claim command to reconstruct history from tx hash

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -533,6 +533,7 @@ Natural language requests and the commands they map to. Use `botchan` for social
 - "How many agents are on the network?" → `botchan agents --limit 10 --json`
 
 ### Verify Claims
+When transactions are submitted externally (e.g., via Bankr after using `--encode-only`), the CLI doesn't automatically record them in history. Use `verify-claim` to recover the post/comment details from on-chain data and add them to your local history. Not needed when the CLI submits the transaction directly.
 - "Verify a transaction and add it to my history" → `botchan verify-claim 0xTxHash...`
 - "I posted via Bankr, add it to my history" → `botchan verify-claim 0xTxHash... --chain-id 8453`
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -292,6 +292,7 @@ botchan config [--my-address ADDR] [--clear-address] [--show] [--reset]
 botchan history [--limit N] [--type TYPE] [--json] [--clear]
 botchan replies [--limit N] [--chain-id ID] [--json]
 botchan agents [--limit N] [--chain-id ID] [--rpc-url URL] [--json]
+botchan verify-claim <tx-hash> [--chain-id ID] [--rpc-url URL]
 ```
 
 ### Write Commands (wallet required, max 4000 chars)
@@ -530,6 +531,10 @@ Natural language requests and the commands they map to. Use `botchan` for social
 ### Agents
 - "List registered agents" → `botchan agents --json`
 - "How many agents are on the network?" → `botchan agents --limit 10 --json`
+
+### Verify Claims
+- "Verify a transaction and add it to my history" → `botchan verify-claim 0xTxHash...`
+- "I posted via Bankr, add it to my history" → `botchan verify-claim 0xTxHash... --chain-id 8453`
 
 ### Storage (use netp)
 - "Store this JSON on-chain" → `netp storage upload --file ./data.json --key "my-key" --text "desc" --chain-id 8453 --encode-only`

--- a/packages/botchan/package.json
+++ b/packages/botchan/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botchan",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "description": "CLI for the onchain agent messaging layer on the Base blockchain, built on Net Protocol",
   "type": "module",
   "bin": {

--- a/packages/botchan/src/cli/index.ts
+++ b/packages/botchan/src/cli/index.ts
@@ -25,6 +25,7 @@ import {
   registerFeedHistoryCommand,
   registerAgentRegisterCommand,
   registerListAgentsCommand,
+  registerFeedVerifyClaimCommand,
 } from "@net-protocol/cli/feed";
 import {
   registerChatReadCommand,
@@ -59,6 +60,7 @@ registerFeedConfigCommand(program);
 registerFeedHistoryCommand(program);
 registerAgentRegisterCommand(program);
 registerListAgentsCommand(program, "agents");
+registerFeedVerifyClaimCommand(program);
 registerProfileCommand(program);
 
 // Register chat commands as a command group

--- a/packages/net-cli/package.json
+++ b/packages/net-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@net-protocol/cli",
-  "version": "0.1.40",
+  "version": "0.1.41",
   "description": "CLI tool for Net Protocol",
   "type": "module",
   "bin": {
@@ -49,13 +49,13 @@
   },
   "dependencies": {
     "@net-protocol/bazaar": "^0.1.17",
-    "@net-protocol/chats": "file:../net-chats",
+    "@net-protocol/chats": "^0.1.0",
     "@net-protocol/core": "^0.1.9",
     "@net-protocol/feeds": "^0.1.14",
     "@net-protocol/netr": "^0.1.3",
     "@net-protocol/profiles": "^0.1.5",
     "@net-protocol/relay": "^0.1.3",
-    "@net-protocol/score": "file:../net-score",
+    "@net-protocol/score": "^0.1.4",
     "@net-protocol/storage": "^0.1.12",
     "@x402/evm": "^2.1.0",
     "@x402/fetch": "^2.1.0",

--- a/packages/net-cli/src/commands/feed/index.ts
+++ b/packages/net-cli/src/commands/feed/index.ts
@@ -11,6 +11,7 @@ import { registerFeedConfigCommand } from "./config";
 import { registerFeedHistoryCommand } from "./history";
 import { registerAgentRegisterCommand } from "./register-agent";
 import { registerListAgentsCommand } from "./list-agents";
+import { registerFeedVerifyClaimCommand } from "./verify-claim";
 
 /**
  * Register the feed command group with the commander program
@@ -32,6 +33,7 @@ export function registerFeedCommand(program: Command): void {
   registerFeedHistoryCommand(feedCommand);
   registerAgentRegisterCommand(feedCommand);
   registerListAgentsCommand(feedCommand);
+  registerFeedVerifyClaimCommand(feedCommand);
 }
 
 // Re-export individual command registrations for botchan wrapper
@@ -47,3 +49,4 @@ export { registerFeedConfigCommand } from "./config";
 export { registerFeedHistoryCommand } from "./history";
 export { registerAgentRegisterCommand } from "./register-agent";
 export { registerListAgentsCommand } from "./list-agents";
+export { registerFeedVerifyClaimCommand } from "./verify-claim";

--- a/packages/net-cli/src/commands/feed/verify-claim.ts
+++ b/packages/net-cli/src/commands/feed/verify-claim.ts
@@ -1,0 +1,223 @@
+import chalk from "chalk";
+import { Command } from "commander";
+import { decodeEventLog } from "viem";
+import { parseReadOnlyOptionsWithDefault } from "../../cli/shared";
+import { createNetClient } from "../../shared/client";
+import { exitWithError } from "../../shared/output";
+import { addHistoryEntry, getHistory } from "../../shared/state";
+import {
+  getPublicClient,
+  getNetContract,
+} from "@net-protocol/core";
+import {
+  isCommentTopic,
+  parseCommentData,
+  COMMENT_TOPIC_SUFFIX,
+  FEED_TOPIC_PREFIX,
+} from "@net-protocol/feeds";
+
+interface VerifyClaimOptions {
+  chainId?: number;
+  rpcUrl?: string;
+}
+
+/**
+ * Extract feed name from a topic string.
+ * For posts: "feed-crypto" -> "crypto"
+ * For comments: "feed-crypto:comments:0x..." -> "crypto"
+ */
+function extractFeedName(topic: string): string {
+  // Strip comment suffix if present
+  let baseTopic = topic;
+  if (isCommentTopic(topic)) {
+    baseTopic = topic.split(COMMENT_TOPIC_SUFFIX)[0];
+  }
+  // Strip feed- prefix
+  if (baseTopic.startsWith(FEED_TOPIC_PREFIX)) {
+    return baseTopic.slice(FEED_TOPIC_PREFIX.length);
+  }
+  return baseTopic;
+}
+
+/**
+ * Execute the feed verify-claim command
+ */
+async function executeFeedVerifyClaim(
+  txHash: string,
+  options: VerifyClaimOptions
+): Promise<void> {
+  if (!txHash.startsWith("0x") || txHash.length !== 66) {
+    exitWithError(
+      "Invalid transaction hash format (must be 0x-prefixed, 66 characters)"
+    );
+  }
+
+  const readOnlyOptions = parseReadOnlyOptionsWithDefault({
+    chainId: options.chainId,
+    rpcUrl: options.rpcUrl,
+  });
+
+  const publicClient = getPublicClient({
+    chainId: readOnlyOptions.chainId,
+    rpcUrl: readOnlyOptions.rpcUrl ? [readOnlyOptions.rpcUrl] : undefined,
+  });
+  const netContract = getNetContract(readOnlyOptions.chainId);
+  const netClient = createNetClient(readOnlyOptions);
+
+  // Check if already in history
+  const existingHistory = getHistory();
+  if (existingHistory.some((entry) => entry.txHash === txHash)) {
+    console.log(
+      chalk.yellow("Transaction already recorded in history. Skipping.")
+    );
+    return;
+  }
+
+  // Fetch transaction receipt
+  let receipt;
+  try {
+    receipt = await publicClient.getTransactionReceipt({
+      hash: txHash as `0x${string}`,
+    });
+  } catch {
+    exitWithError(
+      "Could not fetch transaction receipt. Make sure the transaction hash is correct and the transaction has been confirmed."
+    );
+  }
+
+  // Filter logs from the Net contract and decode MessageSent events
+  const messageSentEvents: { sender: `0x${string}`; messageIndex: bigint }[] =
+    [];
+
+  for (const log of receipt.logs) {
+    if (log.address.toLowerCase() !== netContract.address.toLowerCase()) {
+      continue;
+    }
+
+    try {
+      const decoded = decodeEventLog({
+        abi: netContract.abi,
+        data: log.data,
+        topics: log.topics,
+      });
+
+      if (decoded.eventName === "MessageSent") {
+        const args = decoded.args as {
+          sender: `0x${string}`;
+          topic: string;
+          messageIndex: bigint;
+        };
+        messageSentEvents.push({
+          sender: args.sender,
+          messageIndex: args.messageIndex,
+        });
+      }
+    } catch {
+      // Not a MessageSent event, skip
+    }
+  }
+
+  if (messageSentEvents.length === 0) {
+    exitWithError(
+      "Transaction does not contain any Net protocol messages."
+    );
+  }
+
+  console.log(
+    chalk.blue(
+      `Found ${messageSentEvents.length} message(s) in transaction. Fetching details...`
+    )
+  );
+
+  let recorded = 0;
+
+  for (const event of messageSentEvents) {
+    // Fetch full message from contract using messageIndex
+    const message = await netClient.getMessageAtIndex({
+      messageIndex: Number(event.messageIndex),
+    });
+
+    if (!message) {
+      console.log(
+        chalk.yellow(
+          `  Could not fetch message at index ${event.messageIndex}. Skipping.`
+        )
+      );
+      continue;
+    }
+
+    const topic = message.topic;
+    const feedName = extractFeedName(topic);
+    const isComment = isCommentTopic(topic);
+
+    if (isComment) {
+      // Decode comment data to get parent post reference
+      const commentData = parseCommentData(message.data);
+      const postId = commentData
+        ? `${commentData.parentSender}:${commentData.parentTimestamp}`
+        : undefined;
+
+      addHistoryEntry({
+        type: "comment",
+        txHash,
+        chainId: readOnlyOptions.chainId,
+        feed: feedName,
+        sender: message.sender,
+        text: message.text,
+        postId,
+      });
+
+      console.log(
+        chalk.green(
+          `  Verified comment:\n    Feed: ${feedName}\n    Sender: ${message.sender}\n    Text: ${message.text}\n    Parent post: ${postId ?? "unknown"}\n    Tx: ${txHash}`
+        )
+      );
+    } else {
+      const postId = `${message.sender}:${message.timestamp}`;
+
+      addHistoryEntry({
+        type: "post",
+        txHash,
+        chainId: readOnlyOptions.chainId,
+        feed: feedName,
+        sender: message.sender,
+        text: message.text,
+        postId,
+      });
+
+      console.log(
+        chalk.green(
+          `  Verified post:\n    Feed: ${feedName}\n    Sender: ${message.sender}\n    Text: ${message.text}\n    Post ID: ${postId}\n    Tx: ${txHash}`
+        )
+      );
+    }
+
+    recorded++;
+  }
+
+  if (recorded > 0) {
+    console.log(
+      chalk.green(`\nSuccessfully recorded ${recorded} history entry(ies).`)
+    );
+  }
+}
+
+/**
+ * Register the feed verify-claim subcommand
+ */
+export function registerFeedVerifyClaimCommand(parent: Command): void {
+  parent
+    .command("verify-claim <tx-hash>")
+    .description(
+      "Verify a transaction and add it to history. Recovers post/comment details from on-chain data."
+    )
+    .option(
+      "--chain-id <id>",
+      "Chain ID (default: 8453 for Base)",
+      (value) => parseInt(value, 10)
+    )
+    .option("--rpc-url <url>", "Custom RPC URL")
+    .action(async (txHash, options) => {
+      await executeFeedVerifyClaim(txHash, options);
+    });
+}

--- a/packages/net-cli/src/commands/feed/verify-claim.ts
+++ b/packages/net-cli/src/commands/feed/verify-claim.ts
@@ -97,7 +97,7 @@ async function executeFeedVerifyClaim(
       });
 
       if (decoded.eventName === "MessageSent") {
-        const args = decoded.args as {
+        const args = decoded.args as unknown as {
           sender: `0x${string}`;
           topic: string;
           messageIndex: bigint;

--- a/packages/net-cli/src/commands/feed/verify-claim.ts
+++ b/packages/net-cli/src/commands/feed/verify-claim.ts
@@ -5,6 +5,7 @@ import { parseReadOnlyOptionsWithDefault } from "../../cli/shared";
 import { createNetClient } from "../../shared/client";
 import { exitWithError } from "../../shared/output";
 import { addHistoryEntry, getHistory } from "../../shared/state";
+import { createPostId } from "../../shared/postId";
 import {
   getPublicClient,
   getNetContract,
@@ -27,16 +28,12 @@ interface VerifyClaimOptions {
  * For comments: "feed-crypto:comments:0x..." -> "crypto"
  */
 function extractFeedName(topic: string): string {
-  // Strip comment suffix if present
-  let baseTopic = topic;
-  if (isCommentTopic(topic)) {
-    baseTopic = topic.split(COMMENT_TOPIC_SUFFIX)[0];
-  }
-  // Strip feed- prefix
-  if (baseTopic.startsWith(FEED_TOPIC_PREFIX)) {
-    return baseTopic.slice(FEED_TOPIC_PREFIX.length);
-  }
-  return baseTopic;
+  const baseTopic = isCommentTopic(topic)
+    ? topic.split(COMMENT_TOPIC_SUFFIX)[0]
+    : topic;
+  return baseTopic.startsWith(FEED_TOPIC_PREFIX)
+    ? baseTopic.slice(FEED_TOPIC_PREFIX.length)
+    : baseTopic;
 }
 
 /**
@@ -59,7 +56,7 @@ async function executeFeedVerifyClaim(
 
   const publicClient = getPublicClient({
     chainId: readOnlyOptions.chainId,
-    rpcUrl: readOnlyOptions.rpcUrl ? [readOnlyOptions.rpcUrl] : undefined,
+    rpcUrl: readOnlyOptions.rpcUrl,
   });
   const netContract = getNetContract(readOnlyOptions.chainId);
   const netClient = createNetClient(readOnlyOptions);
@@ -74,23 +71,21 @@ async function executeFeedVerifyClaim(
   }
 
   // Fetch transaction receipt
-  let receipt;
-  try {
-    receipt = await publicClient.getTransactionReceipt({
-      hash: txHash as `0x${string}`,
-    });
-  } catch {
-    exitWithError(
-      "Could not fetch transaction receipt. Make sure the transaction hash is correct and the transaction has been confirmed."
+  const receipt = await publicClient
+    .getTransactionReceipt({ hash: txHash as `0x${string}` })
+    .catch(() =>
+      exitWithError(
+        "Could not fetch transaction receipt. Make sure the transaction hash is correct and the transaction has been confirmed."
+      )
     );
-  }
 
   // Filter logs from the Net contract and decode MessageSent events
+  const contractAddress = netContract.address.toLowerCase();
   const messageSentEvents: { sender: `0x${string}`; messageIndex: bigint }[] =
     [];
 
   for (const log of receipt.logs) {
-    if (log.address.toLowerCase() !== netContract.address.toLowerCase()) {
+    if (log.address.toLowerCase() !== contractAddress) {
       continue;
     }
 
@@ -129,69 +124,59 @@ async function executeFeedVerifyClaim(
     )
   );
 
+  // Fetch all messages in parallel
+  const messages = await Promise.all(
+    messageSentEvents.map((event) =>
+      netClient.getMessageAtIndex({
+        messageIndex: Number(event.messageIndex),
+      })
+    )
+  );
+
   let recorded = 0;
 
-  for (const event of messageSentEvents) {
-    // Fetch full message from contract using messageIndex
-    const message = await netClient.getMessageAtIndex({
-      messageIndex: Number(event.messageIndex),
-    });
-
+  for (let i = 0; i < messages.length; i++) {
+    const message = messages[i];
     if (!message) {
       console.log(
         chalk.yellow(
-          `  Could not fetch message at index ${event.messageIndex}. Skipping.`
+          `  Could not fetch message at index ${messageSentEvents[i].messageIndex}. Skipping.`
         )
       );
       continue;
     }
 
-    const topic = message.topic;
-    const feedName = extractFeedName(topic);
-    const isComment = isCommentTopic(topic);
+    const feedName = extractFeedName(message.topic);
+    const isComment = isCommentTopic(message.topic);
+
+    let type: "post" | "comment";
+    let postId: string | undefined;
+    let label: string;
 
     if (isComment) {
-      // Decode comment data to get parent post reference
+      type = "comment";
       const commentData = parseCommentData(message.data);
-      const postId = commentData
+      postId = commentData
         ? `${commentData.parentSender}:${commentData.parentTimestamp}`
         : undefined;
-
-      addHistoryEntry({
-        type: "comment",
-        txHash,
-        chainId: readOnlyOptions.chainId,
-        feed: feedName,
-        sender: message.sender,
-        text: message.text,
-        postId,
-      });
-
-      console.log(
-        chalk.green(
-          `  Verified comment:\n    Feed: ${feedName}\n    Sender: ${message.sender}\n    Text: ${message.text}\n    Parent post: ${postId ?? "unknown"}\n    Tx: ${txHash}`
-        )
-      );
+      label = `Verified comment:\n    Feed: ${feedName}\n    Sender: ${message.sender}\n    Text: ${message.text}\n    Parent post: ${postId ?? "unknown"}\n    Tx: ${txHash}`;
     } else {
-      const postId = `${message.sender}:${message.timestamp}`;
-
-      addHistoryEntry({
-        type: "post",
-        txHash,
-        chainId: readOnlyOptions.chainId,
-        feed: feedName,
-        sender: message.sender,
-        text: message.text,
-        postId,
-      });
-
-      console.log(
-        chalk.green(
-          `  Verified post:\n    Feed: ${feedName}\n    Sender: ${message.sender}\n    Text: ${message.text}\n    Post ID: ${postId}\n    Tx: ${txHash}`
-        )
-      );
+      type = "post";
+      postId = createPostId(message);
+      label = `Verified post:\n    Feed: ${feedName}\n    Sender: ${message.sender}\n    Text: ${message.text}\n    Post ID: ${postId}\n    Tx: ${txHash}`;
     }
 
+    addHistoryEntry({
+      type,
+      txHash,
+      chainId: readOnlyOptions.chainId,
+      feed: feedName,
+      sender: message.sender,
+      text: message.text,
+      postId,
+    });
+
+    console.log(chalk.green(`  ${label}`));
     recorded++;
   }
 

--- a/skill-references/feeds.md
+++ b/skill-references/feeds.md
@@ -246,6 +246,25 @@ netp feed history --json
 netp feed history --clear
 ```
 
+### Verify Claim
+
+Verify a transaction and add it to your activity history. Useful when transactions were submitted externally (e.g., via Bankr) and need to be recorded locally. Works for both posts and comments.
+
+```bash
+netp feed verify-claim <tx-hash> [--chain-id ID] [--rpc-url URL]
+```
+
+**Examples:**
+```bash
+# Verify a transaction on Base
+netp feed verify-claim 0x1234...5678 --chain-id 8453
+
+# Verify on a different chain
+netp feed verify-claim 0x1234...5678 --chain-id 666666666
+```
+
+The command fetches the transaction receipt, decodes any Net protocol messages from the event logs, retrieves the full message data from the contract, and records verified history entries. If the transaction contains multiple messages, all are recorded. Duplicate transactions (already in history) are skipped.
+
 ## Flags
 
 | Flag | Description |

--- a/yarn.lock
+++ b/yarn.lock
@@ -1242,9 +1242,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@net-protocol/chats@file:../net-chats::locator=%40net-protocol%2Fcli%40file%3A..%2Fnet-cli%23..%2Fnet-cli%3A%3Ahash%3Df69e86%26locator%3Dbotchan%2540workspace%253Apackages%252Fbotchan":
+"@net-protocol/chats@file:../net-chats::locator=%40net-protocol%2Fcli%40file%3A..%2Fnet-cli%23..%2Fnet-cli%3A%3Ahash%3D928be5%26locator%3Dbotchan%2540workspace%253Apackages%252Fbotchan":
   version: 0.1.0
-  resolution: "@net-protocol/chats@file:../net-chats#../net-chats::hash=aa0c04&locator=%40net-protocol%2Fcli%40file%3A..%2Fnet-cli%23..%2Fnet-cli%3A%3Ahash%3Df69e86%26locator%3Dbotchan%2540workspace%253Apackages%252Fbotchan"
+  resolution: "@net-protocol/chats@file:../net-chats#../net-chats::hash=c9444f&locator=%40net-protocol%2Fcli%40file%3A..%2Fnet-cli%23..%2Fnet-cli%3A%3Ahash%3D928be5%26locator%3Dbotchan%2540workspace%253Apackages%252Fbotchan"
   dependencies:
     "@net-protocol/core": "file:../net-core"
     viem: "npm:^2.45.0"
@@ -1256,13 +1256,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: d40a6654e059013fd4ec5ea5407373f58331f998f63cbfc157cf785ae87e35751e51ce4f608f872f6f30e954f6bc3641e60fef1fbe98b143ad917e72377442c6
+  checksum: 8fd45a6fe880fbcd924d174c773996f529218f9a7d26392cf578d494e9ea6dba6ceb5d2d96ccda4a1086c8adf0c3660067ab265fbb294339d38b8444437e8e87
   languageName: node
   linkType: hard
 
 "@net-protocol/chats@file:../net-chats::locator=%40net-protocol%2Fcli%40workspace%3Apackages%2Fnet-cli":
   version: 0.1.0
-  resolution: "@net-protocol/chats@file:../net-chats#../net-chats::hash=aa0c04&locator=%40net-protocol%2Fcli%40workspace%3Apackages%2Fnet-cli"
+  resolution: "@net-protocol/chats@file:../net-chats#../net-chats::hash=c9444f&locator=%40net-protocol%2Fcli%40workspace%3Apackages%2Fnet-cli"
   dependencies:
     "@net-protocol/core": "file:../net-core"
     viem: "npm:^2.45.0"
@@ -1274,13 +1274,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: d40a6654e059013fd4ec5ea5407373f58331f998f63cbfc157cf785ae87e35751e51ce4f608f872f6f30e954f6bc3641e60fef1fbe98b143ad917e72377442c6
+  checksum: 8fd45a6fe880fbcd924d174c773996f529218f9a7d26392cf578d494e9ea6dba6ceb5d2d96ccda4a1086c8adf0c3660067ab265fbb294339d38b8444437e8e87
   languageName: node
   linkType: hard
 
 "@net-protocol/chats@file:../net-chats::locator=botchan%40workspace%3Apackages%2Fbotchan":
   version: 0.1.0
-  resolution: "@net-protocol/chats@file:../net-chats#../net-chats::hash=aa0c04&locator=botchan%40workspace%3Apackages%2Fbotchan"
+  resolution: "@net-protocol/chats@file:../net-chats#../net-chats::hash=c9444f&locator=botchan%40workspace%3Apackages%2Fbotchan"
   dependencies:
     "@net-protocol/core": "file:../net-core"
     viem: "npm:^2.45.0"
@@ -1292,7 +1292,7 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: d40a6654e059013fd4ec5ea5407373f58331f998f63cbfc157cf785ae87e35751e51ce4f608f872f6f30e954f6bc3641e60fef1fbe98b143ad917e72377442c6
+  checksum: 8fd45a6fe880fbcd924d174c773996f529218f9a7d26392cf578d494e9ea6dba6ceb5d2d96ccda4a1086c8adf0c3660067ab265fbb294339d38b8444437e8e87
   languageName: node
   linkType: hard
 
@@ -1318,8 +1318,8 @@ __metadata:
   linkType: soft
 
 "@net-protocol/cli@file:../net-cli::locator=botchan%40workspace%3Apackages%2Fbotchan":
-  version: 0.1.39
-  resolution: "@net-protocol/cli@file:../net-cli#../net-cli::hash=f69e86&locator=botchan%40workspace%3Apackages%2Fbotchan"
+  version: 0.1.40
+  resolution: "@net-protocol/cli@file:../net-cli#../net-cli::hash=928be5&locator=botchan%40workspace%3Apackages%2Fbotchan"
   dependencies:
     "@net-protocol/bazaar": "npm:^0.1.17"
     "@net-protocol/chats": "file:../net-chats"
@@ -1339,7 +1339,7 @@ __metadata:
     viem: "npm:^2.45.0"
   bin:
     netp: ./dist/cli/index.mjs
-  checksum: 54207d24fa6f8e668d7a122a9ab0cc93e40430991d6befff94e7135d5efba90538ca023d3064ff5c89a4a857e2a8255ed11c2a494e9d5b2c52b4ccff439d4185
+  checksum: e7fff084d10b9c292def3f28816d7a354baf880f6c225aaa51d5bbefbc335fe6de60949766220b38d813bde5aee57fba1fc308642793dccefc1cf55b2663ab67
   languageName: node
   linkType: hard
 
@@ -1374,9 +1374,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fchats%40file%3A..%2Fnet-chats%23..%2Fnet-chats%3A%3Ahash%3Daa0c04%26locator%3D%2540net-protocol%252Fcli%2540file%253A..%252Fnet-cli%2523..%252Fnet-cli%253A%253Ahash%253Df69e86%2526locator%253Dbotchan%252540workspace%25253Apackages%25252Fbotchan":
+"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fchats%40file%3A..%2Fnet-chats%23..%2Fnet-chats%3A%3Ahash%3Dc9444f%26locator%3D%2540net-protocol%252Fcli%2540file%253A..%252Fnet-cli%2523..%252Fnet-cli%253A%253Ahash%253D928be5%2526locator%253Dbotchan%252540workspace%25253Apackages%25252Fbotchan":
   version: 0.1.10
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=d7283c&locator=%40net-protocol%2Fchats%40file%3A..%2Fnet-chats%23..%2Fnet-chats%3A%3Ahash%3Daa0c04%26locator%3D%2540net-protocol%252Fcli%2540file%253A..%252Fnet-cli%2523..%252Fnet-cli%253A%253Ahash%253Df69e86%2526locator%253Dbotchan%252540workspace%25253Apackages%25252Fbotchan"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=d7283c&locator=%40net-protocol%2Fchats%40file%3A..%2Fnet-chats%23..%2Fnet-chats%3A%3Ahash%3Dc9444f%26locator%3D%2540net-protocol%252Fcli%2540file%253A..%252Fnet-cli%2523..%252Fnet-cli%253A%253Ahash%253D928be5%2526locator%253Dbotchan%252540workspace%25253Apackages%25252Fbotchan"
   dependencies:
     ox: "npm:^0.13.2"
     viem: "npm:^2.45.0"
@@ -1392,9 +1392,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fchats%40file%3A..%2Fnet-chats%23..%2Fnet-chats%3A%3Ahash%3Daa0c04%26locator%3D%2540net-protocol%252Fcli%2540workspace%253Apackages%252Fnet-cli":
+"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fchats%40file%3A..%2Fnet-chats%23..%2Fnet-chats%3A%3Ahash%3Dc9444f%26locator%3D%2540net-protocol%252Fcli%2540workspace%253Apackages%252Fnet-cli":
   version: 0.1.10
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=d7283c&locator=%40net-protocol%2Fchats%40file%3A..%2Fnet-chats%23..%2Fnet-chats%3A%3Ahash%3Daa0c04%26locator%3D%2540net-protocol%252Fcli%2540workspace%253Apackages%252Fnet-cli"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=d7283c&locator=%40net-protocol%2Fchats%40file%3A..%2Fnet-chats%23..%2Fnet-chats%3A%3Ahash%3Dc9444f%26locator%3D%2540net-protocol%252Fcli%2540workspace%253Apackages%252Fnet-cli"
   dependencies:
     ox: "npm:^0.13.2"
     viem: "npm:^2.45.0"
@@ -1410,9 +1410,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fchats%40file%3A..%2Fnet-chats%23..%2Fnet-chats%3A%3Ahash%3Daa0c04%26locator%3Dbotchan%2540workspace%253Apackages%252Fbotchan":
+"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fchats%40file%3A..%2Fnet-chats%23..%2Fnet-chats%3A%3Ahash%3Dc9444f%26locator%3Dbotchan%2540workspace%253Apackages%252Fbotchan":
   version: 0.1.10
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=d7283c&locator=%40net-protocol%2Fchats%40file%3A..%2Fnet-chats%23..%2Fnet-chats%3A%3Ahash%3Daa0c04%26locator%3Dbotchan%2540workspace%253Apackages%252Fbotchan"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=d7283c&locator=%40net-protocol%2Fchats%40file%3A..%2Fnet-chats%23..%2Fnet-chats%3A%3Ahash%3Dc9444f%26locator%3Dbotchan%2540workspace%253Apackages%252Fbotchan"
   dependencies:
     ox: "npm:^0.13.2"
     viem: "npm:^2.45.0"
@@ -1446,9 +1446,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Ffeeds%40file%3A..%2Fnet-feeds%23..%2Fnet-feeds%3A%3Ahash%3D2a39c9%26locator%3Dbotchan%2540workspace%253Apackages%252Fbotchan":
+"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Ffeeds%40file%3A..%2Fnet-feeds%23..%2Fnet-feeds%3A%3Ahash%3Dd3789b%26locator%3Dbotchan%2540workspace%253Apackages%252Fbotchan":
   version: 0.1.10
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=d7283c&locator=%40net-protocol%2Ffeeds%40file%3A..%2Fnet-feeds%23..%2Fnet-feeds%3A%3Ahash%3D2a39c9%26locator%3Dbotchan%2540workspace%253Apackages%252Fbotchan"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=d7283c&locator=%40net-protocol%2Ffeeds%40file%3A..%2Fnet-feeds%23..%2Fnet-feeds%3A%3Ahash%3Dd3789b%26locator%3Dbotchan%2540workspace%253Apackages%252Fbotchan"
   dependencies:
     ox: "npm:^0.13.2"
     viem: "npm:^2.45.0"
@@ -1536,9 +1536,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fscore%40file%3A..%2Fnet-score%23..%2Fnet-score%3A%3Ahash%3D9170b4%26locator%3D%2540net-protocol%252Fcli%2540file%253A..%252Fnet-cli%2523..%252Fnet-cli%253A%253Ahash%253Df69e86%2526locator%253Dbotchan%252540workspace%25253Apackages%25252Fbotchan":
+"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fscore%40file%3A..%2Fnet-score%23..%2Fnet-score%3A%3Ahash%3Dc7cbfc%26locator%3D%2540net-protocol%252Fcli%2540file%253A..%252Fnet-cli%2523..%252Fnet-cli%253A%253Ahash%253D928be5%2526locator%253Dbotchan%252540workspace%25253Apackages%25252Fbotchan":
   version: 0.1.10
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=d7283c&locator=%40net-protocol%2Fscore%40file%3A..%2Fnet-score%23..%2Fnet-score%3A%3Ahash%3D9170b4%26locator%3D%2540net-protocol%252Fcli%2540file%253A..%252Fnet-cli%2523..%252Fnet-cli%253A%253Ahash%253Df69e86%2526locator%253Dbotchan%252540workspace%25253Apackages%25252Fbotchan"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=d7283c&locator=%40net-protocol%2Fscore%40file%3A..%2Fnet-score%23..%2Fnet-score%3A%3Ahash%3Dc7cbfc%26locator%3D%2540net-protocol%252Fcli%2540file%253A..%252Fnet-cli%2523..%252Fnet-cli%253A%253Ahash%253D928be5%2526locator%253Dbotchan%252540workspace%25253Apackages%25252Fbotchan"
   dependencies:
     ox: "npm:^0.13.2"
     viem: "npm:^2.45.0"
@@ -1554,9 +1554,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fscore%40file%3A..%2Fnet-score%23..%2Fnet-score%3A%3Ahash%3D9170b4%26locator%3D%2540net-protocol%252Fcli%2540workspace%253Apackages%252Fnet-cli":
+"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fscore%40file%3A..%2Fnet-score%23..%2Fnet-score%3A%3Ahash%3Dc7cbfc%26locator%3D%2540net-protocol%252Fcli%2540workspace%253Apackages%252Fnet-cli":
   version: 0.1.10
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=d7283c&locator=%40net-protocol%2Fscore%40file%3A..%2Fnet-score%23..%2Fnet-score%3A%3Ahash%3D9170b4%26locator%3D%2540net-protocol%252Fcli%2540workspace%253Apackages%252Fnet-cli"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=d7283c&locator=%40net-protocol%2Fscore%40file%3A..%2Fnet-score%23..%2Fnet-score%3A%3Ahash%3Dc7cbfc%26locator%3D%2540net-protocol%252Fcli%2540workspace%253Apackages%252Fnet-cli"
   dependencies:
     ox: "npm:^0.13.2"
     viem: "npm:^2.45.0"
@@ -1590,9 +1590,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3D827f9f%26locator%3D%2540net-protocol%252Fnetr%2540workspace%253Apackages%252Fnet-netr":
+"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3D654c1e%26locator%3D%2540net-protocol%252Fnetr%2540workspace%253Apackages%252Fnet-netr":
   version: 0.1.10
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=d7283c&locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3D827f9f%26locator%3D%2540net-protocol%252Fnetr%2540workspace%253Apackages%252Fnet-netr"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=d7283c&locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3D654c1e%26locator%3D%2540net-protocol%252Fnetr%2540workspace%253Apackages%252Fnet-netr"
   dependencies:
     ox: "npm:^0.13.2"
     viem: "npm:^2.45.0"
@@ -1608,9 +1608,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3D827f9f%26locator%3D%2540net-protocol%252Fprofiles%2540workspace%253Apackages%252Fnet-profiles":
+"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3D654c1e%26locator%3D%2540net-protocol%252Fprofiles%2540workspace%253Apackages%252Fnet-profiles":
   version: 0.1.10
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=d7283c&locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3D827f9f%26locator%3D%2540net-protocol%252Fprofiles%2540workspace%253Apackages%252Fnet-profiles"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=d7283c&locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3D654c1e%26locator%3D%2540net-protocol%252Fprofiles%2540workspace%253Apackages%252Fnet-profiles"
   dependencies:
     ox: "npm:^0.13.2"
     viem: "npm:^2.45.0"
@@ -1626,9 +1626,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3D827f9f%26locator%3D%2540net-protocol%252Fscore%2540file%253A..%252Fnet-score%2523..%252Fnet-score%253A%253Ahash%253D9170b4%2526locator%253D%252540net-protocol%25252Fcli%252540file%25253A..%25252Fnet-cli%252523..%25252Fnet-cli%25253A%25253Ahash%25253Df69e86%252526locator%25253Dbotchan%25252540workspace%2525253Apackages%2525252Fbotchan":
+"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3D654c1e%26locator%3D%2540net-protocol%252Fscore%2540file%253A..%252Fnet-score%2523..%252Fnet-score%253A%253Ahash%253Dc7cbfc%2526locator%253D%252540net-protocol%25252Fcli%252540file%25253A..%25252Fnet-cli%252523..%25252Fnet-cli%25253A%25253Ahash%25253D928be5%252526locator%25253Dbotchan%25252540workspace%2525253Apackages%2525252Fbotchan":
   version: 0.1.10
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=d7283c&locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3D827f9f%26locator%3D%2540net-protocol%252Fscore%2540file%253A..%252Fnet-score%2523..%252Fnet-score%253A%253Ahash%253D9170b4%2526locator%253D%252540net-protocol%25252Fcli%252540file%25253A..%25252Fnet-cli%252523..%25252Fnet-cli%25253A%25253Ahash%25253Df69e86%252526locator%25253Dbotchan%25252540workspace%2525253Apackages%2525252Fbotchan"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=d7283c&locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3D654c1e%26locator%3D%2540net-protocol%252Fscore%2540file%253A..%252Fnet-score%2523..%252Fnet-score%253A%253Ahash%253Dc7cbfc%2526locator%253D%252540net-protocol%25252Fcli%252540file%25253A..%25252Fnet-cli%252523..%25252Fnet-cli%25253A%25253Ahash%25253D928be5%252526locator%25253Dbotchan%25252540workspace%2525253Apackages%2525252Fbotchan"
   dependencies:
     ox: "npm:^0.13.2"
     viem: "npm:^2.45.0"
@@ -1644,9 +1644,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3D827f9f%26locator%3D%2540net-protocol%252Fscore%2540file%253A..%252Fnet-score%2523..%252Fnet-score%253A%253Ahash%253D9170b4%2526locator%253D%252540net-protocol%25252Fcli%252540workspace%25253Apackages%25252Fnet-cli":
+"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3D654c1e%26locator%3D%2540net-protocol%252Fscore%2540file%253A..%252Fnet-score%2523..%252Fnet-score%253A%253Ahash%253Dc7cbfc%2526locator%253D%252540net-protocol%25252Fcli%252540workspace%25253Apackages%25252Fnet-cli":
   version: 0.1.10
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=d7283c&locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3D827f9f%26locator%3D%2540net-protocol%252Fscore%2540file%253A..%252Fnet-score%2523..%252Fnet-score%253A%253Ahash%253D9170b4%2526locator%253D%252540net-protocol%25252Fcli%252540workspace%25253Apackages%25252Fnet-cli"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=d7283c&locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3D654c1e%26locator%3D%2540net-protocol%252Fscore%2540file%253A..%252Fnet-score%2523..%252Fnet-score%253A%253Ahash%253Dc7cbfc%2526locator%253D%252540net-protocol%25252Fcli%252540workspace%25253Apackages%25252Fnet-cli"
   dependencies:
     ox: "npm:^0.13.2"
     viem: "npm:^2.45.0"
@@ -1662,9 +1662,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3D827f9f%26locator%3D%2540net-protocol%252Fscore%2540workspace%253Apackages%252Fnet-score":
+"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3D654c1e%26locator%3D%2540net-protocol%252Fscore%2540workspace%253Apackages%252Fnet-score":
   version: 0.1.10
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=d7283c&locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3D827f9f%26locator%3D%2540net-protocol%252Fscore%2540workspace%253Apackages%252Fnet-score"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=d7283c&locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3D654c1e%26locator%3D%2540net-protocol%252Fscore%2540workspace%253Apackages%252Fnet-score"
   dependencies:
     ox: "npm:^0.13.2"
     viem: "npm:^2.45.0"
@@ -1741,7 +1741,7 @@ __metadata:
 
 "@net-protocol/feeds@file:../net-feeds::locator=botchan%40workspace%3Apackages%2Fbotchan":
   version: 0.1.15
-  resolution: "@net-protocol/feeds@file:../net-feeds#../net-feeds::hash=2a39c9&locator=botchan%40workspace%3Apackages%2Fbotchan"
+  resolution: "@net-protocol/feeds@file:../net-feeds#../net-feeds::hash=d3789b&locator=botchan%40workspace%3Apackages%2Fbotchan"
   dependencies:
     "@net-protocol/core": "file:../net-core"
     viem: "npm:^2.45.0"
@@ -1753,7 +1753,7 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: c1084c8b05f3ed2aef2dbef3d5099a7e6ff9b448bf8c68c29f59d07b7980abf70db55f61328345bd2c42be86ac152ae66629035ddbd065e60bb9115062d4297f
+  checksum: df027492c2973367cff855d63cd1e44da9e070f1493d044fda3429444693aa7d151a0065d2e14d4d35a0e967d0e04a647bacd2a855c8d9dba0e54f6ac3c4e4d9
   languageName: node
   linkType: hard
 
@@ -1854,9 +1854,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@net-protocol/score@file:../net-score::locator=%40net-protocol%2Fcli%40file%3A..%2Fnet-cli%23..%2Fnet-cli%3A%3Ahash%3Df69e86%26locator%3Dbotchan%2540workspace%253Apackages%252Fbotchan":
+"@net-protocol/score@file:../net-score::locator=%40net-protocol%2Fcli%40file%3A..%2Fnet-cli%23..%2Fnet-cli%3A%3Ahash%3D928be5%26locator%3Dbotchan%2540workspace%253Apackages%252Fbotchan":
   version: 0.1.4
-  resolution: "@net-protocol/score@file:../net-score#../net-score::hash=9170b4&locator=%40net-protocol%2Fcli%40file%3A..%2Fnet-cli%23..%2Fnet-cli%3A%3Ahash%3Df69e86%26locator%3Dbotchan%2540workspace%253Apackages%252Fbotchan"
+  resolution: "@net-protocol/score@file:../net-score#../net-score::hash=c7cbfc&locator=%40net-protocol%2Fcli%40file%3A..%2Fnet-cli%23..%2Fnet-cli%3A%3Ahash%3D928be5%26locator%3Dbotchan%2540workspace%253Apackages%252Fbotchan"
   dependencies:
     "@net-protocol/core": "file:../net-core"
     "@net-protocol/storage": "file:../net-storage"
@@ -1872,13 +1872,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: ffd53e5780d7edded125c205ca22439ce04865bc4f6e07442506a2680378172f5a0c7108cb65a38a6369aab7f0844f6ef34768a04d865629bdef90c128cd8ecd
+  checksum: 8ffe9713e87d40b4a0876bd0d7f2f56904e109c190da4a097a1bde4f84a0a74e2e98ca77123a902d75eea2fb32498665786009535d1f30e0d1a6a247ff689cbb
   languageName: node
   linkType: hard
 
 "@net-protocol/score@file:../net-score::locator=%40net-protocol%2Fcli%40workspace%3Apackages%2Fnet-cli":
   version: 0.1.4
-  resolution: "@net-protocol/score@file:../net-score#../net-score::hash=9170b4&locator=%40net-protocol%2Fcli%40workspace%3Apackages%2Fnet-cli"
+  resolution: "@net-protocol/score@file:../net-score#../net-score::hash=c7cbfc&locator=%40net-protocol%2Fcli%40workspace%3Apackages%2Fnet-cli"
   dependencies:
     "@net-protocol/core": "file:../net-core"
     "@net-protocol/storage": "file:../net-storage"
@@ -1894,7 +1894,7 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: ffd53e5780d7edded125c205ca22439ce04865bc4f6e07442506a2680378172f5a0c7108cb65a38a6369aab7f0844f6ef34768a04d865629bdef90c128cd8ecd
+  checksum: 8ffe9713e87d40b4a0876bd0d7f2f56904e109c190da4a097a1bde4f84a0a74e2e98ca77123a902d75eea2fb32498665786009535d1f30e0d1a6a247ff689cbb
   languageName: node
   linkType: hard
 
@@ -1932,7 +1932,7 @@ __metadata:
 
 "@net-protocol/storage@file:../net-storage::locator=%40net-protocol%2Fnetr%40workspace%3Apackages%2Fnet-netr":
   version: 0.1.15
-  resolution: "@net-protocol/storage@file:../net-storage#../net-storage::hash=827f9f&locator=%40net-protocol%2Fnetr%40workspace%3Apackages%2Fnet-netr"
+  resolution: "@net-protocol/storage@file:../net-storage#../net-storage::hash=654c1e&locator=%40net-protocol%2Fnetr%40workspace%3Apackages%2Fnet-netr"
   dependencies:
     "@net-protocol/core": "file:../net-core"
     pako: "npm:^2.1.0"
@@ -1946,13 +1946,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: cb30dae5b4cf65f38bed3fe2c507c752fb439d7fb2b9e1c42f903c6d43bd0b96b6058ba93ab159351a094ddcaafaaa8e6f49e4af31d1db5edaecf1cc897fe2be
+  checksum: f69febfceeeb53d8dd65b0eb67f243b89b88a2a3ce94ba1e4fa77680b4e8f55c56201084a71714956ca1f87fbc9469c46a5c1d734d9aa508934d171dca4509b4
   languageName: node
   linkType: hard
 
 "@net-protocol/storage@file:../net-storage::locator=%40net-protocol%2Fprofiles%40workspace%3Apackages%2Fnet-profiles":
   version: 0.1.15
-  resolution: "@net-protocol/storage@file:../net-storage#../net-storage::hash=827f9f&locator=%40net-protocol%2Fprofiles%40workspace%3Apackages%2Fnet-profiles"
+  resolution: "@net-protocol/storage@file:../net-storage#../net-storage::hash=654c1e&locator=%40net-protocol%2Fprofiles%40workspace%3Apackages%2Fnet-profiles"
   dependencies:
     "@net-protocol/core": "file:../net-core"
     pako: "npm:^2.1.0"
@@ -1966,13 +1966,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: cb30dae5b4cf65f38bed3fe2c507c752fb439d7fb2b9e1c42f903c6d43bd0b96b6058ba93ab159351a094ddcaafaaa8e6f49e4af31d1db5edaecf1cc897fe2be
+  checksum: f69febfceeeb53d8dd65b0eb67f243b89b88a2a3ce94ba1e4fa77680b4e8f55c56201084a71714956ca1f87fbc9469c46a5c1d734d9aa508934d171dca4509b4
   languageName: node
   linkType: hard
 
-"@net-protocol/storage@file:../net-storage::locator=%40net-protocol%2Fscore%40file%3A..%2Fnet-score%23..%2Fnet-score%3A%3Ahash%3D9170b4%26locator%3D%2540net-protocol%252Fcli%2540file%253A..%252Fnet-cli%2523..%252Fnet-cli%253A%253Ahash%253Df69e86%2526locator%253Dbotchan%252540workspace%25253Apackages%25252Fbotchan":
+"@net-protocol/storage@file:../net-storage::locator=%40net-protocol%2Fscore%40file%3A..%2Fnet-score%23..%2Fnet-score%3A%3Ahash%3Dc7cbfc%26locator%3D%2540net-protocol%252Fcli%2540file%253A..%252Fnet-cli%2523..%252Fnet-cli%253A%253Ahash%253D928be5%2526locator%253Dbotchan%252540workspace%25253Apackages%25252Fbotchan":
   version: 0.1.15
-  resolution: "@net-protocol/storage@file:../net-storage#../net-storage::hash=827f9f&locator=%40net-protocol%2Fscore%40file%3A..%2Fnet-score%23..%2Fnet-score%3A%3Ahash%3D9170b4%26locator%3D%2540net-protocol%252Fcli%2540file%253A..%252Fnet-cli%2523..%252Fnet-cli%253A%253Ahash%253Df69e86%2526locator%253Dbotchan%252540workspace%25253Apackages%25252Fbotchan"
+  resolution: "@net-protocol/storage@file:../net-storage#../net-storage::hash=654c1e&locator=%40net-protocol%2Fscore%40file%3A..%2Fnet-score%23..%2Fnet-score%3A%3Ahash%3Dc7cbfc%26locator%3D%2540net-protocol%252Fcli%2540file%253A..%252Fnet-cli%2523..%252Fnet-cli%253A%253Ahash%253D928be5%2526locator%253Dbotchan%252540workspace%25253Apackages%25252Fbotchan"
   dependencies:
     "@net-protocol/core": "file:../net-core"
     pako: "npm:^2.1.0"
@@ -1986,13 +1986,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: cb30dae5b4cf65f38bed3fe2c507c752fb439d7fb2b9e1c42f903c6d43bd0b96b6058ba93ab159351a094ddcaafaaa8e6f49e4af31d1db5edaecf1cc897fe2be
+  checksum: f69febfceeeb53d8dd65b0eb67f243b89b88a2a3ce94ba1e4fa77680b4e8f55c56201084a71714956ca1f87fbc9469c46a5c1d734d9aa508934d171dca4509b4
   languageName: node
   linkType: hard
 
-"@net-protocol/storage@file:../net-storage::locator=%40net-protocol%2Fscore%40file%3A..%2Fnet-score%23..%2Fnet-score%3A%3Ahash%3D9170b4%26locator%3D%2540net-protocol%252Fcli%2540workspace%253Apackages%252Fnet-cli":
+"@net-protocol/storage@file:../net-storage::locator=%40net-protocol%2Fscore%40file%3A..%2Fnet-score%23..%2Fnet-score%3A%3Ahash%3Dc7cbfc%26locator%3D%2540net-protocol%252Fcli%2540workspace%253Apackages%252Fnet-cli":
   version: 0.1.15
-  resolution: "@net-protocol/storage@file:../net-storage#../net-storage::hash=827f9f&locator=%40net-protocol%2Fscore%40file%3A..%2Fnet-score%23..%2Fnet-score%3A%3Ahash%3D9170b4%26locator%3D%2540net-protocol%252Fcli%2540workspace%253Apackages%252Fnet-cli"
+  resolution: "@net-protocol/storage@file:../net-storage#../net-storage::hash=654c1e&locator=%40net-protocol%2Fscore%40file%3A..%2Fnet-score%23..%2Fnet-score%3A%3Ahash%3Dc7cbfc%26locator%3D%2540net-protocol%252Fcli%2540workspace%253Apackages%252Fnet-cli"
   dependencies:
     "@net-protocol/core": "file:../net-core"
     pako: "npm:^2.1.0"
@@ -2006,13 +2006,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: cb30dae5b4cf65f38bed3fe2c507c752fb439d7fb2b9e1c42f903c6d43bd0b96b6058ba93ab159351a094ddcaafaaa8e6f49e4af31d1db5edaecf1cc897fe2be
+  checksum: f69febfceeeb53d8dd65b0eb67f243b89b88a2a3ce94ba1e4fa77680b4e8f55c56201084a71714956ca1f87fbc9469c46a5c1d734d9aa508934d171dca4509b4
   languageName: node
   linkType: hard
 
 "@net-protocol/storage@file:../net-storage::locator=%40net-protocol%2Fscore%40workspace%3Apackages%2Fnet-score":
   version: 0.1.15
-  resolution: "@net-protocol/storage@file:../net-storage#../net-storage::hash=827f9f&locator=%40net-protocol%2Fscore%40workspace%3Apackages%2Fnet-score"
+  resolution: "@net-protocol/storage@file:../net-storage#../net-storage::hash=654c1e&locator=%40net-protocol%2Fscore%40workspace%3Apackages%2Fnet-score"
   dependencies:
     "@net-protocol/core": "file:../net-core"
     pako: "npm:^2.1.0"
@@ -2026,7 +2026,7 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: cb30dae5b4cf65f38bed3fe2c507c752fb439d7fb2b9e1c42f903c6d43bd0b96b6058ba93ab159351a094ddcaafaaa8e6f49e4af31d1db5edaecf1cc897fe2be
+  checksum: f69febfceeeb53d8dd65b0eb67f243b89b88a2a3ce94ba1e4fa77680b4e8f55c56201084a71714956ca1f87fbc9469c46a5c1d734d9aa508934d171dca4509b4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fetches transaction receipt, decodes MessageSent events, retrieves
full message data from the contract, and records verified history
entries. Works for both posts and comments.

https://claude.ai/code/session_018qakkv25S8NmzCR9aKKxAN