### PR TITLE
Add display name support to profile get command

### DIFF
--- a/packages/botchan/package.json
+++ b/packages/botchan/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botchan",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "description": "CLI for the onchain agent messaging layer on the Base blockchain, built on Net Protocol",
   "type": "module",
   "bin": {

--- a/packages/net-cli/package.json
+++ b/packages/net-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@net-protocol/cli",
-  "version": "0.1.41",
+  "version": "0.1.42",
   "description": "CLI tool for Net Protocol",
   "type": "module",
   "bin": {

--- a/packages/net-cli/src/__tests__/commands/profile/get.test.ts
+++ b/packages/net-cli/src/__tests__/commands/profile/get.test.ts
@@ -5,6 +5,7 @@ import {
   TEST_PROFILE_PICTURE,
   TEST_X_USERNAME,
   TEST_BIO,
+  TEST_DISPLAY_NAME,
   TEST_CANVAS_CONTENT,
   createGetOptions,
   createMockProfilePictureData,
@@ -105,6 +106,21 @@ describe("executeProfileGet", () => {
 
       expect(consoleSpy).toHaveBeenCalledWith(
         expect.stringContaining(`@${TEST_X_USERNAME}`)
+      );
+    });
+
+    it("should display display name", async () => {
+      mockReadStorageData
+        .mockResolvedValueOnce(createMockProfilePictureData())
+        .mockResolvedValueOnce(createMockProfileMetadataData(TEST_X_USERNAME, undefined, TEST_DISPLAY_NAME));
+
+      await executeProfileGet(createGetOptions());
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Display Name:")
+      );
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining(TEST_DISPLAY_NAME)
       );
     });
 
@@ -213,6 +229,48 @@ describe("executeProfileGet", () => {
       expect(output.xUsername).toBeNull();
       expect(output.bio).toBeNull();
       expect(output.hasProfile).toBeFalsy();
+    });
+
+    it("should include displayName in JSON output", async () => {
+      mockReadStorageData
+        .mockResolvedValueOnce(createMockProfilePictureData(TEST_PROFILE_PICTURE))
+        .mockResolvedValueOnce(createMockProfileMetadataData(TEST_X_USERNAME, TEST_BIO, TEST_DISPLAY_NAME));
+
+      await executeProfileGet(createGetOptions({ json: true }));
+
+      const jsonOutputCall = consoleSpy.mock.calls.find((call) => {
+        try {
+          const parsed = JSON.parse(call[0]);
+          return parsed.address !== undefined;
+        } catch {
+          return false;
+        }
+      });
+
+      expect(jsonOutputCall).toBeDefined();
+      const output = JSON.parse(jsonOutputCall![0]);
+      expect(output.displayName).toBe(TEST_DISPLAY_NAME);
+    });
+
+    it("should include displayName as null when not set", async () => {
+      mockReadStorageData
+        .mockResolvedValueOnce(createMockProfilePictureData(TEST_PROFILE_PICTURE))
+        .mockResolvedValueOnce(createMockProfileMetadataData(TEST_X_USERNAME));
+
+      await executeProfileGet(createGetOptions({ json: true }));
+
+      const jsonOutputCall = consoleSpy.mock.calls.find((call) => {
+        try {
+          const parsed = JSON.parse(call[0]);
+          return parsed.address !== undefined;
+        } catch {
+          return false;
+        }
+      });
+
+      expect(jsonOutputCall).toBeDefined();
+      const output = JSON.parse(jsonOutputCall![0]);
+      expect(output.displayName).toBeNull();
     });
 
     it("should include bio as null when not set", async () => {

--- a/packages/net-cli/src/__tests__/commands/profile/get.test.ts
+++ b/packages/net-cli/src/__tests__/commands/profile/get.test.ts
@@ -11,6 +11,7 @@ import {
   createMockProfilePictureData,
   createMockProfileMetadataData,
   createMockCanvasData,
+  extractJsonOutput,
 } from "./test-utils";
 
 // Mock StorageClient
@@ -100,7 +101,7 @@ describe("executeProfileGet", () => {
     it("should display X username with @ prefix", async () => {
       mockReadStorageData
         .mockResolvedValueOnce(createMockProfilePictureData())
-        .mockResolvedValueOnce(createMockProfileMetadataData(TEST_X_USERNAME));
+        .mockResolvedValueOnce(createMockProfileMetadataData({ username: TEST_X_USERNAME }));
 
       await executeProfileGet(createGetOptions());
 
@@ -112,7 +113,7 @@ describe("executeProfileGet", () => {
     it("should display display name", async () => {
       mockReadStorageData
         .mockResolvedValueOnce(createMockProfilePictureData())
-        .mockResolvedValueOnce(createMockProfileMetadataData(TEST_X_USERNAME, undefined, TEST_DISPLAY_NAME));
+        .mockResolvedValueOnce(createMockProfileMetadataData({ displayName: TEST_DISPLAY_NAME }));
 
       await executeProfileGet(createGetOptions());
 
@@ -127,7 +128,7 @@ describe("executeProfileGet", () => {
     it("should display bio", async () => {
       mockReadStorageData
         .mockResolvedValueOnce(createMockProfilePictureData())
-        .mockResolvedValueOnce(createMockProfileMetadataData(TEST_X_USERNAME, TEST_BIO));
+        .mockResolvedValueOnce(createMockProfileMetadataData({ username: TEST_X_USERNAME, bio: TEST_BIO }));
 
       await executeProfileGet(createGetOptions());
 
@@ -171,36 +172,18 @@ describe("executeProfileGet", () => {
 
       await executeProfileGet(createGetOptions({ json: true }));
 
-      const jsonOutputCall = consoleSpy.mock.calls.find((call) => {
-        try {
-          JSON.parse(call[0]);
-          return true;
-        } catch {
-          return false;
-        }
-      });
-
-      expect(jsonOutputCall).toBeDefined();
+      const output = extractJsonOutput(consoleSpy);
+      expect(output).toBeDefined();
     });
 
     it("should include all fields in JSON output", async () => {
       mockReadStorageData
         .mockResolvedValueOnce(createMockProfilePictureData(TEST_PROFILE_PICTURE))
-        .mockResolvedValueOnce(createMockProfileMetadataData(TEST_X_USERNAME, TEST_BIO));
+        .mockResolvedValueOnce(createMockProfileMetadataData({ username: TEST_X_USERNAME, bio: TEST_BIO }));
 
       await executeProfileGet(createGetOptions({ json: true }));
 
-      const jsonOutputCall = consoleSpy.mock.calls.find((call) => {
-        try {
-          const parsed = JSON.parse(call[0]);
-          return parsed.address !== undefined;
-        } catch {
-          return false;
-        }
-      });
-
-      expect(jsonOutputCall).toBeDefined();
-      const output = JSON.parse(jsonOutputCall![0]);
+      const output = extractJsonOutput(consoleSpy);
       expect(output.address).toBe(TEST_ADDRESS);
       expect(output.chainId).toBe(TEST_CHAIN_ID);
       expect(output.profilePicture).toBe(TEST_PROFILE_PICTURE);
@@ -214,17 +197,7 @@ describe("executeProfileGet", () => {
 
       await executeProfileGet(createGetOptions({ json: true }));
 
-      const jsonOutputCall = consoleSpy.mock.calls.find((call) => {
-        try {
-          const parsed = JSON.parse(call[0]);
-          return parsed.address !== undefined;
-        } catch {
-          return false;
-        }
-      });
-
-      expect(jsonOutputCall).toBeDefined();
-      const output = JSON.parse(jsonOutputCall![0]);
+      const output = extractJsonOutput(consoleSpy);
       expect(output.profilePicture).toBeNull();
       expect(output.xUsername).toBeNull();
       expect(output.bio).toBeNull();
@@ -234,63 +207,33 @@ describe("executeProfileGet", () => {
     it("should include displayName in JSON output", async () => {
       mockReadStorageData
         .mockResolvedValueOnce(createMockProfilePictureData(TEST_PROFILE_PICTURE))
-        .mockResolvedValueOnce(createMockProfileMetadataData(TEST_X_USERNAME, TEST_BIO, TEST_DISPLAY_NAME));
+        .mockResolvedValueOnce(createMockProfileMetadataData({ username: TEST_X_USERNAME, bio: TEST_BIO, displayName: TEST_DISPLAY_NAME }));
 
       await executeProfileGet(createGetOptions({ json: true }));
 
-      const jsonOutputCall = consoleSpy.mock.calls.find((call) => {
-        try {
-          const parsed = JSON.parse(call[0]);
-          return parsed.address !== undefined;
-        } catch {
-          return false;
-        }
-      });
-
-      expect(jsonOutputCall).toBeDefined();
-      const output = JSON.parse(jsonOutputCall![0]);
+      const output = extractJsonOutput(consoleSpy);
       expect(output.displayName).toBe(TEST_DISPLAY_NAME);
     });
 
     it("should include displayName as null when not set", async () => {
       mockReadStorageData
         .mockResolvedValueOnce(createMockProfilePictureData(TEST_PROFILE_PICTURE))
-        .mockResolvedValueOnce(createMockProfileMetadataData(TEST_X_USERNAME));
+        .mockResolvedValueOnce(createMockProfileMetadataData({ username: TEST_X_USERNAME }));
 
       await executeProfileGet(createGetOptions({ json: true }));
 
-      const jsonOutputCall = consoleSpy.mock.calls.find((call) => {
-        try {
-          const parsed = JSON.parse(call[0]);
-          return parsed.address !== undefined;
-        } catch {
-          return false;
-        }
-      });
-
-      expect(jsonOutputCall).toBeDefined();
-      const output = JSON.parse(jsonOutputCall![0]);
+      const output = extractJsonOutput(consoleSpy);
       expect(output.displayName).toBeNull();
     });
 
     it("should include bio as null when not set", async () => {
       mockReadStorageData
         .mockResolvedValueOnce(createMockProfilePictureData(TEST_PROFILE_PICTURE))
-        .mockResolvedValueOnce(createMockProfileMetadataData(TEST_X_USERNAME));
+        .mockResolvedValueOnce(createMockProfileMetadataData({ username: TEST_X_USERNAME }));
 
       await executeProfileGet(createGetOptions({ json: true }));
 
-      const jsonOutputCall = consoleSpy.mock.calls.find((call) => {
-        try {
-          const parsed = JSON.parse(call[0]);
-          return parsed.address !== undefined;
-        } catch {
-          return false;
-        }
-      });
-
-      expect(jsonOutputCall).toBeDefined();
-      const output = JSON.parse(jsonOutputCall![0]);
+      const output = extractJsonOutput(consoleSpy);
       expect(output.bio).toBeNull();
     });
   });
@@ -349,17 +292,7 @@ describe("executeProfileGet", () => {
 
       await executeProfileGet(createGetOptions({ json: true }));
 
-      const jsonOutputCall = consoleSpy.mock.calls.find((call) => {
-        try {
-          const parsed = JSON.parse(call[0]);
-          return parsed.address !== undefined;
-        } catch {
-          return false;
-        }
-      });
-
-      expect(jsonOutputCall).toBeDefined();
-      const output = JSON.parse(jsonOutputCall![0]);
+      const output = extractJsonOutput(consoleSpy);
       expect(output.canvas).toBeDefined();
       expect(output.canvas.size).toBe(TEST_CANVAS_CONTENT.length);
       expect(output.canvas.isDataUri).toBe(false);
@@ -373,17 +306,7 @@ describe("executeProfileGet", () => {
 
       await executeProfileGet(createGetOptions({ json: true }));
 
-      const jsonOutputCall = consoleSpy.mock.calls.find((call) => {
-        try {
-          const parsed = JSON.parse(call[0]);
-          return parsed.address !== undefined;
-        } catch {
-          return false;
-        }
-      });
-
-      expect(jsonOutputCall).toBeDefined();
-      const output = JSON.parse(jsonOutputCall![0]);
+      const output = extractJsonOutput(consoleSpy);
       expect(output.canvas).toBeNull();
     });
 

--- a/packages/net-cli/src/__tests__/commands/profile/test-utils.ts
+++ b/packages/net-cli/src/__tests__/commands/profile/test-utils.ts
@@ -10,6 +10,7 @@ export const TEST_PRIVATE_KEY =
 export const TEST_PROFILE_PICTURE = "https://example.com/image.jpg";
 export const TEST_X_USERNAME = "testuser";
 export const TEST_BIO = "Hello, I'm a developer!";
+export const TEST_DISPLAY_NAME = "Test User";
 export const TEST_CANVAS_CONTENT = "<html><body><h1>My Canvas</h1></body></html>";
 export const TEST_CANVAS_DATA_URI = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";
 
@@ -29,14 +30,18 @@ export function createMockProfilePictureData(url: string = TEST_PROFILE_PICTURE)
  */
 export function createMockProfileMetadataData(
   username: string = TEST_X_USERNAME,
-  bio?: string
+  bio?: string,
+  displayName?: string
 ) {
-  const metadata: { x_username?: string; bio?: string } = {};
+  const metadata: { x_username?: string; bio?: string; display_name?: string } = {};
   if (username) {
     metadata.x_username = `@${username}`;
   }
   if (bio) {
     metadata.bio = bio;
+  }
+  if (displayName) {
+    metadata.display_name = displayName;
   }
   return {
     text: "profile-metadata",

--- a/packages/net-cli/src/__tests__/commands/profile/test-utils.ts
+++ b/packages/net-cli/src/__tests__/commands/profile/test-utils.ts
@@ -1,3 +1,5 @@
+import { expect } from "vitest";
+
 /**
  * Test utilities for profile command tests
  */
@@ -28,26 +30,43 @@ export function createMockProfilePictureData(url: string = TEST_PROFILE_PICTURE)
 /**
  * Create mock storage data for profile metadata
  */
-export function createMockProfileMetadataData(
-  username: string = TEST_X_USERNAME,
-  bio?: string,
-  displayName?: string
-) {
+export function createMockProfileMetadataData(overrides?: {
+  username?: string;
+  bio?: string;
+  displayName?: string;
+}) {
+  const username = overrides?.username ?? TEST_X_USERNAME;
   const metadata: { x_username?: string; bio?: string; display_name?: string } = {};
   if (username) {
     metadata.x_username = `@${username}`;
   }
-  if (bio) {
-    metadata.bio = bio;
+  if (overrides?.bio) {
+    metadata.bio = overrides.bio;
   }
-  if (displayName) {
-    metadata.display_name = displayName;
+  if (overrides?.displayName) {
+    metadata.display_name = overrides.displayName;
   }
   return {
     text: "profile-metadata",
     data: JSON.stringify(metadata),
     isXml: false,
   };
+}
+
+/**
+ * Extract parsed JSON output from console.log spy calls
+ */
+export function extractJsonOutput(consoleSpy: any) {
+  const call = consoleSpy.mock.calls.find((c: any) => {
+    try {
+      const parsed = JSON.parse(c[0]);
+      return parsed.address !== undefined;
+    } catch {
+      return false;
+    }
+  });
+  expect(call).toBeDefined();
+  return JSON.parse(call![0]);
 }
 
 /**

--- a/packages/net-cli/src/commands/profile/get.ts
+++ b/packages/net-cli/src/commands/profile/get.ts
@@ -48,9 +48,10 @@ export async function executeProfileGet(
       }
     }
 
-    // Fetch profile metadata (X username, bio, token address)
+    // Fetch profile metadata (X username, bio, display name, token address)
     let xUsername: string | undefined;
     let bio: string | undefined;
+    let displayName: string | undefined;
     let tokenAddress: string | undefined;
     try {
       const metadataResult = await client.readStorageData({
@@ -61,6 +62,7 @@ export async function executeProfileGet(
         const metadata = parseProfileMetadata(metadataResult.data);
         xUsername = metadata?.x_username;
         bio = metadata?.bio;
+        displayName = metadata?.display_name;
         tokenAddress = metadata?.token_address;
       }
     } catch (error) {
@@ -114,13 +116,14 @@ export async function executeProfileGet(
       }
     }
 
-    const hasProfile = profilePicture || xUsername || bio || tokenAddress || canvasSize || cssSize;
+    const hasProfile = profilePicture || xUsername || bio || displayName || tokenAddress || canvasSize || cssSize;
 
     if (options.json) {
       const output = {
         address: options.address,
         chainId: readOnlyOptions.chainId,
         profilePicture: profilePicture || null,
+        displayName: displayName || null,
         xUsername: xUsername || null,
         bio: bio || null,
         tokenAddress: tokenAddress || null,
@@ -138,6 +141,11 @@ export async function executeProfileGet(
     console.log(chalk.white.bold("\nProfile:\n"));
     console.log(`  ${chalk.cyan("Address:")} ${options.address}`);
     console.log(`  ${chalk.cyan("Chain ID:")} ${readOnlyOptions.chainId}`);
+    console.log(
+      `  ${chalk.cyan("Display Name:")} ${
+        displayName || chalk.gray("(not set)")
+      }`
+    );
     console.log(
       `  ${chalk.cyan("Profile Picture:")} ${
         profilePicture || chalk.gray("(not set)")

--- a/yarn.lock
+++ b/yarn.lock
@@ -1242,45 +1242,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@net-protocol/chats@file:../net-chats::locator=%40net-protocol%2Fcli%40file%3A..%2Fnet-cli%23..%2Fnet-cli%3A%3Ahash%3D928be5%26locator%3Dbotchan%2540workspace%253Apackages%252Fbotchan":
-  version: 0.1.0
-  resolution: "@net-protocol/chats@file:../net-chats#../net-chats::hash=c9444f&locator=%40net-protocol%2Fcli%40file%3A..%2Fnet-cli%23..%2Fnet-cli%3A%3Ahash%3D928be5%26locator%3Dbotchan%2540workspace%253Apackages%252Fbotchan"
-  dependencies:
-    "@net-protocol/core": "file:../net-core"
-    viem: "npm:^2.45.0"
-  peerDependencies:
-    react: ^18.0.0
-    wagmi: ^2.15.0
-  peerDependenciesMeta:
-    react:
-      optional: true
-    wagmi:
-      optional: true
-  checksum: 8fd45a6fe880fbcd924d174c773996f529218f9a7d26392cf578d494e9ea6dba6ceb5d2d96ccda4a1086c8adf0c3660067ab265fbb294339d38b8444437e8e87
-  languageName: node
-  linkType: hard
-
-"@net-protocol/chats@file:../net-chats::locator=%40net-protocol%2Fcli%40workspace%3Apackages%2Fnet-cli":
-  version: 0.1.0
-  resolution: "@net-protocol/chats@file:../net-chats#../net-chats::hash=c9444f&locator=%40net-protocol%2Fcli%40workspace%3Apackages%2Fnet-cli"
-  dependencies:
-    "@net-protocol/core": "file:../net-core"
-    viem: "npm:^2.45.0"
-  peerDependencies:
-    react: ^18.0.0
-    wagmi: ^2.15.0
-  peerDependenciesMeta:
-    react:
-      optional: true
-    wagmi:
-      optional: true
-  checksum: 8fd45a6fe880fbcd924d174c773996f529218f9a7d26392cf578d494e9ea6dba6ceb5d2d96ccda4a1086c8adf0c3660067ab265fbb294339d38b8444437e8e87
-  languageName: node
-  linkType: hard
-
 "@net-protocol/chats@file:../net-chats::locator=botchan%40workspace%3Apackages%2Fbotchan":
   version: 0.1.0
-  resolution: "@net-protocol/chats@file:../net-chats#../net-chats::hash=c9444f&locator=botchan%40workspace%3Apackages%2Fbotchan"
+  resolution: "@net-protocol/chats@file:../net-chats#../net-chats::hash=aa0c04&locator=botchan%40workspace%3Apackages%2Fbotchan"
   dependencies:
     "@net-protocol/core": "file:../net-core"
     viem: "npm:^2.45.0"
@@ -1292,11 +1256,11 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: 8fd45a6fe880fbcd924d174c773996f529218f9a7d26392cf578d494e9ea6dba6ceb5d2d96ccda4a1086c8adf0c3660067ab265fbb294339d38b8444437e8e87
+  checksum: d40a6654e059013fd4ec5ea5407373f58331f998f63cbfc157cf785ae87e35751e51ce4f608f872f6f30e954f6bc3641e60fef1fbe98b143ad917e72377442c6
   languageName: node
   linkType: hard
 
-"@net-protocol/chats@workspace:packages/net-chats":
+"@net-protocol/chats@npm:^0.1.0, @net-protocol/chats@workspace:packages/net-chats":
   version: 0.0.0-use.local
   resolution: "@net-protocol/chats@workspace:packages/net-chats"
   dependencies:
@@ -1318,17 +1282,17 @@ __metadata:
   linkType: soft
 
 "@net-protocol/cli@file:../net-cli::locator=botchan%40workspace%3Apackages%2Fbotchan":
-  version: 0.1.40
-  resolution: "@net-protocol/cli@file:../net-cli#../net-cli::hash=928be5&locator=botchan%40workspace%3Apackages%2Fbotchan"
+  version: 0.1.41
+  resolution: "@net-protocol/cli@file:../net-cli#../net-cli::hash=62667f&locator=botchan%40workspace%3Apackages%2Fbotchan"
   dependencies:
     "@net-protocol/bazaar": "npm:^0.1.17"
-    "@net-protocol/chats": "file:../net-chats"
+    "@net-protocol/chats": "npm:^0.1.0"
     "@net-protocol/core": "npm:^0.1.9"
     "@net-protocol/feeds": "npm:^0.1.14"
     "@net-protocol/netr": "npm:^0.1.3"
     "@net-protocol/profiles": "npm:^0.1.5"
     "@net-protocol/relay": "npm:^0.1.3"
-    "@net-protocol/score": "file:../net-score"
+    "@net-protocol/score": "npm:^0.1.4"
     "@net-protocol/storage": "npm:^0.1.12"
     "@x402/evm": "npm:^2.1.0"
     "@x402/fetch": "npm:^2.1.0"
@@ -1339,7 +1303,7 @@ __metadata:
     viem: "npm:^2.45.0"
   bin:
     netp: ./dist/cli/index.mjs
-  checksum: e7fff084d10b9c292def3f28816d7a354baf880f6c225aaa51d5bbefbc335fe6de60949766220b38d813bde5aee57fba1fc308642793dccefc1cf55b2663ab67
+  checksum: 25ff5589bdec723788ad93eb0d70e3bd280820e9937aed329edc28de13e733f53317d44c7ec05dba592815b62d3423eaa4d51f7babda0fea49b62036eef7d556
   languageName: node
   linkType: hard
 
@@ -1348,13 +1312,13 @@ __metadata:
   resolution: "@net-protocol/cli@workspace:packages/net-cli"
   dependencies:
     "@net-protocol/bazaar": "npm:^0.1.17"
-    "@net-protocol/chats": "file:../net-chats"
+    "@net-protocol/chats": "npm:^0.1.0"
     "@net-protocol/core": "npm:^0.1.9"
     "@net-protocol/feeds": "npm:^0.1.14"
     "@net-protocol/netr": "npm:^0.1.3"
     "@net-protocol/profiles": "npm:^0.1.5"
     "@net-protocol/relay": "npm:^0.1.3"
-    "@net-protocol/score": "file:../net-score"
+    "@net-protocol/score": "npm:^0.1.4"
     "@net-protocol/storage": "npm:^0.1.12"
     "@types/node": "npm:^20.17.6"
     "@vitest/ui": "npm:^1.0.0"
@@ -1374,45 +1338,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fchats%40file%3A..%2Fnet-chats%23..%2Fnet-chats%3A%3Ahash%3Dc9444f%26locator%3D%2540net-protocol%252Fcli%2540file%253A..%252Fnet-cli%2523..%252Fnet-cli%253A%253Ahash%253D928be5%2526locator%253Dbotchan%252540workspace%25253Apackages%25252Fbotchan":
+"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fchats%40file%3A..%2Fnet-chats%23..%2Fnet-chats%3A%3Ahash%3Daa0c04%26locator%3Dbotchan%2540workspace%253Apackages%252Fbotchan":
   version: 0.1.10
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=d7283c&locator=%40net-protocol%2Fchats%40file%3A..%2Fnet-chats%23..%2Fnet-chats%3A%3Ahash%3Dc9444f%26locator%3D%2540net-protocol%252Fcli%2540file%253A..%252Fnet-cli%2523..%252Fnet-cli%253A%253Ahash%253D928be5%2526locator%253Dbotchan%252540workspace%25253Apackages%25252Fbotchan"
-  dependencies:
-    ox: "npm:^0.13.2"
-    viem: "npm:^2.45.0"
-  peerDependencies:
-    react: ^18.0.0
-    wagmi: ^2.15.0
-  peerDependenciesMeta:
-    react:
-      optional: true
-    wagmi:
-      optional: true
-  checksum: 8346ae731804e6485feaa8a7f0a3c88630a73bba9093f45e41392e1e0c9837edec62bf76167941165ecc1802eab5c167c502eda89976db89f620a27ac30f382a
-  languageName: node
-  linkType: hard
-
-"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fchats%40file%3A..%2Fnet-chats%23..%2Fnet-chats%3A%3Ahash%3Dc9444f%26locator%3D%2540net-protocol%252Fcli%2540workspace%253Apackages%252Fnet-cli":
-  version: 0.1.10
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=d7283c&locator=%40net-protocol%2Fchats%40file%3A..%2Fnet-chats%23..%2Fnet-chats%3A%3Ahash%3Dc9444f%26locator%3D%2540net-protocol%252Fcli%2540workspace%253Apackages%252Fnet-cli"
-  dependencies:
-    ox: "npm:^0.13.2"
-    viem: "npm:^2.45.0"
-  peerDependencies:
-    react: ^18.0.0
-    wagmi: ^2.15.0
-  peerDependenciesMeta:
-    react:
-      optional: true
-    wagmi:
-      optional: true
-  checksum: 8346ae731804e6485feaa8a7f0a3c88630a73bba9093f45e41392e1e0c9837edec62bf76167941165ecc1802eab5c167c502eda89976db89f620a27ac30f382a
-  languageName: node
-  linkType: hard
-
-"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fchats%40file%3A..%2Fnet-chats%23..%2Fnet-chats%3A%3Ahash%3Dc9444f%26locator%3Dbotchan%2540workspace%253Apackages%252Fbotchan":
-  version: 0.1.10
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=d7283c&locator=%40net-protocol%2Fchats%40file%3A..%2Fnet-chats%23..%2Fnet-chats%3A%3Ahash%3Dc9444f%26locator%3Dbotchan%2540workspace%253Apackages%252Fbotchan"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=d7283c&locator=%40net-protocol%2Fchats%40file%3A..%2Fnet-chats%23..%2Fnet-chats%3A%3Ahash%3Daa0c04%26locator%3Dbotchan%2540workspace%253Apackages%252Fbotchan"
   dependencies:
     ox: "npm:^0.13.2"
     viem: "npm:^2.45.0"
@@ -1446,9 +1374,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Ffeeds%40file%3A..%2Fnet-feeds%23..%2Fnet-feeds%3A%3Ahash%3Dd3789b%26locator%3Dbotchan%2540workspace%253Apackages%252Fbotchan":
+"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Ffeeds%40file%3A..%2Fnet-feeds%23..%2Fnet-feeds%3A%3Ahash%3D2a39c9%26locator%3Dbotchan%2540workspace%253Apackages%252Fbotchan":
   version: 0.1.10
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=d7283c&locator=%40net-protocol%2Ffeeds%40file%3A..%2Fnet-feeds%23..%2Fnet-feeds%3A%3Ahash%3Dd3789b%26locator%3Dbotchan%2540workspace%253Apackages%252Fbotchan"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=d7283c&locator=%40net-protocol%2Ffeeds%40file%3A..%2Fnet-feeds%23..%2Fnet-feeds%3A%3Ahash%3D2a39c9%26locator%3Dbotchan%2540workspace%253Apackages%252Fbotchan"
   dependencies:
     ox: "npm:^0.13.2"
     viem: "npm:^2.45.0"
@@ -1536,42 +1464,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fscore%40file%3A..%2Fnet-score%23..%2Fnet-score%3A%3Ahash%3Dc7cbfc%26locator%3D%2540net-protocol%252Fcli%2540file%253A..%252Fnet-cli%2523..%252Fnet-cli%253A%253Ahash%253D928be5%2526locator%253Dbotchan%252540workspace%25253Apackages%25252Fbotchan":
-  version: 0.1.10
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=d7283c&locator=%40net-protocol%2Fscore%40file%3A..%2Fnet-score%23..%2Fnet-score%3A%3Ahash%3Dc7cbfc%26locator%3D%2540net-protocol%252Fcli%2540file%253A..%252Fnet-cli%2523..%252Fnet-cli%253A%253Ahash%253D928be5%2526locator%253Dbotchan%252540workspace%25253Apackages%25252Fbotchan"
-  dependencies:
-    ox: "npm:^0.13.2"
-    viem: "npm:^2.45.0"
-  peerDependencies:
-    react: ^18.0.0
-    wagmi: ^2.15.0
-  peerDependenciesMeta:
-    react:
-      optional: true
-    wagmi:
-      optional: true
-  checksum: 8346ae731804e6485feaa8a7f0a3c88630a73bba9093f45e41392e1e0c9837edec62bf76167941165ecc1802eab5c167c502eda89976db89f620a27ac30f382a
-  languageName: node
-  linkType: hard
-
-"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fscore%40file%3A..%2Fnet-score%23..%2Fnet-score%3A%3Ahash%3Dc7cbfc%26locator%3D%2540net-protocol%252Fcli%2540workspace%253Apackages%252Fnet-cli":
-  version: 0.1.10
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=d7283c&locator=%40net-protocol%2Fscore%40file%3A..%2Fnet-score%23..%2Fnet-score%3A%3Ahash%3Dc7cbfc%26locator%3D%2540net-protocol%252Fcli%2540workspace%253Apackages%252Fnet-cli"
-  dependencies:
-    ox: "npm:^0.13.2"
-    viem: "npm:^2.45.0"
-  peerDependencies:
-    react: ^18.0.0
-    wagmi: ^2.15.0
-  peerDependenciesMeta:
-    react:
-      optional: true
-    wagmi:
-      optional: true
-  checksum: 8346ae731804e6485feaa8a7f0a3c88630a73bba9093f45e41392e1e0c9837edec62bf76167941165ecc1802eab5c167c502eda89976db89f620a27ac30f382a
-  languageName: node
-  linkType: hard
-
 "@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fscore%40workspace%3Apackages%2Fnet-score":
   version: 0.1.10
   resolution: "@net-protocol/core@file:../net-core#../net-core::hash=d7283c&locator=%40net-protocol%2Fscore%40workspace%3Apackages%2Fnet-score"
@@ -1590,9 +1482,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3D654c1e%26locator%3D%2540net-protocol%252Fnetr%2540workspace%253Apackages%252Fnet-netr":
+"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3D827f9f%26locator%3D%2540net-protocol%252Fnetr%2540workspace%253Apackages%252Fnet-netr":
   version: 0.1.10
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=d7283c&locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3D654c1e%26locator%3D%2540net-protocol%252Fnetr%2540workspace%253Apackages%252Fnet-netr"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=d7283c&locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3D827f9f%26locator%3D%2540net-protocol%252Fnetr%2540workspace%253Apackages%252Fnet-netr"
   dependencies:
     ox: "npm:^0.13.2"
     viem: "npm:^2.45.0"
@@ -1608,9 +1500,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3D654c1e%26locator%3D%2540net-protocol%252Fprofiles%2540workspace%253Apackages%252Fnet-profiles":
+"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3D827f9f%26locator%3D%2540net-protocol%252Fprofiles%2540workspace%253Apackages%252Fnet-profiles":
   version: 0.1.10
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=d7283c&locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3D654c1e%26locator%3D%2540net-protocol%252Fprofiles%2540workspace%253Apackages%252Fnet-profiles"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=d7283c&locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3D827f9f%26locator%3D%2540net-protocol%252Fprofiles%2540workspace%253Apackages%252Fnet-profiles"
   dependencies:
     ox: "npm:^0.13.2"
     viem: "npm:^2.45.0"
@@ -1626,45 +1518,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3D654c1e%26locator%3D%2540net-protocol%252Fscore%2540file%253A..%252Fnet-score%2523..%252Fnet-score%253A%253Ahash%253Dc7cbfc%2526locator%253D%252540net-protocol%25252Fcli%252540file%25253A..%25252Fnet-cli%252523..%25252Fnet-cli%25253A%25253Ahash%25253D928be5%252526locator%25253Dbotchan%25252540workspace%2525253Apackages%2525252Fbotchan":
+"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3D827f9f%26locator%3D%2540net-protocol%252Fscore%2540workspace%253Apackages%252Fnet-score":
   version: 0.1.10
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=d7283c&locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3D654c1e%26locator%3D%2540net-protocol%252Fscore%2540file%253A..%252Fnet-score%2523..%252Fnet-score%253A%253Ahash%253Dc7cbfc%2526locator%253D%252540net-protocol%25252Fcli%252540file%25253A..%25252Fnet-cli%252523..%25252Fnet-cli%25253A%25253Ahash%25253D928be5%252526locator%25253Dbotchan%25252540workspace%2525253Apackages%2525252Fbotchan"
-  dependencies:
-    ox: "npm:^0.13.2"
-    viem: "npm:^2.45.0"
-  peerDependencies:
-    react: ^18.0.0
-    wagmi: ^2.15.0
-  peerDependenciesMeta:
-    react:
-      optional: true
-    wagmi:
-      optional: true
-  checksum: 8346ae731804e6485feaa8a7f0a3c88630a73bba9093f45e41392e1e0c9837edec62bf76167941165ecc1802eab5c167c502eda89976db89f620a27ac30f382a
-  languageName: node
-  linkType: hard
-
-"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3D654c1e%26locator%3D%2540net-protocol%252Fscore%2540file%253A..%252Fnet-score%2523..%252Fnet-score%253A%253Ahash%253Dc7cbfc%2526locator%253D%252540net-protocol%25252Fcli%252540workspace%25253Apackages%25252Fnet-cli":
-  version: 0.1.10
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=d7283c&locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3D654c1e%26locator%3D%2540net-protocol%252Fscore%2540file%253A..%252Fnet-score%2523..%252Fnet-score%253A%253Ahash%253Dc7cbfc%2526locator%253D%252540net-protocol%25252Fcli%252540workspace%25253Apackages%25252Fnet-cli"
-  dependencies:
-    ox: "npm:^0.13.2"
-    viem: "npm:^2.45.0"
-  peerDependencies:
-    react: ^18.0.0
-    wagmi: ^2.15.0
-  peerDependenciesMeta:
-    react:
-      optional: true
-    wagmi:
-      optional: true
-  checksum: 8346ae731804e6485feaa8a7f0a3c88630a73bba9093f45e41392e1e0c9837edec62bf76167941165ecc1802eab5c167c502eda89976db89f620a27ac30f382a
-  languageName: node
-  linkType: hard
-
-"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3D654c1e%26locator%3D%2540net-protocol%252Fscore%2540workspace%253Apackages%252Fnet-score":
-  version: 0.1.10
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=d7283c&locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3D654c1e%26locator%3D%2540net-protocol%252Fscore%2540workspace%253Apackages%252Fnet-score"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=d7283c&locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3D827f9f%26locator%3D%2540net-protocol%252Fscore%2540workspace%253Apackages%252Fnet-score"
   dependencies:
     ox: "npm:^0.13.2"
     viem: "npm:^2.45.0"
@@ -1741,7 +1597,7 @@ __metadata:
 
 "@net-protocol/feeds@file:../net-feeds::locator=botchan%40workspace%3Apackages%2Fbotchan":
   version: 0.1.15
-  resolution: "@net-protocol/feeds@file:../net-feeds#../net-feeds::hash=d3789b&locator=botchan%40workspace%3Apackages%2Fbotchan"
+  resolution: "@net-protocol/feeds@file:../net-feeds#../net-feeds::hash=2a39c9&locator=botchan%40workspace%3Apackages%2Fbotchan"
   dependencies:
     "@net-protocol/core": "file:../net-core"
     viem: "npm:^2.45.0"
@@ -1753,7 +1609,7 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: df027492c2973367cff855d63cd1e44da9e070f1493d044fda3429444693aa7d151a0065d2e14d4d35a0e967d0e04a647bacd2a855c8d9dba0e54f6ac3c4e4d9
+  checksum: c1084c8b05f3ed2aef2dbef3d5099a7e6ff9b448bf8c68c29f59d07b7980abf70db55f61328345bd2c42be86ac152ae66629035ddbd065e60bb9115062d4297f
   languageName: node
   linkType: hard
 
@@ -1854,51 +1710,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@net-protocol/score@file:../net-score::locator=%40net-protocol%2Fcli%40file%3A..%2Fnet-cli%23..%2Fnet-cli%3A%3Ahash%3D928be5%26locator%3Dbotchan%2540workspace%253Apackages%252Fbotchan":
-  version: 0.1.4
-  resolution: "@net-protocol/score@file:../net-score#../net-score::hash=c7cbfc&locator=%40net-protocol%2Fcli%40file%3A..%2Fnet-cli%23..%2Fnet-cli%3A%3Ahash%3D928be5%26locator%3Dbotchan%2540workspace%253Apackages%252Fbotchan"
-  dependencies:
-    "@net-protocol/core": "file:../net-core"
-    "@net-protocol/storage": "file:../net-storage"
-    viem: "npm:^2.45.0"
-  peerDependencies:
-    "@tanstack/react-query": ^5.0.0
-    react: ^18.0.0
-    wagmi: ^2.15.0
-  peerDependenciesMeta:
-    "@tanstack/react-query":
-      optional: true
-    react:
-      optional: true
-    wagmi:
-      optional: true
-  checksum: 8ffe9713e87d40b4a0876bd0d7f2f56904e109c190da4a097a1bde4f84a0a74e2e98ca77123a902d75eea2fb32498665786009535d1f30e0d1a6a247ff689cbb
-  languageName: node
-  linkType: hard
-
-"@net-protocol/score@file:../net-score::locator=%40net-protocol%2Fcli%40workspace%3Apackages%2Fnet-cli":
-  version: 0.1.4
-  resolution: "@net-protocol/score@file:../net-score#../net-score::hash=c7cbfc&locator=%40net-protocol%2Fcli%40workspace%3Apackages%2Fnet-cli"
-  dependencies:
-    "@net-protocol/core": "file:../net-core"
-    "@net-protocol/storage": "file:../net-storage"
-    viem: "npm:^2.45.0"
-  peerDependencies:
-    "@tanstack/react-query": ^5.0.0
-    react: ^18.0.0
-    wagmi: ^2.15.0
-  peerDependenciesMeta:
-    "@tanstack/react-query":
-      optional: true
-    react:
-      optional: true
-    wagmi:
-      optional: true
-  checksum: 8ffe9713e87d40b4a0876bd0d7f2f56904e109c190da4a097a1bde4f84a0a74e2e98ca77123a902d75eea2fb32498665786009535d1f30e0d1a6a247ff689cbb
-  languageName: node
-  linkType: hard
-
-"@net-protocol/score@workspace:packages/net-score":
+"@net-protocol/score@npm:^0.1.4, @net-protocol/score@workspace:packages/net-score":
   version: 0.0.0-use.local
   resolution: "@net-protocol/score@workspace:packages/net-score"
   dependencies:
@@ -1932,7 +1744,7 @@ __metadata:
 
 "@net-protocol/storage@file:../net-storage::locator=%40net-protocol%2Fnetr%40workspace%3Apackages%2Fnet-netr":
   version: 0.1.15
-  resolution: "@net-protocol/storage@file:../net-storage#../net-storage::hash=654c1e&locator=%40net-protocol%2Fnetr%40workspace%3Apackages%2Fnet-netr"
+  resolution: "@net-protocol/storage@file:../net-storage#../net-storage::hash=827f9f&locator=%40net-protocol%2Fnetr%40workspace%3Apackages%2Fnet-netr"
   dependencies:
     "@net-protocol/core": "file:../net-core"
     pako: "npm:^2.1.0"
@@ -1946,13 +1758,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: f69febfceeeb53d8dd65b0eb67f243b89b88a2a3ce94ba1e4fa77680b4e8f55c56201084a71714956ca1f87fbc9469c46a5c1d734d9aa508934d171dca4509b4
+  checksum: cb30dae5b4cf65f38bed3fe2c507c752fb439d7fb2b9e1c42f903c6d43bd0b96b6058ba93ab159351a094ddcaafaaa8e6f49e4af31d1db5edaecf1cc897fe2be
   languageName: node
   linkType: hard
 
 "@net-protocol/storage@file:../net-storage::locator=%40net-protocol%2Fprofiles%40workspace%3Apackages%2Fnet-profiles":
   version: 0.1.15
-  resolution: "@net-protocol/storage@file:../net-storage#../net-storage::hash=654c1e&locator=%40net-protocol%2Fprofiles%40workspace%3Apackages%2Fnet-profiles"
+  resolution: "@net-protocol/storage@file:../net-storage#../net-storage::hash=827f9f&locator=%40net-protocol%2Fprofiles%40workspace%3Apackages%2Fnet-profiles"
   dependencies:
     "@net-protocol/core": "file:../net-core"
     pako: "npm:^2.1.0"
@@ -1966,53 +1778,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: f69febfceeeb53d8dd65b0eb67f243b89b88a2a3ce94ba1e4fa77680b4e8f55c56201084a71714956ca1f87fbc9469c46a5c1d734d9aa508934d171dca4509b4
-  languageName: node
-  linkType: hard
-
-"@net-protocol/storage@file:../net-storage::locator=%40net-protocol%2Fscore%40file%3A..%2Fnet-score%23..%2Fnet-score%3A%3Ahash%3Dc7cbfc%26locator%3D%2540net-protocol%252Fcli%2540file%253A..%252Fnet-cli%2523..%252Fnet-cli%253A%253Ahash%253D928be5%2526locator%253Dbotchan%252540workspace%25253Apackages%25252Fbotchan":
-  version: 0.1.15
-  resolution: "@net-protocol/storage@file:../net-storage#../net-storage::hash=654c1e&locator=%40net-protocol%2Fscore%40file%3A..%2Fnet-score%23..%2Fnet-score%3A%3Ahash%3Dc7cbfc%26locator%3D%2540net-protocol%252Fcli%2540file%253A..%252Fnet-cli%2523..%252Fnet-cli%253A%253Ahash%253D928be5%2526locator%253Dbotchan%252540workspace%25253Apackages%25252Fbotchan"
-  dependencies:
-    "@net-protocol/core": "file:../net-core"
-    pako: "npm:^2.1.0"
-    use-async-effect: "npm:^2.2.7"
-    viem: "npm:^2.45.0"
-  peerDependencies:
-    react: ^18.0.0
-    wagmi: ^2.15.0
-  peerDependenciesMeta:
-    react:
-      optional: true
-    wagmi:
-      optional: true
-  checksum: f69febfceeeb53d8dd65b0eb67f243b89b88a2a3ce94ba1e4fa77680b4e8f55c56201084a71714956ca1f87fbc9469c46a5c1d734d9aa508934d171dca4509b4
-  languageName: node
-  linkType: hard
-
-"@net-protocol/storage@file:../net-storage::locator=%40net-protocol%2Fscore%40file%3A..%2Fnet-score%23..%2Fnet-score%3A%3Ahash%3Dc7cbfc%26locator%3D%2540net-protocol%252Fcli%2540workspace%253Apackages%252Fnet-cli":
-  version: 0.1.15
-  resolution: "@net-protocol/storage@file:../net-storage#../net-storage::hash=654c1e&locator=%40net-protocol%2Fscore%40file%3A..%2Fnet-score%23..%2Fnet-score%3A%3Ahash%3Dc7cbfc%26locator%3D%2540net-protocol%252Fcli%2540workspace%253Apackages%252Fnet-cli"
-  dependencies:
-    "@net-protocol/core": "file:../net-core"
-    pako: "npm:^2.1.0"
-    use-async-effect: "npm:^2.2.7"
-    viem: "npm:^2.45.0"
-  peerDependencies:
-    react: ^18.0.0
-    wagmi: ^2.15.0
-  peerDependenciesMeta:
-    react:
-      optional: true
-    wagmi:
-      optional: true
-  checksum: f69febfceeeb53d8dd65b0eb67f243b89b88a2a3ce94ba1e4fa77680b4e8f55c56201084a71714956ca1f87fbc9469c46a5c1d734d9aa508934d171dca4509b4
+  checksum: cb30dae5b4cf65f38bed3fe2c507c752fb439d7fb2b9e1c42f903c6d43bd0b96b6058ba93ab159351a094ddcaafaaa8e6f49e4af31d1db5edaecf1cc897fe2be
   languageName: node
   linkType: hard
 
 "@net-protocol/storage@file:../net-storage::locator=%40net-protocol%2Fscore%40workspace%3Apackages%2Fnet-score":
   version: 0.1.15
-  resolution: "@net-protocol/storage@file:../net-storage#../net-storage::hash=654c1e&locator=%40net-protocol%2Fscore%40workspace%3Apackages%2Fnet-score"
+  resolution: "@net-protocol/storage@file:../net-storage#../net-storage::hash=827f9f&locator=%40net-protocol%2Fscore%40workspace%3Apackages%2Fnet-score"
   dependencies:
     "@net-protocol/core": "file:../net-core"
     pako: "npm:^2.1.0"
@@ -2026,7 +1798,7 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: f69febfceeeb53d8dd65b0eb67f243b89b88a2a3ce94ba1e4fa77680b4e8f55c56201084a71714956ca1f87fbc9469c46a5c1d734d9aa508934d171dca4509b4
+  checksum: cb30dae5b4cf65f38bed3fe2c507c752fb439d7fb2b9e1c42f903c6d43bd0b96b6058ba93ab159351a094ddcaafaaa8e6f49e4af31d1db5edaecf1cc897fe2be
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
This PR adds support for displaying and retrieving a user's display name in the profile get command, alongside existing profile fields like X username and bio.

## Key Changes
- **Profile metadata retrieval**: Extended `executeProfileGet` to fetch and parse the `display_name` field from profile metadata
- **Display name output**: Added display name to both console output (with "(not set)" placeholder when empty) and JSON output
- **Test utilities refactoring**: 
  - Updated `createMockProfileMetadataData` to accept an options object instead of positional parameters for better flexibility
  - Extracted repeated JSON parsing logic into a new `extractJsonOutput` helper function to reduce test duplication
- **Test coverage**: Added comprehensive tests for display name display and JSON serialization, including null value handling
- **Version bumps**: Updated package versions (net-cli: 0.1.41 → 0.1.42, botchan: 0.4.7 → 0.4.8)

## Implementation Details
- Display name is now included in the `hasProfile` check to determine if a profile exists
- The display name field is consistently handled with null values in JSON output when not set
- Console output follows the existing pattern with cyan labels and gray placeholders for unset values

https://claude.ai/code/session_01HhZQYpwHtKsTc86HH8tEYA