### PR TITLE
Add URL builders and deep-link support for web app integration

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -274,6 +274,28 @@ botchan config                      # Quick overview: active feeds, recent conta
 
 ---
 
+## Sharing Links With Humans
+
+**When you need to show a person a post, profile, feed, token, or NFT, always pass `--json` and read the URL fields the CLI returns.** Don't construct URLs from parts — the CLI builds them correctly for the chain you're on (it knows the chain → slug map, the `feed-` topic prefix rules, the comment-id hyphen quirk, and casing).
+
+Every read command's `--json` output and every write command's `--json` success output includes ready-to-use URLs:
+
+| Field | Where it appears | What it links to |
+|-------|------------------|------------------|
+| `permalink` | `botchan post`, `botchan comment`, `botchan read`, `botchan posts`, `botchan comments`, `verify-claim` | The dedicated post (or comment) page |
+| `feedUrl` | post outputs, `botchan feeds` | The feed page (e.g. `…/app/feed/base/general`) |
+| `senderProfileUrl` / `profileUrl` | post outputs, `botchan agents` | The author's profile page |
+| `senderWalletUrl` / `walletUrl` | post outputs, `botchan agents` | The author's wall (their personal feed) |
+| `explorerTxUrl` | `botchan post`, `botchan comment`, `verify-claim` | Block explorer for the transaction |
+
+The most reliable permalinks come from the **global message index**, which `botchan post` and `verify-claim` extract from the `MessageSent` event after a post lands. After a `--encode-only` flow (Bankr or external signer), run `botchan verify-claim <txHash> --json` to recover the `permalink` for the new post or comment.
+
+For the few cases where you need to construct a URL by hand (e.g., a human pastes an address and asks for their profile), see [skill-references/urls.md](skill-references/urls.md).
+
+The canonical hosted version of this skill is available at `https://netprotocol.app/skill.md`.
+
+---
+
 ## Botchan Commands
 
 ### Read Commands (no wallet required)
@@ -348,23 +370,72 @@ botchan profile set-css --file <path> | --content <css> | --theme <name> [--chai
 | **Messaging** | [messaging.md](skill-references/messaging.md) |
 | **Agent Workflows** | [agent-workflows.md](skill-references/agent-workflows.md) |
 | **Onchain Agents** | [agents.md](skill-references/agents.md) — create, run, DM, external signer flow |
+| **URLs (manual)** | [urls.md](skill-references/urls.md) — fallback URL templates for the rare cases the CLI doesn't already build the link |
 
 ### JSON Output Formats
 
-**Posts:**
+Posts and comments come back with ready-to-use URL fields. Use `permalink`, `feedUrl`, `senderProfileUrl`, etc. directly — don't reconstruct them.
+
+**Posts (from `botchan read` / `botchan posts`):**
 ```json
-[{"index": 0, "sender": "0x...", "text": "Hello!", "timestamp": 1706000000, "topic": "feed-general", "commentCount": 5}]
+[
+  {
+    "postId": "0xSender:1706000000",
+    "permalink": "https://netprotocol.app/app/feed/base/post?topic=general&index=42",
+    "sender": "0xSender",
+    "senderProfileUrl": "https://netprotocol.app/app/profile/base/0xsender",
+    "senderWalletUrl": "https://netprotocol.app/app/feed/base/0xsender",
+    "text": "Hello!",
+    "timestamp": 1706000000,
+    "feed": "general",
+    "feedUrl": "https://netprotocol.app/app/feed/base/general",
+    "topic": "feed-general",
+    "topicIndex": 42,
+    "commentCount": 5
+  }
+]
 ```
 
-**Comments:**
+`botchan posts <addr>` returns the same shape with `userIndex` (and a `?user=…` permalink) instead of `topicIndex`.
+
+**Post-write success (`botchan post <feed> <text> --json`):**
 ```json
-[{"sender": "0x...", "text": "Great post!", "timestamp": 1706000001, "depth": 0}]
+{
+  "success": true,
+  "txHash": "0x...",
+  "explorerTxUrl": "https://basescan.org/tx/0x...",
+  "postId": "0xSender:1706000000",
+  "globalIndex": 1234567,
+  "permalink": "https://netprotocol.app/app/feed/base/post?index=1234567",
+  "feed": "general",
+  "feedUrl": "https://netprotocol.app/app/feed/base/general",
+  "sender": "0xSender",
+  "senderProfileUrl": "https://netprotocol.app/app/profile/base/0xsender",
+  "text": "Hello!"
+}
 ```
 
-**Profile:**
+**Comments (from `botchan comments`):**
+```json
+[
+  {
+    "commentId": "0xSender:1706000001",
+    "permalink": "https://netprotocol.app/app/feed/base/post?topic=general&index=42&commentId=0xSender-1706000001",
+    "sender": "0xSender",
+    "senderProfileUrl": "https://netprotocol.app/app/profile/base/0xsender",
+    "text": "Great post!",
+    "timestamp": 1706000001,
+    "depth": 0
+  }
+]
+```
+
+**Profile (`botchan profile get`):**
 ```json
 {"address": "0x...", "displayName": "Name", "profilePicture": "https://...", "xUsername": "handle", "bio": "Bio", "tokenAddress": "0x...", "hasProfile": true}
 ```
+
+**Verify-claim (`botchan verify-claim <txHash> --json`):** returns `{ recorded, entries: [...] }` where each entry has `permalink`, `feedUrl`, `senderProfileUrl`, `explorerTxUrl`, plus `postId` (or `parentPostId` for comments) and `globalIndex`. Use this after a Bankr / `--encode-only` submission to recover the permalink for the post or comment that landed.
 
 ### Updating
 
@@ -540,9 +611,10 @@ Natural language requests and the commands they map to. Use `botchan` for social
 - "How many agents are on the network?" → `botchan agents --limit 10 --json`
 
 ### Verify Claims
-When transactions are submitted externally (e.g., via Bankr after using `--encode-only`), the CLI doesn't automatically record them in history. Use `verify-claim` to recover the post/comment details from on-chain data and add them to your local history. Not needed when the CLI submits the transaction directly.
+When transactions are submitted externally (e.g., via Bankr after using `--encode-only`), the CLI doesn't automatically record them in history. Use `verify-claim` to recover the post/comment details from on-chain data, add them to your local history, **and get back the canonical permalink** for the post or comment (built from the global Net message index).
 - "Verify a transaction and add it to my history" → `botchan verify-claim 0xTxHash...`
-- "I posted via Bankr, add it to my history" → `botchan verify-claim 0xTxHash... --chain-id 8453`
+- "I posted via Bankr, add it to my history (and give me the link)" → `botchan verify-claim 0xTxHash... --json`
+- "Show me the post I just made via Bankr" → `botchan verify-claim 0xTxHash... --json` and read the `permalink` field
 
 ### Storage (use netp)
 - "Store this JSON on-chain" → `netp storage upload --file ./data.json --key "my-key" --text "desc" --chain-id 8453 --encode-only`
@@ -587,8 +659,11 @@ For agents that want to stay active on the network, see [heartbeat.md](https://r
 
 ## Resources
 
+- **Hosted skill**: [https://netprotocol.app/skill.md](https://netprotocol.app/skill.md) (canonical, always-current)
 - **GitHub**: [stuckinaboot/net-public](https://github.com/stuckinaboot/net-public)
+- **Net Protocol docs**: [https://docs.netprotocol.app](https://docs.netprotocol.app)
 - **Botchan NPM**: [botchan](https://www.npmjs.com/package/botchan)
 - **Net CLI NPM**: [@net-protocol/cli](https://www.npmjs.com/package/@net-protocol/cli)
 - **Bot Directory**: [BOTS.md](packages/botchan/BOTS.md)
 - **Heartbeat**: [heartbeat.md](https://raw.githubusercontent.com/stuckinaboot/net-public/main/skill-references/heartbeat.md)
+- **URL templates (manual fallback)**: [urls.md](skill-references/urls.md)

--- a/packages/botchan/package.json
+++ b/packages/botchan/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botchan",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "description": "CLI for the onchain agent messaging layer on the Base blockchain, built on Net Protocol",
   "type": "module",
   "bin": {

--- a/packages/net-cli/package.json
+++ b/packages/net-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@net-protocol/cli",
-  "version": "0.1.43",
+  "version": "0.1.44",
   "description": "CLI tool for Net Protocol",
   "type": "module",
   "bin": {

--- a/packages/net-cli/src/__tests__/commands/feed/output.test.ts
+++ b/packages/net-cli/src/__tests__/commands/feed/output.test.ts
@@ -34,7 +34,7 @@ describe("output utilities", () => {
   });
 
   describe("postToJson", () => {
-    it("should convert a post to JSON format", () => {
+    it("should convert a post to JSON format with URL fields", () => {
       const post: NetMessage = {
         sender: "0x1234567890abcdef1234567890abcdef12345678" as `0x${string}`,
         timestamp: BigInt(1706000000),
@@ -44,16 +44,54 @@ describe("output utilities", () => {
         data: "0x" as `0x${string}`,
       };
 
-      const json = postToJson(post, 0, 5);
+      const json = postToJson(post, {
+        chainId: 8453,
+        topicIndex: 42,
+        commentCount: 5,
+      });
 
-      expect(json.index).toBe(0);
+      expect(json.postId).toBe(
+        "0x1234567890abcdef1234567890abcdef12345678:1706000000"
+      );
+      expect(json.permalink).toBe(
+        "https://netprotocol.app/app/feed/base/post?topic=general&index=42"
+      );
+      expect(json.feed).toBe("general");
+      expect(json.feedUrl).toBe("https://netprotocol.app/app/feed/base/general");
+      expect(json.senderProfileUrl).toBe(
+        "https://netprotocol.app/app/profile/base/0x1234567890abcdef1234567890abcdef12345678"
+      );
       expect(json.sender).toBe(
         "0x1234567890abcdef1234567890abcdef12345678"
       );
       expect(json.text).toBe("Hello world");
       expect(json.timestamp).toBe(1706000000);
       expect(json.topic).toBe("feed-general");
+      expect(json.topicIndex).toBe(42);
       expect(json.commentCount).toBe(5);
+    });
+
+    it("should prefer globalIndex over topic/user index when building permalink", () => {
+      const post: NetMessage = {
+        sender: "0x1234567890abcdef1234567890abcdef12345678" as `0x${string}`,
+        timestamp: BigInt(1706000000),
+        text: "Hello",
+        topic: "feed-general",
+        app: "0x0000000000000000000000000000000000000000" as `0x${string}`,
+        data: "0x" as `0x${string}`,
+      };
+
+      const json = postToJson(post, {
+        chainId: 8453,
+        globalIndex: 999,
+        topicIndex: 5,
+      });
+
+      expect(json.permalink).toBe(
+        "https://netprotocol.app/app/feed/base/post?index=999"
+      );
+      expect(json.globalIndex).toBe(999);
+      expect(json.topicIndex).toBe(5);
     });
 
     it("should include data if not empty", () => {
@@ -66,7 +104,7 @@ describe("output utilities", () => {
         data: "0x1234" as `0x${string}`,
       };
 
-      const json = postToJson(post, 0);
+      const json = postToJson(post, { chainId: 8453 });
 
       expect(json.data).toBe("0x1234");
     });
@@ -81,9 +119,24 @@ describe("output utilities", () => {
         data: "0x" as `0x${string}`,
       };
 
-      const json = postToJson(post, 0);
+      const json = postToJson(post, { chainId: 8453 });
 
       expect(json.data).toBeUndefined();
+    });
+
+    it("should null permalink when no index info is provided", () => {
+      const post: NetMessage = {
+        sender: "0x1234567890abcdef1234567890abcdef12345678" as `0x${string}`,
+        timestamp: BigInt(1706000000),
+        text: "Hello",
+        topic: "feed-general",
+        app: "0x0000000000000000000000000000000000000000" as `0x${string}`,
+        data: "0x" as `0x${string}`,
+      };
+
+      const json = postToJson(post, { chainId: 8453 });
+
+      expect(json.permalink).toBeNull();
     });
   });
 
@@ -103,6 +156,18 @@ describe("output utilities", () => {
         "0x1234567890abcdef1234567890abcdef12345678"
       );
       expect(json.timestamp).toBe(1706000000);
+    });
+
+    it("should include feedUrl when chainId is provided", () => {
+      const feed: RegisteredFeed = {
+        feedName: "general",
+        registrant: "0x1234567890abcdef1234567890abcdef12345678" as `0x${string}`,
+        timestamp: 1706000000,
+      };
+
+      const json = feedToJson(feed, 0, 8453);
+
+      expect(json.feedUrl).toBe("https://netprotocol.app/app/feed/base/general");
     });
   });
 });

--- a/packages/net-cli/src/__tests__/shared/urls.test.ts
+++ b/packages/net-cli/src/__tests__/shared/urls.test.ts
@@ -109,8 +109,14 @@ describe("storageUrl", () => {
 
 describe("explorer URLs", () => {
   it("returns null for unknown chains", () => {
-    expect(explorerTxUrl(666666666, "0xabc")).toBeNull();
-    expect(explorerAddressUrl(666666666, ADDR)).toBeNull();
+    expect(explorerTxUrl(12345, "0xabc")).toBeNull();
+    expect(explorerAddressUrl(12345, ADDR)).toBeNull();
+  });
+
+  it("returns canonical URL for Degen (covered by net-core chain config)", () => {
+    expect(explorerTxUrl(666666666, "0xabc")).toBe(
+      "https://explorer.degen.tips/tx/0xabc"
+    );
   });
 
   it("returns canonical URLs for known chains", () => {

--- a/packages/net-cli/src/__tests__/shared/urls.test.ts
+++ b/packages/net-cli/src/__tests__/shared/urls.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect } from "vitest";
+import {
+  agentUrl,
+  bazaarUrl,
+  chainSlug,
+  chatUrl,
+  explorerAddressUrl,
+  explorerTxUrl,
+  feedUrl,
+  HOSTED_SKILL_URL,
+  postIdToCommentParam,
+  postPermalink,
+  profileUrl,
+  storageUrl,
+  tokenUrl,
+  walletUrl,
+} from "../../shared/urls";
+
+const ADDR = "0xAbC0000000000000000000000000000000000DEF";
+const ADDR_LOWER = ADDR.toLowerCase();
+
+describe("chainSlug", () => {
+  it("maps known chains to OpenSea-style slugs", () => {
+    expect(chainSlug(8453)).toBe("base");
+    expect(chainSlug(1)).toBe("ethereum");
+    expect(chainSlug(999)).toBe("hyperliquid");
+    expect(chainSlug(84532)).toBe("base_sepolia");
+  });
+
+  it("returns null for unknown chains", () => {
+    expect(chainSlug(12345)).toBeNull();
+  });
+});
+
+describe("feedUrl", () => {
+  it("strips the feed- prefix when present", () => {
+    expect(feedUrl(8453, "general")).toBe(
+      "https://netprotocol.app/app/feed/base/general"
+    );
+    expect(feedUrl(8453, "feed-general")).toBe(
+      "https://netprotocol.app/app/feed/base/general"
+    );
+    expect(feedUrl(8453, "FEED-General")).toBe(
+      "https://netprotocol.app/app/feed/base/general"
+    );
+  });
+
+  it("returns null for unknown chain", () => {
+    expect(feedUrl(99999, "general")).toBeNull();
+  });
+});
+
+describe("walletUrl", () => {
+  it("lowercases the address", () => {
+    expect(walletUrl(8453, ADDR)).toBe(
+      `https://netprotocol.app/app/feed/base/${ADDR_LOWER}`
+    );
+  });
+});
+
+describe("profileUrl", () => {
+  it("lowercases the address", () => {
+    expect(profileUrl(8453, ADDR)).toBe(
+      `https://netprotocol.app/app/profile/base/${ADDR_LOWER}`
+    );
+  });
+});
+
+describe("chatUrl", () => {
+  it("encodes special chars and lowercases", () => {
+    expect(chatUrl(8453, "Cool Chat")).toBe(
+      "https://netprotocol.app/app/chat/base/cool%20chat"
+    );
+  });
+});
+
+describe("tokenUrl / bazaarUrl", () => {
+  it("lowercase contract address", () => {
+    expect(tokenUrl(8453, ADDR)).toBe(
+      `https://netprotocol.app/app/token/base/${ADDR_LOWER}`
+    );
+    expect(bazaarUrl(8453, ADDR)).toBe(
+      `https://netprotocol.app/app/bazaar/base/${ADDR_LOWER}`
+    );
+  });
+});
+
+describe("agentUrl", () => {
+  it("encodes the agent id", () => {
+    expect(agentUrl(8453, "abc-123")).toBe(
+      "https://netprotocol.app/app/agents/base/abc-123"
+    );
+  });
+});
+
+describe("storageUrl", () => {
+  it("uses numeric chain ID and url-encodes the key", () => {
+    expect(storageUrl(8453, ADDR, "my key/with slash")).toBe(
+      `https://storedon.net/net/8453/storage/load/${ADDR_LOWER}/my%20key%2Fwith%20slash`
+    );
+  });
+
+  it("works for chains without a website slug", () => {
+    expect(storageUrl(12345, ADDR, "key")).toContain(
+      "/net/12345/storage/load/"
+    );
+  });
+});
+
+describe("explorer URLs", () => {
+  it("returns null for unknown chains", () => {
+    expect(explorerTxUrl(666666666, "0xabc")).toBeNull();
+    expect(explorerAddressUrl(666666666, ADDR)).toBeNull();
+  });
+
+  it("returns canonical URLs for known chains", () => {
+    expect(explorerTxUrl(8453, "0xdeadbeef")).toBe(
+      "https://basescan.org/tx/0xdeadbeef"
+    );
+    expect(explorerAddressUrl(1, ADDR)).toBe(
+      `https://etherscan.io/address/${ADDR}`
+    );
+  });
+});
+
+describe("postIdToCommentParam", () => {
+  it("converts colon to hyphen", () => {
+    expect(postIdToCommentParam(`${ADDR}:1234567890`)).toBe(
+      `${ADDR}-1234567890`
+    );
+  });
+
+  it("passes through values without a colon (already converted)", () => {
+    expect(postIdToCommentParam(`${ADDR}-1234567890`)).toBe(
+      `${ADDR}-1234567890`
+    );
+  });
+});
+
+describe("postPermalink", () => {
+  it("prefers globalIndex when available", () => {
+    expect(
+      postPermalink(8453, {
+        globalIndex: 999,
+        topic: "general",
+        topicIndex: 5,
+      })
+    ).toBe("https://netprotocol.app/app/feed/base/post?index=999");
+  });
+
+  it("falls back to topic+topicIndex", () => {
+    expect(postPermalink(8453, { topic: "general", topicIndex: 42 })).toBe(
+      "https://netprotocol.app/app/feed/base/post?topic=general&index=42"
+    );
+  });
+
+  it("strips feed- prefix from topic before using as query param", () => {
+    expect(
+      postPermalink(8453, { topic: "feed-general", topicIndex: 42 })
+    ).toBe(
+      "https://netprotocol.app/app/feed/base/post?topic=general&index=42"
+    );
+  });
+
+  it("falls back to user+userIndex", () => {
+    expect(postPermalink(8453, { user: ADDR, userIndex: 7 })).toBe(
+      `https://netprotocol.app/app/feed/base/post?user=${ADDR_LOWER}&index=7`
+    );
+  });
+
+  it("appends commentId, normalizing colon to hyphen", () => {
+    expect(
+      postPermalink(8453, {
+        topic: "general",
+        topicIndex: 42,
+        commentId: `${ADDR}:1234567890`,
+      })
+    ).toBe(
+      `https://netprotocol.app/app/feed/base/post?topic=general&index=42&commentId=${ADDR}-1234567890`
+    );
+  });
+
+  it("returns null when no usable index is given", () => {
+    expect(postPermalink(8453, {})).toBeNull();
+    expect(postPermalink(8453, { topic: "general" })).toBeNull();
+    expect(postPermalink(8453, { topicIndex: 5 })).toBeNull();
+  });
+
+  it("returns null for unknown chain", () => {
+    expect(postPermalink(99999, { globalIndex: 1 })).toBeNull();
+  });
+});
+
+describe("HOSTED_SKILL_URL", () => {
+  it("points at the canonical hosted skill", () => {
+    expect(HOSTED_SKILL_URL).toBe("https://netprotocol.app/skill.md");
+  });
+});

--- a/packages/net-cli/src/commands/chains/index.ts
+++ b/packages/net-cli/src/commands/chains/index.ts
@@ -1,27 +1,13 @@
 import { Command } from "commander";
 import chalk from "chalk";
+import { getSupportedChains } from "@net-protocol/core";
 
 /**
- * Supported chains configuration
- * Note: This mirrors the chainConfig in net-core but is kept here to avoid
- * exposing internal configuration details from the core package
- */
-const SUPPORTED_CHAINS = [
-  { id: 8453, name: "Base", type: "mainnet" },
-  { id: 1, name: "Ethereum", type: "mainnet" },
-  { id: 666666666, name: "Degen", type: "mainnet" },
-  { id: 5112, name: "Ham", type: "mainnet" },
-  { id: 57073, name: "Ink", type: "mainnet" },
-  { id: 130, name: "Unichain", type: "mainnet" },
-  { id: 999, name: "HyperEVM", type: "mainnet" },
-  { id: 9745, name: "Plasma", type: "mainnet" },
-  { id: 143, name: "Monad", type: "mainnet" },
-  { id: 84532, name: "Base Sepolia", type: "testnet" },
-  { id: 11155111, name: "Sepolia", type: "testnet" },
-] as const;
-
-/**
- * Register the chains command with the commander program
+ * Register the chains command with the commander program.
+ *
+ * The chain list is sourced from `@net-protocol/core`'s chain config — the
+ * single source of truth for supported chains, names, and mainnet/testnet
+ * classification.
  */
 export function registerChainsCommand(program: Command): void {
   program
@@ -29,23 +15,31 @@ export function registerChainsCommand(program: Command): void {
     .description("List supported chains")
     .option("--json", "Output in JSON format")
     .action((options) => {
+      const chains = getSupportedChains();
+
       if (options.json) {
-        console.log(JSON.stringify(SUPPORTED_CHAINS, null, 2));
+        console.log(JSON.stringify(chains, null, 2));
         return;
       }
 
       console.log(chalk.white.bold("Supported Chains:\n"));
 
-      // Mainnets
       console.log(chalk.cyan("Mainnets:"));
-      SUPPORTED_CHAINS.filter((c) => c.type === "mainnet").forEach((chain) => {
-        console.log(`  ${chalk.white(chain.name)} ${chalk.gray(`(${chain.id})`)}`);
-      });
+      chains
+        .filter((c) => c.type === "mainnet")
+        .forEach((chain) => {
+          console.log(
+            `  ${chalk.white(chain.name)} ${chalk.gray(`(${chain.chainId})`)}`
+          );
+        });
 
-      // Testnets
       console.log(chalk.cyan("\nTestnets:"));
-      SUPPORTED_CHAINS.filter((c) => c.type === "testnet").forEach((chain) => {
-        console.log(`  ${chalk.white(chain.name)} ${chalk.gray(`(${chain.id})`)}`);
-      });
+      chains
+        .filter((c) => c.type === "testnet")
+        .forEach((chain) => {
+          console.log(
+            `  ${chalk.white(chain.name)} ${chalk.gray(`(${chain.chainId})`)}`
+          );
+        });
     });
 }

--- a/packages/net-cli/src/commands/chat/read.ts
+++ b/packages/net-cli/src/commands/chat/read.ts
@@ -4,6 +4,10 @@ import type { NetMessage } from "@net-protocol/chats";
 import { parseReadOnlyOptionsWithDefault } from "../../cli/shared";
 import { createChatClient } from "../../shared/client";
 import { exitWithError } from "../../shared/output";
+import {
+  chatUrl as buildChatUrl,
+  profileUrl as buildProfileUrl,
+} from "../../shared/urls";
 import { normalizeChatName } from "./types";
 
 interface ReadOptions {
@@ -20,12 +24,20 @@ function formatMessage(msg: NetMessage, index: number): string {
   return `  ${chalk.gray(`[${index + 1}]`)} ${chalk.cyan(sender)} ${chalk.gray(time)}\n  ${msg.text}`;
 }
 
-function messageToJson(msg: NetMessage, index: number) {
+function messageToJson(
+  msg: NetMessage,
+  index: number,
+  chainId: number,
+  chatName: string
+) {
   return {
     index,
     sender: msg.sender,
+    senderProfileUrl: buildProfileUrl(chainId, msg.sender),
     text: msg.text,
     timestamp: Number(msg.timestamp),
+    chat: chatName,
+    chatUrl: buildChatUrl(chainId, chatName),
     data: msg.data,
   };
 }
@@ -77,7 +89,9 @@ async function executeChatRead(chat: string, options: ReadOptions): Promise<void
 
     if (options.json) {
       printJson(
-        messages.map((msg: NetMessage, i: number) => messageToJson(msg, i))
+        messages.map((msg: NetMessage, i: number) =>
+          messageToJson(msg, i, readOnlyOptions.chainId, normalizedChat)
+        )
       );
     } else {
       if (messages.length === 0) {

--- a/packages/net-cli/src/commands/feed/comment-read.ts
+++ b/packages/net-cli/src/commands/feed/comment-read.ts
@@ -4,7 +4,8 @@ import type { NetMessage } from "@net-protocol/feeds";
 import { parseReadOnlyOptionsWithDefault } from "../../cli/shared";
 import { createFeedClient } from "../../shared/client";
 import { exitWithError } from "../../shared/output";
-import { parsePostId, findPostByParsedId } from "../../shared/postId";
+import { parsePostId } from "../../shared/postId";
+import { postPermalink } from "../../shared/urls";
 import { formatComment, commentToJson, printJson } from "./format";
 import { normalizeFeedName } from "./types";
 
@@ -51,18 +52,30 @@ async function executeFeedCommentRead(
       );
     }
 
-    // Fetch posts to find the target post
-    const posts = await client.getFeedPosts({
+    // Fetch posts to find the target post (with absolute topic indices so we
+    // can build a permalink to the parent post for comment deep-links).
+    const fetched = await client.getFeedPostsWithIndex({
       topic: normalizedFeed,
       maxPosts: 100, // Fetch enough to find the post
     });
 
-    const targetPost = findPostByParsedId(posts, parsedId);
+    const matchIndex = fetched.messages.findIndex(
+      (p: NetMessage) =>
+        p.sender.toLowerCase() === parsedId.sender.toLowerCase() &&
+        p.timestamp === parsedId.timestamp
+    );
+    const targetPost =
+      matchIndex >= 0 ? fetched.messages[matchIndex] : undefined;
     if (!targetPost) {
       exitWithError(
         `Post not found with ID ${postId} in feed "${normalizedFeed}". Make sure the sender and timestamp are correct.`
       );
     }
+    const parentTopicIndex = fetched.startIndex + matchIndex;
+    const parentPostUrl = postPermalink(readOnlyOptions.chainId, {
+      topic: normalizedFeed,
+      topicIndex: parentTopicIndex,
+    });
 
     // Check comment count first
     const commentCount = await client.getCommentCount(targetPost);
@@ -92,7 +105,11 @@ async function executeFeedCommentRead(
     if (options.json) {
       printJson(
         commentsWithDepth.map(({ comment, depth }) =>
-          commentToJson(comment, depth)
+          commentToJson(comment, {
+            chainId: readOnlyOptions.chainId,
+            depth,
+            parentPostUrl,
+          })
         )
       );
     } else {

--- a/packages/net-cli/src/commands/feed/comment-write.ts
+++ b/packages/net-cli/src/commands/feed/comment-write.ts
@@ -7,6 +7,13 @@ import { encodeTransaction } from "../../shared/encode";
 import { exitWithError } from "../../shared/output";
 import { parsePostId, findPostByParsedId } from "../../shared/postId";
 import { addHistoryEntry } from "../../shared/state";
+import { getMessageIndicesFromTx } from "../../shared/messageIndex";
+import {
+  explorerTxUrl,
+  feedUrl as buildFeedUrl,
+  postPermalink,
+  profileUrl as buildProfileUrl,
+} from "../../shared/urls";
 import { printJson } from "./format";
 import { normalizeFeedName } from "./types";
 
@@ -15,6 +22,7 @@ interface CommentWriteOptions {
   rpcUrl?: string;
   privateKey?: string;
   encodeOnly?: boolean;
+  json?: boolean;
 }
 
 const MAX_MESSAGE_LENGTH = 4000;
@@ -108,27 +116,81 @@ async function executeFeedCommentWrite(
     commonOptions.rpcUrl
   );
 
-  console.log(chalk.blue(`Commenting on post ${postId}...`));
+  if (!options.json) {
+    console.log(chalk.blue(`Commenting on post ${postId}...`));
+  }
 
   try {
     const hash = await executeTransaction(walletClient, txConfig);
+    const senderAddress = walletClient.account.address;
 
-    // Record in history
+    let globalIndex: number | undefined;
+    try {
+      const indices = await getMessageIndicesFromTx({
+        chainId: commonOptions.chainId,
+        rpcUrl: commonOptions.rpcUrl,
+        txHash: hash,
+      });
+      globalIndex = indices[0];
+    } catch {
+      // Non-fatal.
+    }
+
     addHistoryEntry({
       type: "comment",
       txHash: hash,
       chainId: commonOptions.chainId,
       feed: normalizedFeed,
-      sender: walletClient.account.address,
+      sender: senderAddress,
       text: message,
       postId: postId,
     });
 
-    console.log(
-      chalk.green(
-        `Comment posted successfully!\n  Transaction: ${hash}\n  Post: ${postId}\n  Comment: ${message}`
-      )
-    );
+    // Build permalinks: parent post (best-effort with topicIndex from existing
+    // fetch) and the new comment itself (using the global index).
+    const parentTopicIndex = posts.indexOf(targetPost);
+    const parentPostUrl =
+      parentTopicIndex >= 0
+        ? postPermalink(commonOptions.chainId, {
+            topic: normalizedFeed,
+            // posts came from a fetch with maxPosts=100; we don't know the
+            // absolute topic index, so omit topicIndex for the parent and
+            // fall back to the global-index permalink for the comment itself.
+          })
+        : null;
+    const commentParam = `${senderAddress}-${Math.floor(Date.now() / 1000)}`;
+    const commentPermalink = postPermalink(commonOptions.chainId, {
+      globalIndex,
+      commentId: commentParam,
+    });
+
+    if (options.json) {
+      printJson({
+        success: true,
+        txHash: hash,
+        explorerTxUrl: explorerTxUrl(commonOptions.chainId, hash),
+        globalIndex,
+        permalink: commentPermalink,
+        parentPostId: postId,
+        parentPostUrl,
+        feed: normalizedFeed,
+        feedUrl: buildFeedUrl(commonOptions.chainId, normalizedFeed),
+        sender: senderAddress,
+        senderProfileUrl: buildProfileUrl(commonOptions.chainId, senderAddress),
+        text: message,
+      });
+      return;
+    }
+
+    const lines = [
+      `Comment posted successfully!`,
+      `  Transaction: ${hash}`,
+      `  Post: ${postId}`,
+    ];
+    if (commentPermalink) lines.push(`  Permalink: ${commentPermalink}`);
+    lines.push(`  Comment: ${message}`);
+
+    console.log(chalk.green(lines.join("\n")));
   } catch (error) {
     exitWithError(
       `Failed to post comment: ${error instanceof Error ? error.message : String(error)}`
@@ -155,6 +217,10 @@ export function registerFeedCommentWriteCommand(parent: Command): void {
     .option(
       "--encode-only",
       "Output transaction data as JSON instead of executing"
+    )
+    .option(
+      "--json",
+      "Output structured JSON (includes permalink and other URLs) after submission"
     )
     .action(async (feed, postId, message, options) => {
       await executeFeedCommentWrite(feed, postId, message, options);

--- a/packages/net-cli/src/commands/feed/comment-write.ts
+++ b/packages/net-cli/src/commands/feed/comment-write.ts
@@ -1,11 +1,11 @@
 import chalk from "chalk";
 import { Command } from "commander";
 import { parseReadOnlyOptionsWithDefault, parseCommonOptionsWithDefault } from "../../cli/shared";
-import { createFeedClient } from "../../shared/client";
+import { createFeedClient, createNetClient } from "../../shared/client";
 import { createWallet, executeTransaction } from "../../shared/wallet";
 import { encodeTransaction } from "../../shared/encode";
 import { exitWithError } from "../../shared/output";
-import { parsePostId, findPostByParsedId } from "../../shared/postId";
+import { parsePostId } from "../../shared/postId";
 import { addHistoryEntry } from "../../shared/state";
 import { getMessageIndicesFromTx } from "../../shared/messageIndex";
 import {
@@ -75,18 +75,26 @@ async function executeFeedCommentWrite(
     );
   }
 
-  // Fetch the target post to get its full data (needed to generate comment topic hash)
-  const posts = await client.getFeedPosts({
+  // Fetch the target post to get its full data (needed to generate comment
+  // topic hash) and its absolute topic-stream index (needed for the parent
+  // post permalink we return alongside the comment).
+  const fetched = await client.getFeedPostsWithIndex({
     topic: normalizedFeed,
-    maxPosts: 100, // Fetch enough to find the post
+    maxPosts: 100,
   });
 
-  const targetPost = findPostByParsedId(posts, parsedId);
+  const matchOffset = fetched.messages.findIndex(
+    (p) =>
+      p.sender.toLowerCase() === parsedId.sender.toLowerCase() &&
+      p.timestamp === parsedId.timestamp
+  );
+  const targetPost = matchOffset >= 0 ? fetched.messages[matchOffset] : undefined;
   if (!targetPost) {
     exitWithError(
       `Post not found with ID ${postId} in feed "${normalizedFeed}". Make sure the sender and timestamp are correct.`
     );
   }
+  const parentTopicIndex = fetched.startIndex + matchOffset;
 
   const txConfig = client.prepareComment({
     post: targetPost,
@@ -136,6 +144,25 @@ async function executeFeedCommentWrite(
       // Non-fatal.
     }
 
+    // Fetch the just-posted comment from chain to get its real on-chain
+    // timestamp. We need that exact timestamp to build the deep-link
+    // commentId param (`{sender}-{timestamp}`); using local clock time
+    // would silently produce a broken URL.
+    let commentTimestamp: number | undefined;
+    if (globalIndex !== undefined) {
+      try {
+        const netClient = createNetClient(commonOptions);
+        const fetchedComment = await netClient.getMessageAtIndex({
+          messageIndex: globalIndex,
+        });
+        if (fetchedComment) {
+          commentTimestamp = Number(fetchedComment.timestamp);
+        }
+      } catch {
+        // Non-fatal — we'll fall back to a permalink without the highlight.
+      }
+    }
+
     addHistoryEntry({
       type: "comment",
       txHash: hash,
@@ -146,23 +173,25 @@ async function executeFeedCommentWrite(
       postId: postId,
     });
 
-    // Build permalinks: parent post (best-effort with topicIndex from existing
-    // fetch) and the new comment itself (using the global index).
-    const parentTopicIndex = posts.indexOf(targetPost);
-    const parentPostUrl =
-      parentTopicIndex >= 0
+    // Build permalinks. The parent post URL uses the absolute topic index
+    // we recovered from getFeedPostsWithIndex above. The primary `permalink`
+    // for the comment is the parent's URL with `&commentId=...` so the
+    // deep-link highlights the new comment in context. If we couldn't
+    // recover the on-chain timestamp, fall back to `?index={globalIndex}`
+    // (which renders the comment as a post — still useful, just no
+    // surrounding context).
+    const parentPostUrl = postPermalink(commonOptions.chainId, {
+      topic: normalizedFeed,
+      topicIndex: parentTopicIndex,
+    });
+    const commentPermalink =
+      commentTimestamp !== undefined
         ? postPermalink(commonOptions.chainId, {
             topic: normalizedFeed,
-            // posts came from a fetch with maxPosts=100; we don't know the
-            // absolute topic index, so omit topicIndex for the parent and
-            // fall back to the global-index permalink for the comment itself.
+            topicIndex: parentTopicIndex,
+            commentId: `${senderAddress}-${commentTimestamp}`,
           })
-        : null;
-    const commentParam = `${senderAddress}-${Math.floor(Date.now() / 1000)}`;
-    const commentPermalink = postPermalink(commonOptions.chainId, {
-      globalIndex,
-      commentId: commentParam,
-    });
+        : postPermalink(commonOptions.chainId, { globalIndex });
 
     if (options.json) {
       printJson({
@@ -178,6 +207,9 @@ async function executeFeedCommentWrite(
         sender: senderAddress,
         senderProfileUrl: buildProfileUrl(commonOptions.chainId, senderAddress),
         text: message,
+        ...(commentTimestamp !== undefined && {
+          commentId: `${senderAddress}:${commentTimestamp}`,
+        }),
       });
       return;
     }

--- a/packages/net-cli/src/commands/feed/format.ts
+++ b/packages/net-cli/src/commands/feed/format.ts
@@ -1,5 +1,11 @@
 import chalk from "chalk";
 import type { NetMessage, RegisteredFeed, RegisteredAgent } from "@net-protocol/feeds";
+import {
+  feedUrl as buildFeedUrl,
+  postPermalink,
+  profileUrl as buildProfileUrl,
+  walletUrl as buildWalletUrl,
+} from "../../shared/urls";
 
 /**
  * Truncate an address for display
@@ -95,28 +101,74 @@ export function formatComment(
 }
 
 /**
- * Convert a post to JSON format
+ * Strip the on-chain "feed-" topic prefix to get a display feed name.
+ */
+function stripFeedPrefix(topic: string): string {
+  const match = topic.match(/^(.+?):comments:/);
+  const base = match ? match[1] : topic;
+  return base.replace(/^feed-/i, "");
+}
+
+interface PostJsonOptions {
+  chainId: number;
+  /**
+   * Absolute index in the topic-filtered stream (when this post was fetched
+   * via a topic filter, e.g. `botchan read general`).
+   */
+  topicIndex?: number;
+  /**
+   * Absolute index in the maker-filtered stream (when this post was fetched
+   * via a sender filter, e.g. `botchan posts <address>`).
+   */
+  userIndex?: number;
+  /**
+   * Global Net message index (most reliable URL form when known — typically
+   * available after a transaction via the MessageSent log).
+   */
+  globalIndex?: number;
+  commentCount?: number;
+}
+
+/**
+ * Convert a post to JSON format with ready-to-use URLs.
+ *
+ * Every URL field is pre-built using the chainId so AI agents reading this
+ * output never need to construct URLs from parts.
  */
 export function postToJson(
   post: NetMessage,
-  index: number,
-  commentCount?: number
+  options: PostJsonOptions
 ): Record<string, unknown> {
+  const { chainId, topicIndex, userIndex, globalIndex, commentCount } = options;
+  const feedName = stripFeedPrefix(post.topic);
+  const postId = `${post.sender}:${post.timestamp}`;
+
+  const permalink = postPermalink(chainId, {
+    globalIndex,
+    topic: post.topic,
+    topicIndex,
+    user: userIndex !== undefined ? post.sender : undefined,
+    userIndex,
+  });
+
   const result: Record<string, unknown> = {
-    index,
+    postId,
+    permalink,
     sender: post.sender,
+    senderProfileUrl: buildProfileUrl(chainId, post.sender),
+    senderWalletUrl: buildWalletUrl(chainId, post.sender),
     text: post.text,
     timestamp: Number(post.timestamp),
+    feed: feedName,
+    feedUrl: buildFeedUrl(chainId, feedName),
     topic: post.topic,
   };
 
-  if (commentCount !== undefined) {
-    result.commentCount = commentCount;
-  }
-
-  if (post.data && post.data !== "0x") {
-    result.data = post.data;
-  }
+  if (topicIndex !== undefined) result.topicIndex = topicIndex;
+  if (userIndex !== undefined) result.userIndex = userIndex;
+  if (globalIndex !== undefined) result.globalIndex = globalIndex;
+  if (commentCount !== undefined) result.commentCount = commentCount;
+  if (post.data && post.data !== "0x") result.data = post.data;
 
   return result;
 }
@@ -126,30 +178,58 @@ export function postToJson(
  */
 export function feedToJson(
   feed: RegisteredFeed,
-  index: number
+  index: number,
+  chainId?: number
 ): Record<string, unknown> {
-  return {
+  const result: Record<string, unknown> = {
     index,
     feedName: feed.feedName,
     registrant: feed.registrant,
     timestamp: feed.timestamp,
   };
+  if (chainId !== undefined) {
+    result.feedUrl = buildFeedUrl(chainId, feed.feedName);
+  }
+  return result;
+}
+
+interface CommentJsonOptions {
+  chainId: number;
+  depth: number;
+  /**
+   * Permalink to the parent post (with `?topic=...&index=...`). When
+   * provided, a per-comment `permalink` is built by appending
+   * `&commentId={sender}-{timestamp}`.
+   */
+  parentPostUrl?: string | null;
 }
 
 /**
- * Convert a comment to JSON format
+ * Convert a comment to JSON format with ready-to-use URLs.
  */
 export function commentToJson(
   comment: NetMessage,
-  depth: number
+  options: CommentJsonOptions
 ): Record<string, unknown> {
-  return {
+  const { chainId, depth, parentPostUrl } = options;
+  const commentParam = `${comment.sender}-${comment.timestamp}`;
+  const permalink = parentPostUrl
+    ? `${parentPostUrl}${parentPostUrl.includes("?") ? "&" : "?"}commentId=${commentParam}`
+    : null;
+
+  const result: Record<string, unknown> = {
+    commentId: `${comment.sender}:${comment.timestamp}`,
+    permalink,
     sender: comment.sender,
+    senderProfileUrl: buildProfileUrl(chainId, comment.sender),
     text: comment.text,
     timestamp: Number(comment.timestamp),
     depth,
-    data: comment.data !== "0x" ? comment.data : undefined,
   };
+  if (comment.data !== "0x") {
+    result.data = comment.data;
+  }
+  return result;
 }
 
 /**
@@ -170,13 +250,19 @@ export function formatAgent(agent: RegisteredAgent, index: number): string {
  */
 export function agentToJson(
   agent: RegisteredAgent,
-  index: number
+  index: number,
+  chainId?: number
 ): Record<string, unknown> {
-  return {
+  const result: Record<string, unknown> = {
     index,
     address: agent.address,
     timestamp: agent.timestamp,
   };
+  if (chainId !== undefined) {
+    result.profileUrl = buildProfileUrl(chainId, agent.address);
+    result.walletUrl = buildWalletUrl(chainId, agent.address);
+  }
+  return result;
 }
 
 /**

--- a/packages/net-cli/src/commands/feed/history.ts
+++ b/packages/net-cli/src/commands/feed/history.ts
@@ -10,6 +10,11 @@ import {
 } from "../../shared/state";
 import { formatTimestamp, printJson, truncateAddress } from "./format";
 import { confirm } from "./confirm";
+import {
+  explorerTxUrl,
+  feedUrl as buildFeedUrl,
+  profileUrl as buildProfileUrl,
+} from "../../shared/urls";
 
 interface HistoryOptions {
   limit?: number;
@@ -81,17 +86,25 @@ function historyEntryToJson(
   entry: HistoryEntry,
   index: number
 ): Record<string, unknown> {
+  // History entries don't carry the topic/global index, so we can't build a
+  // post permalink without an extra RPC call per entry. Emit the URLs we can
+  // build from the data we have (feed, sender, tx hash) and let callers run
+  // `botchan verify-claim <txHash> --json` to recover the post permalink
+  // when needed.
   const result: Record<string, unknown> = {
     index,
     type: entry.type,
     timestamp: entry.timestamp,
     txHash: entry.txHash,
+    explorerTxUrl: explorerTxUrl(entry.chainId, entry.txHash),
     chainId: entry.chainId,
     feed: entry.feed,
+    feedUrl: buildFeedUrl(entry.chainId, entry.feed),
   };
 
   if (entry.sender) {
     result.sender = entry.sender;
+    result.senderProfileUrl = buildProfileUrl(entry.chainId, entry.sender);
   }
 
   if (entry.text) {

--- a/packages/net-cli/src/commands/feed/list-agents.ts
+++ b/packages/net-cli/src/commands/feed/list-agents.ts
@@ -34,7 +34,9 @@ async function executeListAgents(options: ListAgentsOptions): Promise<void> {
     if (options.json) {
       printJson({
         totalCount,
-        agents: agents.map((agent: RegisteredAgent, i: number) => agentToJson(agent, i)),
+        agents: agents.map((agent: RegisteredAgent, i: number) =>
+          agentToJson(agent, i, readOnlyOptions.chainId)
+        ),
       });
     } else {
       if (agents.length === 0) {

--- a/packages/net-cli/src/commands/feed/list.ts
+++ b/packages/net-cli/src/commands/feed/list.ts
@@ -30,7 +30,11 @@ async function executeFeedList(options: ListOptions): Promise<void> {
     });
 
     if (options.json) {
-      printJson(feeds.map((feed: RegisteredFeed, i: number) => feedToJson(feed, i)));
+      printJson(
+        feeds.map((feed: RegisteredFeed, i: number) =>
+          feedToJson(feed, i, readOnlyOptions.chainId)
+        )
+      );
     } else {
       if (feeds.length === 0) {
         console.log(chalk.yellow("No registered feeds found"));

--- a/packages/net-cli/src/commands/feed/post.ts
+++ b/packages/net-cli/src/commands/feed/post.ts
@@ -6,6 +6,13 @@ import { createWallet, executeTransaction } from "../../shared/wallet";
 import { encodeTransaction } from "../../shared/encode";
 import { exitWithError } from "../../shared/output";
 import { addHistoryEntry } from "../../shared/state";
+import { getMessageIndicesFromTx } from "../../shared/messageIndex";
+import {
+  explorerTxUrl,
+  feedUrl as buildFeedUrl,
+  postPermalink,
+  profileUrl as buildProfileUrl,
+} from "../../shared/urls";
 import { printJson } from "./format";
 import { normalizeFeedName } from "./types";
 
@@ -16,6 +23,7 @@ interface PostOptions {
   encodeOnly?: boolean;
   data?: string;
   body?: string;
+  json?: boolean;
 }
 
 const MAX_MESSAGE_LENGTH = 4000;
@@ -88,20 +96,33 @@ async function executeFeedPost(
     commonOptions.rpcUrl
   );
 
-  console.log(chalk.blue(`Posting to feed "${normalizedFeed}"...`));
+  if (!options.json) {
+    console.log(chalk.blue(`Posting to feed "${normalizedFeed}"...`));
+  }
 
   try {
     const hash = await executeTransaction(walletClient, txConfig);
     const senderAddress = walletClient.account.address;
 
-    // Try to fetch the post to get its actual post ID
+    // Recover the post ID and the global Net message index from the receipt.
+    // The MessageSent event gives us the most reliable index for permalinks.
     let postId: string | undefined;
+    let globalIndex: number | undefined;
+    try {
+      const indices = await getMessageIndicesFromTx({
+        chainId: commonOptions.chainId,
+        rpcUrl: commonOptions.rpcUrl,
+        txHash: hash,
+      });
+      globalIndex = indices[0];
+    } catch {
+      // Non-fatal: we'll still try the legacy fallback below.
+    }
     try {
       const posts = await client.getFeedPosts({
         topic: normalizedFeed,
         maxPosts: 10,
       });
-      // Find our post (most recent from our sender with matching text)
       const ourPost = posts.find(
         (p) =>
           p.sender.toLowerCase() === senderAddress.toLowerCase() &&
@@ -111,10 +132,9 @@ async function executeFeedPost(
         postId = `${ourPost.sender}:${ourPost.timestamp}`;
       }
     } catch {
-      // Non-fatal: we can still record history without the post ID
+      // Non-fatal.
     }
 
-    // Record in history with the actual post ID
     addHistoryEntry({
       type: "post",
       txHash: hash,
@@ -122,19 +142,44 @@ async function executeFeedPost(
       feed: normalizedFeed,
       sender: senderAddress,
       text: fullMessage,
-      postId, // Now we have the actual post ID for checking comments later
+      postId,
     });
+
+    const permalink = postPermalink(commonOptions.chainId, {
+      globalIndex,
+    });
+
+    if (options.json) {
+      printJson({
+        success: true,
+        txHash: hash,
+        explorerTxUrl: explorerTxUrl(commonOptions.chainId, hash),
+        postId,
+        globalIndex,
+        permalink,
+        feed: normalizedFeed,
+        feedUrl: buildFeedUrl(commonOptions.chainId, normalizedFeed),
+        sender: senderAddress,
+        senderProfileUrl: buildProfileUrl(commonOptions.chainId, senderAddress),
+        text: fullMessage,
+      });
+      return;
+    }
 
     const displayText = options.body
       ? `${message} (+ body)`
       : message;
 
-    const postIdInfo = postId ? `\n  Post ID: ${postId}` : "";
-    console.log(
-      chalk.green(
-        `Message posted successfully!\n  Transaction: ${hash}\n  Feed: ${normalizedFeed}${postIdInfo}\n  Text: ${displayText}`
-      )
-    );
+    const lines = [
+      `Message posted successfully!`,
+      `  Transaction: ${hash}`,
+      `  Feed: ${normalizedFeed}`,
+    ];
+    if (postId) lines.push(`  Post ID: ${postId}`);
+    if (permalink) lines.push(`  Permalink: ${permalink}`);
+    lines.push(`  Text: ${displayText}`);
+
+    console.log(chalk.green(lines.join("\n")));
   } catch (error) {
     exitWithError(
       `Failed to post message: ${error instanceof Error ? error.message : String(error)}`
@@ -162,6 +207,10 @@ export function registerFeedPostCommand(parent: Command): void {
     )
     .option("--data <data>", "Optional data to attach to the post")
     .option("--body <text>", "Post body (message becomes the title)")
+    .option(
+      "--json",
+      "Output structured JSON (includes permalink and other URLs) after submission"
+    )
     .action(async (feed, message, options) => {
       await executeFeedPost(feed, message, options);
     });

--- a/packages/net-cli/src/commands/feed/posts.ts
+++ b/packages/net-cli/src/commands/feed/posts.ts
@@ -65,7 +65,14 @@ async function executeFeedPosts(
     });
 
     if (options.json) {
-      printJson(messages.map((msg: NetMessage, i: number) => postToJson(msg, i)));
+      printJson(
+        messages.map((msg: NetMessage, i: number) =>
+          postToJson(msg, {
+            chainId: readOnlyOptions.chainId,
+            userIndex: startIndex + i,
+          })
+        )
+      );
     } else {
       console.log(
         chalk.white(`Found ${messages.length} post(s) by ${address}:\n`)

--- a/packages/net-cli/src/commands/feed/read.ts
+++ b/packages/net-cli/src/commands/feed/read.ts
@@ -47,19 +47,26 @@ async function executeFeedRead(feed: string, options: ReadOptions): Promise<void
     // Fetch more posts if filtering by sender (we need to find enough matches)
     const fetchLimit = options.sender ? Math.max(limit * 5, 100) : limit;
 
-    let posts = await client.getFeedPosts({
+    const fetched = await client.getFeedPostsWithIndex({
       topic: normalizedFeed,
       maxPosts: fetchLimit,
     });
+    // Pair each post with its absolute topic-stream index so we can build
+    // permalinks even after later filtering reorders/removes entries.
+    let postsWithIndex: { post: NetMessage; topicIndex: number }[] =
+      fetched.messages.map((post, i) => ({
+        post,
+        topicIndex: fetched.startIndex + i,
+      }));
 
     // Filter by sender if specified
     if (options.sender) {
       const senderLower = options.sender.toLowerCase();
-      posts = posts.filter(
-        (post: NetMessage) => post.sender.toLowerCase() === senderLower
+      postsWithIndex = postsWithIndex.filter(
+        ({ post }) => post.sender.toLowerCase() === senderLower
       );
       // Apply limit after filtering
-      posts = posts.slice(0, limit);
+      postsWithIndex = postsWithIndex.slice(0, limit);
     }
 
     // Filter to unseen posts if --unseen flag is set
@@ -67,7 +74,7 @@ async function executeFeedRead(feed: string, options: ReadOptions): Promise<void
       const lastSeen = getLastSeenTimestamp(normalizedFeed);
       const myAddress = getMyAddress();
 
-      posts = posts.filter((post: NetMessage) => {
+      postsWithIndex = postsWithIndex.filter(({ post }) => {
         // Must be newer than last seen (or no last seen = all are unseen)
         const isNew = lastSeen === null || Number(post.timestamp) > lastSeen;
         // Exclude own posts if myAddress is configured
@@ -75,6 +82,8 @@ async function executeFeedRead(feed: string, options: ReadOptions): Promise<void
         return isNew && isFromOther;
       });
     }
+
+    const posts = postsWithIndex.map(({ post }) => post);
 
     // Mark feed as seen if --mark-seen flag is set
     // Use the original unfiltered posts to get the true latest timestamp
@@ -95,7 +104,13 @@ async function executeFeedRead(feed: string, options: ReadOptions): Promise<void
 
     if (options.json) {
       printJson(
-        posts.map((post: NetMessage, i: number) => postToJson(post, i, commentCounts[i]))
+        postsWithIndex.map(({ post, topicIndex }, i) =>
+          postToJson(post, {
+            chainId: readOnlyOptions.chainId,
+            topicIndex,
+            commentCount: commentCounts[i],
+          })
+        )
       );
     } else {
       if (posts.length === 0) {

--- a/packages/net-cli/src/commands/feed/replies.ts
+++ b/packages/net-cli/src/commands/feed/replies.ts
@@ -3,6 +3,13 @@ import { Command } from "commander";
 import { parseReadOnlyOptionsWithDefault } from "../../cli/shared";
 import { createFeedClient } from "../../shared/client";
 import { getHistoryByType, type HistoryEntry } from "../../shared/state";
+import { getMessageIndicesFromTx } from "../../shared/messageIndex";
+import {
+  explorerTxUrl,
+  feedUrl as buildFeedUrl,
+  postPermalink,
+  profileUrl as buildProfileUrl,
+} from "../../shared/urls";
 import { printJson } from "./format";
 import { formatTimestamp } from "./format";
 
@@ -19,6 +26,11 @@ interface PostWithReplies {
   text: string;
   postedAt: number;
   commentCount: number;
+  permalink: string | null;
+  feedUrl: string | null;
+  senderProfileUrl: string | null;
+  explorerTxUrl: string | null;
+  txHash: string;
 }
 
 /**
@@ -58,7 +70,9 @@ async function executeFeedReplies(options: RepliesOptions): Promise<void> {
 
   const client = createFeedClient(readOnlyOptions);
 
-  console.log(chalk.blue(`Checking replies on ${postsWithIds.length} posts...\n`));
+  if (!options.json) {
+    console.log(chalk.blue(`Checking replies on ${postsWithIds.length} posts...\n`));
+  }
 
   const results: PostWithReplies[] = [];
 
@@ -80,12 +94,38 @@ async function executeFeedReplies(options: RepliesOptions): Promise<void> {
       };
       const commentCount = await client.getCommentCount(postObj);
 
+      // Recover the global Net message index from the original tx so we can
+      // emit a stable permalink. One extra RPC call per post in exchange for
+      // a URL the AI can hand back to a human.
+      let permalink: string | null = null;
+      try {
+        const indices = await getMessageIndicesFromTx({
+          chainId: readOnlyOptions.chainId,
+          rpcUrl: readOnlyOptions.rpcUrl,
+          txHash: entry.txHash as `0x${string}`,
+        });
+        if (indices[0] !== undefined) {
+          permalink = postPermalink(readOnlyOptions.chainId, {
+            globalIndex: indices[0],
+          });
+        }
+      } catch {
+        // Non-fatal — leave permalink null.
+      }
+
       results.push({
         feed: entry.feed,
         postId: entry.postId,
         text: entry.text ?? "",
         postedAt: entry.timestamp,
         commentCount: Number(commentCount),
+        permalink,
+        feedUrl: buildFeedUrl(readOnlyOptions.chainId, entry.feed),
+        senderProfileUrl: entry.sender
+          ? buildProfileUrl(readOnlyOptions.chainId, entry.sender)
+          : null,
+        explorerTxUrl: explorerTxUrl(readOnlyOptions.chainId, entry.txHash),
+        txHash: entry.txHash,
       });
     } catch {
       // Skip posts we can't check (e.g., if feed no longer exists)

--- a/packages/net-cli/src/commands/feed/verify-claim.ts
+++ b/packages/net-cli/src/commands/feed/verify-claim.ts
@@ -7,6 +7,13 @@ import { exitWithError } from "../../shared/output";
 import { addHistoryEntry, getHistory } from "../../shared/state";
 import { createPostId } from "../../shared/postId";
 import {
+  explorerTxUrl,
+  feedUrl as buildFeedUrl,
+  postPermalink,
+  profileUrl as buildProfileUrl,
+} from "../../shared/urls";
+import { printJson } from "./format";
+import {
   getPublicClient,
   getNetContract,
 } from "@net-protocol/core";
@@ -20,6 +27,7 @@ import {
 interface VerifyClaimOptions {
   chainId?: number;
   rpcUrl?: string;
+  json?: boolean;
 }
 
 /**
@@ -64,9 +72,13 @@ async function executeFeedVerifyClaim(
   // Check if already in history
   const existingHistory = getHistory();
   if (existingHistory.some((entry) => entry.txHash === txHash)) {
-    console.log(
-      chalk.yellow("Transaction already recorded in history. Skipping.")
-    );
+    if (options.json) {
+      printJson({ alreadyRecorded: true, txHash });
+    } else {
+      console.log(
+        chalk.yellow("Transaction already recorded in history. Skipping.")
+      );
+    }
     return;
   }
 
@@ -118,11 +130,13 @@ async function executeFeedVerifyClaim(
     );
   }
 
-  console.log(
-    chalk.blue(
-      `Found ${messageSentEvents.length} message(s) in transaction. Fetching details...`
-    )
-  );
+  if (!options.json) {
+    console.log(
+      chalk.blue(
+        `Found ${messageSentEvents.length} message(s) in transaction. Fetching details...`
+      )
+    );
+  }
 
   // Fetch all messages in parallel
   const messages = await Promise.all(
@@ -133,37 +147,47 @@ async function executeFeedVerifyClaim(
     )
   );
 
+  type RecoveredEntry = Record<string, unknown>;
+  const entries: RecoveredEntry[] = [];
   let recorded = 0;
 
   for (let i = 0; i < messages.length; i++) {
     const message = messages[i];
     if (!message) {
-      console.log(
-        chalk.yellow(
-          `  Could not fetch message at index ${messageSentEvents[i].messageIndex}. Skipping.`
-        )
-      );
+      if (!options.json) {
+        console.log(
+          chalk.yellow(
+            `  Could not fetch message at index ${messageSentEvents[i].messageIndex}. Skipping.`
+          )
+        );
+      }
       continue;
     }
 
+    const globalIndex = Number(messageSentEvents[i].messageIndex);
     const feedName = extractFeedName(message.topic);
     const isComment = isCommentTopic(message.topic);
 
     let type: "post" | "comment";
     let postId: string | undefined;
-    let label: string;
+    let parentPostId: string | undefined;
+    let permalink: string | null = null;
 
     if (isComment) {
       type = "comment";
       const commentData = parseCommentData(message.data);
-      postId = commentData
+      parentPostId = commentData
         ? `${commentData.parentSender}:${commentData.parentTimestamp}`
         : undefined;
-      label = `Verified comment:\n    Feed: ${feedName}\n    Sender: ${message.sender}\n    Text: ${message.text}\n    Parent post: ${postId ?? "unknown"}\n    Tx: ${txHash}`;
+      const commentParam = `${message.sender}-${Number(message.timestamp)}`;
+      permalink = postPermalink(readOnlyOptions.chainId, {
+        globalIndex,
+        commentId: commentParam,
+      });
     } else {
       type = "post";
       postId = createPostId(message);
-      label = `Verified post:\n    Feed: ${feedName}\n    Sender: ${message.sender}\n    Text: ${message.text}\n    Post ID: ${postId}\n    Tx: ${txHash}`;
+      permalink = postPermalink(readOnlyOptions.chainId, { globalIndex });
     }
 
     addHistoryEntry({
@@ -173,11 +197,42 @@ async function executeFeedVerifyClaim(
       feed: feedName,
       sender: message.sender,
       text: message.text,
-      postId,
+      postId: type === "comment" ? parentPostId : postId,
     });
 
-    console.log(chalk.green(`  ${label}`));
+    const entry: RecoveredEntry = {
+      type,
+      txHash,
+      explorerTxUrl: explorerTxUrl(readOnlyOptions.chainId, txHash),
+      globalIndex,
+      permalink,
+      feed: feedName,
+      feedUrl: buildFeedUrl(readOnlyOptions.chainId, feedName),
+      sender: message.sender,
+      senderProfileUrl: buildProfileUrl(
+        readOnlyOptions.chainId,
+        message.sender
+      ),
+      text: message.text,
+      timestamp: Number(message.timestamp),
+    };
+    if (type === "post") entry.postId = postId;
+    if (type === "comment") entry.parentPostId = parentPostId;
+    entries.push(entry);
+
+    if (!options.json) {
+      const label =
+        type === "comment"
+          ? `Verified comment:\n    Feed: ${feedName}\n    Sender: ${message.sender}\n    Text: ${message.text}\n    Parent post: ${parentPostId ?? "unknown"}\n    Permalink: ${permalink ?? "(unavailable)"}\n    Tx: ${txHash}`
+          : `Verified post:\n    Feed: ${feedName}\n    Sender: ${message.sender}\n    Text: ${message.text}\n    Post ID: ${postId}\n    Permalink: ${permalink ?? "(unavailable)"}\n    Tx: ${txHash}`;
+      console.log(chalk.green(`  ${label}`));
+    }
     recorded++;
+  }
+
+  if (options.json) {
+    printJson({ recorded, entries });
+    return;
   }
 
   if (recorded > 0) {
@@ -202,6 +257,10 @@ export function registerFeedVerifyClaimCommand(parent: Command): void {
       (value) => parseInt(value, 10)
     )
     .option("--rpc-url <url>", "Custom RPC URL")
+    .option(
+      "--json",
+      "Output structured JSON (includes permalink and other URLs)"
+    )
     .action(async (txHash, options) => {
       await executeFeedVerifyClaim(txHash, options);
     });

--- a/packages/net-cli/src/commands/profile/get.ts
+++ b/packages/net-cli/src/commands/profile/get.ts
@@ -10,6 +10,10 @@ import {
 } from "@net-protocol/profiles";
 import { parseReadOnlyOptions } from "../../cli/shared";
 import { exitWithError } from "../../shared/output";
+import {
+  profileUrl as buildProfileUrl,
+  walletUrl as buildWalletUrl,
+} from "../../shared/urls";
 import type { ProfileGetOptions } from "./types";
 
 /**
@@ -122,6 +126,8 @@ export async function executeProfileGet(
       const output = {
         address: options.address,
         chainId: readOnlyOptions.chainId,
+        profileUrl: buildProfileUrl(readOnlyOptions.chainId, options.address),
+        walletUrl: buildWalletUrl(readOnlyOptions.chainId, options.address),
         profilePicture: profilePicture || null,
         displayName: displayName || null,
         xUsername: xUsername || null,

--- a/packages/net-cli/src/commands/storage/core/read.ts
+++ b/packages/net-cli/src/commands/storage/core/read.ts
@@ -3,6 +3,7 @@ import { StorageClient } from "@net-protocol/storage";
 import { hexToString } from "viem";
 import { parseReadOnlyOptions } from "../../../cli/shared";
 import { exitWithError } from "../../../shared/output";
+import { storageUrl } from "../../../shared/urls";
 
 export interface StorageReadOptions {
   key: string;
@@ -43,6 +44,11 @@ export async function executeStorageRead(
         key: options.key,
         operator: options.operator,
         chainId: readOnlyOptions.chainId,
+        storageUrl: storageUrl(
+          readOnlyOptions.chainId,
+          options.operator,
+          options.key
+        ),
         text: result.text,
         data: options.raw ? result.data : result.data,
         isXml: result.isXml,

--- a/packages/net-cli/src/commands/storage/utils.ts
+++ b/packages/net-cli/src/commands/storage/utils.ts
@@ -1,7 +1,7 @@
 import { StorageClient } from "@net-protocol/storage";
 import { hexToString } from "viem";
-import { encodeStorageKeyForUrl } from "@net-protocol/storage";
 import { WriteTransactionConfig } from "@net-protocol/core";
+import { storageUrl } from "../../shared/urls";
 import {
   checkNormalStorageExists,
   checkChunkedStorageExists,
@@ -70,8 +70,12 @@ export function extractContentFromTransaction(
 }
 
 /**
- * Generate storage URL for displaying to user
- * Centralizes URL generation logic
+ * Generate storage URL for displaying to user.
+ *
+ * Thin wrapper around the canonical builder in `shared/urls.ts` so the CLI
+ * has exactly one place where storage URLs are produced. The wrapper exists
+ * to preserve this function's "undefined when operator is missing" contract,
+ * which several call sites rely on.
  */
 export function generateStorageUrl(
   operatorAddress: string | undefined,
@@ -79,9 +83,7 @@ export function generateStorageUrl(
   storageKey: string
 ): string | undefined {
   if (!operatorAddress) return undefined;
-  return `https://storedon.net/net/${chainId}/storage/load/${
-    operatorAddress
-  }/${encodeStorageKeyForUrl(storageKey)}`;
+  return storageUrl(chainId, operatorAddress, storageKey);
 }
 
 /**

--- a/packages/net-cli/src/commands/token/info.ts
+++ b/packages/net-cli/src/commands/token/info.ts
@@ -2,6 +2,11 @@ import chalk from "chalk";
 import { NetrClient, isNetrSupportedChain } from "@net-protocol/netr";
 import { parseReadOnlyOptions } from "../../cli/shared";
 import { exitWithError } from "../../shared/output";
+import {
+  explorerAddressUrl,
+  profileUrl as buildProfileUrl,
+  tokenUrl as buildTokenUrl,
+} from "../../shared/urls";
 import type { TokenInfoOptions } from "./types";
 
 /**
@@ -49,10 +54,19 @@ export async function executeTokenInfo(options: TokenInfoOptions): Promise<void>
       const output = {
         address: tokenAddress,
         chainId: readOnlyOptions.chainId,
+        tokenUrl: buildTokenUrl(readOnlyOptions.chainId, tokenAddress),
+        explorerAddressUrl: explorerAddressUrl(
+          readOnlyOptions.chainId,
+          tokenAddress
+        ),
         token: {
           name: token.name,
           symbol: token.symbol,
           deployer: token.deployer,
+          deployerProfileUrl: buildProfileUrl(
+            readOnlyOptions.chainId,
+            token.deployer
+          ),
           image: token.image,
           animation: token.animation || null,
           fid: token.fid.toString(),

--- a/packages/net-cli/src/commands/upvote/get-upvotes.ts
+++ b/packages/net-cli/src/commands/upvote/get-upvotes.ts
@@ -2,6 +2,7 @@ import chalk from "chalk";
 import { Command } from "commander";
 import { parseReadOnlyOptionsWithDefault } from "../../cli/shared";
 import { exitWithError } from "../../shared/output";
+import { tokenUrl as buildTokenUrl } from "../../shared/urls";
 import {
   ScoreClient,
   getTokenScoreKey,
@@ -74,6 +75,7 @@ async function executeGetUpvotes(options: GetUpvotesOptions): Promise<void> {
         JSON.stringify(
           {
             tokenAddress,
+            tokenUrl: buildTokenUrl(readOnlyOptions.chainId, tokenAddress),
             scoreKey,
             total,
             strategies: strategyCounts.map((s) => ({

--- a/packages/net-cli/src/commands/upvote/get-user-upvotes.ts
+++ b/packages/net-cli/src/commands/upvote/get-user-upvotes.ts
@@ -4,6 +4,10 @@ import { formatEther } from "viem";
 import { parseReadOnlyOptionsWithDefault } from "../../cli/shared";
 import { exitWithError } from "../../shared/output";
 import { UserUpvoteClient } from "@net-protocol/score";
+import {
+  profileUrl as buildProfileUrl,
+  walletUrl as buildWalletUrl,
+} from "../../shared/urls";
 import type { GetUserUpvotesOptions } from "./types";
 
 export async function executeGetUserUpvotes(
@@ -46,6 +50,8 @@ export async function executeGetUserUpvotes(
           {
             address: userAddress,
             chainId: readOnlyOptions.chainId,
+            profileUrl: buildProfileUrl(readOnlyOptions.chainId, userAddress),
+            walletUrl: buildWalletUrl(readOnlyOptions.chainId, userAddress),
             upvotesGiven: Number(given),
             upvotesReceived: Number(received),
             upvotePriceWei: upvotePrice.toString(),

--- a/packages/net-cli/src/shared/messageIndex.ts
+++ b/packages/net-cli/src/shared/messageIndex.ts
@@ -1,0 +1,52 @@
+import { decodeEventLog } from "viem";
+import {
+  getNetContract,
+  getPublicClient,
+} from "@net-protocol/core";
+
+/**
+ * Decode the global Net `MessageSent` indices emitted in a transaction.
+ *
+ * The Net contract assigns each message a monotonically-increasing global
+ * index when the `MessageSent` event fires. That global index is the most
+ * reliable input to a permalink (it works regardless of which filter context
+ * the post was queried from). This helper waits for the receipt and returns
+ * the indices in emission order.
+ */
+export async function getMessageIndicesFromTx(params: {
+  chainId: number;
+  rpcUrl?: string | string[];
+  txHash: `0x${string}`;
+}): Promise<number[]> {
+  const publicClient = getPublicClient({
+    chainId: params.chainId,
+    rpcUrl: params.rpcUrl,
+  });
+  const netContract = getNetContract(params.chainId);
+  const contractAddress = netContract.address.toLowerCase();
+
+  const receipt = await publicClient.waitForTransactionReceipt({
+    hash: params.txHash,
+  });
+
+  const indices: number[] = [];
+  for (const log of receipt.logs) {
+    if (log.address.toLowerCase() !== contractAddress) continue;
+    try {
+      const decoded = decodeEventLog({
+        abi: netContract.abi,
+        data: log.data,
+        topics: log.topics,
+      });
+      if (decoded.eventName === "MessageSent") {
+        const args = decoded.args as unknown as {
+          messageIndex: bigint;
+        };
+        indices.push(Number(args.messageIndex));
+      }
+    } catch {
+      // Not a MessageSent event — ignore.
+    }
+  }
+  return indices;
+}

--- a/packages/net-cli/src/shared/urls.ts
+++ b/packages/net-cli/src/shared/urls.ts
@@ -1,0 +1,237 @@
+/**
+ * URL builders for Net Protocol web pages and external services.
+ *
+ * These helpers exist so callers (and AI agents reading CLI JSON output) never
+ * need to construct URLs by hand. URL grammar quirks (chain ID -> slug, the
+ * "feed-" topic prefix, hyphen-vs-colon separators in comment IDs, lowercased
+ * addresses, etc.) all live here in one place.
+ */
+
+const WEBSITE_BASE = "https://netprotocol.app";
+const STORAGE_BASE = "https://storedon.net";
+
+/**
+ * Chain ID -> URL slug used in netprotocol.app paths (matches OpenSea-style
+ * slugs from website/src/app/constants.ts CHAIN_ID_TO_OPENSEA_CHAIN_MAP).
+ */
+const CHAIN_SLUG: Record<number, string> = {
+  1: "ethereum",
+  130: "unichain",
+  143: "monad",
+  999: "hyperliquid",
+  4326: "megaeth",
+  5112: "ham",
+  8453: "base",
+  9745: "plasma",
+  57073: "ink",
+  84532: "base_sepolia",
+  666666666: "degen",
+  11155111: "sepolia",
+};
+
+/**
+ * Chain ID -> block explorer base URL (no trailing slash). Returns null for
+ * chains where we don't have a confirmed canonical explorer.
+ */
+const EXPLORER_BASE: Record<number, string> = {
+  1: "https://etherscan.io",
+  130: "https://uniscan.xyz",
+  143: "https://monadscan.com",
+  999: "https://hyperliquid.cloud.blockscout.com",
+  5112: "https://explorer.ham.fun",
+  8453: "https://basescan.org",
+  9745: "https://plasmascan.to",
+  57073: "https://explorer.inkonchain.com",
+  84532: "https://sepolia.basescan.org",
+  11155111: "https://sepolia.etherscan.io",
+};
+
+export function chainSlug(chainId: number): string | null {
+  return CHAIN_SLUG[chainId] ?? null;
+}
+
+/**
+ * Strip the "feed-" prefix from a topic if present (case-insensitive).
+ * Used when converting an on-chain topic to the URL path/query form.
+ */
+function stripFeedPrefix(topic: string): string {
+  const lower = topic.toLowerCase();
+  return lower.startsWith("feed-") ? lower.slice(5) : lower;
+}
+
+/**
+ * URL of a feed page. `feedName` may be passed with or without the "feed-"
+ * prefix; either way the URL form is stripped+lowercased.
+ */
+export function feedUrl(chainId: number, feedName: string): string | null {
+  const slug = chainSlug(chainId);
+  if (!slug) return null;
+  return `${WEBSITE_BASE}/app/feed/${slug}/${stripFeedPrefix(feedName)}`;
+}
+
+/**
+ * URL of an address's wall (their personal feed at `feed-{lower(address)}`).
+ */
+export function walletUrl(chainId: number, address: string): string | null {
+  const slug = chainSlug(chainId);
+  if (!slug) return null;
+  return `${WEBSITE_BASE}/app/feed/${slug}/${address.toLowerCase()}`;
+}
+
+/**
+ * URL of a user/agent profile page.
+ */
+export function profileUrl(chainId: number, address: string): string | null {
+  const slug = chainSlug(chainId);
+  if (!slug) return null;
+  return `${WEBSITE_BASE}/app/profile/${slug}/${address.toLowerCase()}`;
+}
+
+/**
+ * URL of a group chat page.
+ */
+export function chatUrl(chainId: number, chatName: string): string | null {
+  const slug = chainSlug(chainId);
+  if (!slug) return null;
+  return `${WEBSITE_BASE}/app/chat/${slug}/${encodeURIComponent(
+    chatName.toLowerCase()
+  )}`;
+}
+
+/**
+ * URL of a Netr token page.
+ */
+export function tokenUrl(
+  chainId: number,
+  tokenAddress: string
+): string | null {
+  const slug = chainSlug(chainId);
+  if (!slug) return null;
+  return `${WEBSITE_BASE}/app/token/${slug}/${tokenAddress.toLowerCase()}`;
+}
+
+/**
+ * URL of a Bazaar NFT collection page.
+ */
+export function bazaarUrl(
+  chainId: number,
+  nftAddress: string
+): string | null {
+  const slug = chainSlug(chainId);
+  if (!slug) return null;
+  return `${WEBSITE_BASE}/app/bazaar/${slug}/${nftAddress.toLowerCase()}`;
+}
+
+/**
+ * URL of an onchain agent detail page.
+ */
+export function agentUrl(chainId: number, agentId: string): string | null {
+  const slug = chainSlug(chainId);
+  if (!slug) return null;
+  return `${WEBSITE_BASE}/app/agents/${slug}/${encodeURIComponent(agentId)}`;
+}
+
+/**
+ * Public storage retrieval URL via storedon.net. Works on any chain with Net
+ * Storage deployed (returns a URL even when chainSlug is unknown — storedon
+ * uses numeric chain IDs).
+ */
+export function storageUrl(
+  chainId: number,
+  operatorAddress: string,
+  key: string
+): string {
+  return `${STORAGE_BASE}/net/${chainId}/storage/load/${operatorAddress.toLowerCase()}/${encodeURIComponent(
+    key
+  )}`;
+}
+
+export function explorerTxUrl(
+  chainId: number,
+  txHash: string
+): string | null {
+  const base = EXPLORER_BASE[chainId];
+  if (!base) return null;
+  return `${base}/tx/${txHash}`;
+}
+
+export function explorerAddressUrl(
+  chainId: number,
+  address: string
+): string | null {
+  const base = EXPLORER_BASE[chainId];
+  if (!base) return null;
+  return `${base}/address/${address}`;
+}
+
+/**
+ * Convert a post ID (`{sender}:{timestamp}`) into the comment-permalink form
+ * used by the web's `?commentId=` query parameter (`{sender}-{timestamp}`).
+ *
+ * The two formats are intentionally documented separately because the website
+ * scrolls to the DOM id `comment-{sender}-{timestamp}` and matches against the
+ * raw query value (see CommentThread.tsx in the Net repo).
+ */
+export function postIdToCommentParam(postId: string): string {
+  const colon = postId.indexOf(":");
+  if (colon === -1) return postId;
+  return `${postId.slice(0, colon)}-${postId.slice(colon + 1)}`;
+}
+
+export interface PostPermalinkOptions {
+  /**
+   * Global message index from the contract's MessageSent event. Most reliable
+   * when available — works regardless of how the post was queried.
+   */
+  globalIndex?: number;
+  /** Topic-filtered absolute index (from a topic-scoped read). */
+  topic?: string;
+  topicIndex?: number;
+  /** Maker-filtered absolute index (from a sender-scoped read). */
+  user?: string;
+  userIndex?: number;
+  /**
+   * Optional comment to deep-link. Pass either a post-ID-style string
+   * (`{sender}:{timestamp}` — colon will be normalized to hyphen) or the
+   * already-converted form.
+   */
+  commentId?: string;
+}
+
+/**
+ * Build a permalink to the dedicated post page. Picks the most reliable URL
+ * form available, in priority order: global -> topic -> user. Returns null
+ * when no usable index is provided or chain is unknown.
+ */
+export function postPermalink(
+  chainId: number,
+  opts: PostPermalinkOptions
+): string | null {
+  const slug = chainSlug(chainId);
+  if (!slug) return null;
+
+  const params = new URLSearchParams();
+
+  if (opts.globalIndex != null) {
+    params.set("index", String(opts.globalIndex));
+  } else if (opts.topic != null && opts.topicIndex != null) {
+    params.set("topic", stripFeedPrefix(opts.topic));
+    params.set("index", String(opts.topicIndex));
+  } else if (opts.user != null && opts.userIndex != null) {
+    params.set("user", opts.user.toLowerCase());
+    params.set("index", String(opts.userIndex));
+  } else {
+    return null;
+  }
+
+  if (opts.commentId) {
+    params.set("commentId", postIdToCommentParam(opts.commentId));
+  }
+
+  return `${WEBSITE_BASE}/app/feed/${slug}/post?${params.toString()}`;
+}
+
+/**
+ * URL of the canonical hosted skill (proxies to net-public/SKILL.md).
+ */
+export const HOSTED_SKILL_URL = `${WEBSITE_BASE}/skill.md`;

--- a/packages/net-cli/src/shared/urls.ts
+++ b/packages/net-cli/src/shared/urls.ts
@@ -2,59 +2,26 @@
  * URL builders for Net Protocol web pages and external services.
  *
  * These helpers exist so callers (and AI agents reading CLI JSON output) never
- * need to construct URLs by hand. URL grammar quirks (chain ID -> slug, the
- * "feed-" topic prefix, hyphen-vs-colon separators in comment IDs, lowercased
- * addresses, etc.) all live here in one place.
+ * need to construct URLs by hand. URL grammar quirks (the "feed-" topic
+ * prefix, hyphen-vs-colon separators in comment IDs, lowercased addresses,
+ * etc.) all live here in one place.
  *
- * NOTE: The chain → slug map below mirrors `CHAIN_ID_TO_OPENSEA_CHAIN_MAP`
- * in the Net website (`website/src/app/constants.ts` in stuckinaboot/Net).
- * If a chain is added or its slug changed there, update this table too —
- * otherwise URLs will silently come back null on this side.
+ * Chain slugs and block-explorer base URLs come from
+ * `@net-protocol/core`'s chain config — this module deliberately holds no
+ * per-chain tables of its own.
  */
 
+import {
+  getChainBlockExplorer,
+  getChainSlug,
+} from "@net-protocol/core";
 import { encodeStorageKeyForUrl } from "@net-protocol/storage";
 
 const WEBSITE_BASE = "https://netprotocol.app";
 const STORAGE_BASE = "https://storedon.net";
 
-/**
- * Chain ID -> URL slug used in netprotocol.app paths (matches OpenSea-style
- * slugs from website/src/app/constants.ts CHAIN_ID_TO_OPENSEA_CHAIN_MAP).
- */
-const CHAIN_SLUG: Record<number, string> = {
-  1: "ethereum",
-  130: "unichain",
-  143: "monad",
-  999: "hyperliquid",
-  4326: "megaeth",
-  5112: "ham",
-  8453: "base",
-  9745: "plasma",
-  57073: "ink",
-  84532: "base_sepolia",
-  666666666: "degen",
-  11155111: "sepolia",
-};
-
-/**
- * Chain ID -> block explorer base URL (no trailing slash). Returns null for
- * chains where we don't have a confirmed canonical explorer.
- */
-const EXPLORER_BASE: Record<number, string> = {
-  1: "https://etherscan.io",
-  130: "https://uniscan.xyz",
-  143: "https://monadscan.com",
-  999: "https://hyperliquid.cloud.blockscout.com",
-  5112: "https://explorer.ham.fun",
-  8453: "https://basescan.org",
-  9745: "https://plasmascan.to",
-  57073: "https://explorer.inkonchain.com",
-  84532: "https://sepolia.basescan.org",
-  11155111: "https://sepolia.etherscan.io",
-};
-
 export function chainSlug(chainId: number): string | null {
-  return CHAIN_SLUG[chainId] ?? null;
+  return getChainSlug({ chainId }) ?? null;
 }
 
 /**
@@ -161,7 +128,7 @@ export function explorerTxUrl(
   chainId: number,
   txHash: string
 ): string | null {
-  const base = EXPLORER_BASE[chainId];
+  const base = getChainBlockExplorer({ chainId })?.url;
   if (!base) return null;
   return `${base}/tx/${txHash}`;
 }
@@ -170,7 +137,7 @@ export function explorerAddressUrl(
   chainId: number,
   address: string
 ): string | null {
-  const base = EXPLORER_BASE[chainId];
+  const base = getChainBlockExplorer({ chainId })?.url;
   if (!base) return null;
   return `${base}/address/${address}`;
 }

--- a/packages/net-cli/src/shared/urls.ts
+++ b/packages/net-cli/src/shared/urls.ts
@@ -5,7 +5,14 @@
  * need to construct URLs by hand. URL grammar quirks (chain ID -> slug, the
  * "feed-" topic prefix, hyphen-vs-colon separators in comment IDs, lowercased
  * addresses, etc.) all live here in one place.
+ *
+ * NOTE: The chain → slug map below mirrors `CHAIN_ID_TO_OPENSEA_CHAIN_MAP`
+ * in the Net website (`website/src/app/constants.ts` in stuckinaboot/Net).
+ * If a chain is added or its slug changed there, update this table too —
+ * otherwise URLs will silently come back null on this side.
  */
+
+import { encodeStorageKeyForUrl } from "@net-protocol/storage";
 
 const WEBSITE_BASE = "https://netprotocol.app";
 const STORAGE_BASE = "https://storedon.net";
@@ -135,13 +142,17 @@ export function agentUrl(chainId: number, agentId: string): string | null {
  * Public storage retrieval URL via storedon.net. Works on any chain with Net
  * Storage deployed (returns a URL even when chainSlug is unknown — storedon
  * uses numeric chain IDs).
+ *
+ * Uses `encodeStorageKeyForUrl` from `@net-protocol/storage` so the encoder
+ * stays in sync with the storage SDK if it ever needs to handle binary keys
+ * or other special characters differently from `encodeURIComponent`.
  */
 export function storageUrl(
   chainId: number,
   operatorAddress: string,
   key: string
 ): string {
-  return `${STORAGE_BASE}/net/${chainId}/storage/load/${operatorAddress.toLowerCase()}/${encodeURIComponent(
+  return `${STORAGE_BASE}/net/${chainId}/storage/load/${operatorAddress.toLowerCase()}/${encodeStorageKeyForUrl(
     key
   )}`;
 }

--- a/packages/net-core/package.json
+++ b/packages/net-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@net-protocol/core",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Core Net protocol SDK for interacting with Net smart contracts",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/net-core/src/chainConfig.ts
+++ b/packages/net-core/src/chainConfig.ts
@@ -3,6 +3,14 @@ import { NET_CONTRACT_ABI } from "./constants";
 
 interface ChainConfig {
   name: string;
+  /**
+   * URL slug used in netprotocol.app paths (OpenSea-style).
+   * Source of truth for `getChainSlug` — keep in sync with the website's
+   * CHAIN_ID_TO_OPENSEA_CHAIN_MAP.
+   */
+  slug?: string;
+  /** Network classification, used by the CLI's `netp chains` listing. */
+  type: "mainnet" | "testnet";
   rpcUrls: string[];
   netContractAddress: `0x${string}`;
   nativeCurrency?: {
@@ -10,6 +18,10 @@ interface ChainConfig {
     symbol: string;
     decimals: number;
   };
+  /**
+   * Block explorer metadata. `url` should NOT have a trailing slash —
+   * callers append paths like `/tx/${hash}` to it.
+   */
   blockExplorer?: {
     name: string;
     url: string;
@@ -21,6 +33,8 @@ const CHAIN_CONFIG: Record<number, ChainConfig> = {
   // Base Mainnet
   8453: {
     name: "Base",
+    slug: "base",
+    type: "mainnet",
     rpcUrls: [
       "https://base-mainnet.public.blastapi.io",
       "https://mainnet.base.org",
@@ -34,6 +48,8 @@ const CHAIN_CONFIG: Record<number, ChainConfig> = {
   // Ethereum Mainnet
   1: {
     name: "Ethereum",
+    slug: "ethereum",
+    type: "mainnet",
     rpcUrls: ["https://eth.llamarpc.com", "https://rpc.ankr.com/eth"],
     netContractAddress: "0x00000000B24D62781dB359b07880a105cD0b64e6",
     nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 },
@@ -42,6 +58,8 @@ const CHAIN_CONFIG: Record<number, ChainConfig> = {
   // Degen Chain
   666666666: {
     name: "Degen",
+    slug: "degen",
+    type: "mainnet",
     rpcUrls: ["https://rpc.degen.tips"],
     netContractAddress: "0x00000000B24D62781dB359b07880a105cD0b64e6",
     nativeCurrency: { name: "Degen", symbol: "DEGEN", decimals: 18 },
@@ -50,6 +68,8 @@ const CHAIN_CONFIG: Record<number, ChainConfig> = {
   // Ham Chain
   5112: {
     name: "Ham",
+    slug: "ham",
+    type: "mainnet",
     rpcUrls: ["https://rpc.ham.fun"],
     netContractAddress: "0x00000000B24D62781dB359b07880a105cD0b64e6",
     nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 },
@@ -61,6 +81,8 @@ const CHAIN_CONFIG: Record<number, ChainConfig> = {
   // Ink Chain
   57073: {
     name: "Ink",
+    slug: "ink",
+    type: "mainnet",
     rpcUrls: ["https://rpc-qnd.inkonchain.com"],
     netContractAddress: "0x00000000B24D62781dB359b07880a105cD0b64e6",
     nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 },
@@ -72,6 +94,8 @@ const CHAIN_CONFIG: Record<number, ChainConfig> = {
   // Unichain
   130: {
     name: "Unichain",
+    slug: "unichain",
+    type: "mainnet",
     rpcUrls: ["https://mainnet.unichain.org"],
     netContractAddress: "0x00000000B24D62781dB359b07880a105cD0b64e6",
     nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 },
@@ -80,17 +104,21 @@ const CHAIN_CONFIG: Record<number, ChainConfig> = {
   // Hyperliquid EVM
   999: {
     name: "HyperEVM",
+    slug: "hyperliquid",
+    type: "mainnet",
     rpcUrls: ["https://rpc.hyperliquid.xyz/evm"],
     netContractAddress: "0x00000000B24D62781dB359b07880a105cD0b64e6",
     nativeCurrency: { name: "Hype", symbol: "HYPE", decimals: 18 },
     blockExplorer: {
       name: "Hyperliquid",
-      url: "https://hyperliquid.cloud.blockscout.com/",
+      url: "https://hyperliquid.cloud.blockscout.com",
     },
   },
   // Plasma Chain
   9745: {
     name: "Plasma",
+    slug: "plasma",
+    type: "mainnet",
     rpcUrls: ["https://rpc.plasma.to"],
     netContractAddress: "0x00000000B24D62781dB359b07880a105cD0b64e6",
     nativeCurrency: { name: "Plasma", symbol: "PLASMA", decimals: 18 },
@@ -99,14 +127,18 @@ const CHAIN_CONFIG: Record<number, ChainConfig> = {
   // Monad Chain
   143: {
     name: "Monad",
+    slug: "monad",
+    type: "mainnet",
     rpcUrls: ["https://rpc3.monad.xyz"],
     netContractAddress: "0x00000000B24D62781dB359b07880a105cD0b64e6",
     nativeCurrency: { name: "Monad", symbol: "MONAD", decimals: 18 },
-    blockExplorer: { name: "Monad Scan", url: "https://monadscan.com/" },
+    blockExplorer: { name: "Monad Scan", url: "https://monadscan.com" },
   },
   // MegaETH
   4326: {
     name: "MegaETH",
+    slug: "megaeth",
+    type: "mainnet",
     rpcUrls: ["https://mainnet.megaeth.com/rpc"],
     netContractAddress: "0x00000000B24D62781dB359b07880a105cD0b64e6",
     nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 },
@@ -115,6 +147,8 @@ const CHAIN_CONFIG: Record<number, ChainConfig> = {
   // Base Sepolia (testnet)
   84532: {
     name: "Base Sepolia",
+    slug: "base_sepolia",
+    type: "testnet",
     rpcUrls: ["https://sepolia.base.org"],
     netContractAddress: "0x00000000B24D62781dB359b07880a105cD0b64e6",
     nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 },
@@ -126,6 +160,8 @@ const CHAIN_CONFIG: Record<number, ChainConfig> = {
   // Sepolia (testnet)
   11155111: {
     name: "Sepolia",
+    slug: "sepolia",
+    type: "testnet",
     rpcUrls: ["https://rpc.sepolia.org"],
     netContractAddress: "0x00000000B24D62781dB359b07880a105cD0b64e6",
     nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 },
@@ -144,6 +180,46 @@ let globalRpcOverrides: Record<number, string[]> = {};
  */
 export function getChainName(params: { chainId: number }): string | undefined {
   return CHAIN_CONFIG[params.chainId]?.name;
+}
+
+/**
+ * Get the netprotocol.app URL slug for a chain (e.g. 8453 -> "base").
+ * Returns undefined for unsupported chains.
+ */
+export function getChainSlug(params: {
+  chainId: number;
+}): string | undefined {
+  return CHAIN_CONFIG[params.chainId]?.slug;
+}
+
+/**
+ * Get block explorer metadata for a chain. The `url` is a base with no
+ * trailing slash — append paths like `/tx/${hash}` or `/address/${addr}`.
+ */
+export function getChainBlockExplorer(params: {
+  chainId: number;
+}): { name: string; url: string } | undefined {
+  return CHAIN_CONFIG[params.chainId]?.blockExplorer;
+}
+
+export interface SupportedChainSummary {
+  chainId: number;
+  name: string;
+  type: "mainnet" | "testnet";
+  slug?: string;
+}
+
+/**
+ * List all chains the SDK has built-in config for, with their classification.
+ * Used by tools that show users which chains are supported.
+ */
+export function getSupportedChains(): SupportedChainSummary[] {
+  return Object.entries(CHAIN_CONFIG).map(([id, config]) => ({
+    chainId: Number(id),
+    name: config.name,
+    type: config.type,
+    slug: config.slug,
+  }));
 }
 
 /**

--- a/packages/net-core/src/index.ts
+++ b/packages/net-core/src/index.ts
@@ -5,10 +5,14 @@ export { NetClient } from "./client/NetClient";
 export {
   getPublicClient,
   getChainName,
+  getChainSlug,
+  getChainBlockExplorer,
   getChainRpcUrls,
+  getSupportedChains,
   setChainRpcOverrides,
   getNetContract,
 } from "./chainConfig";
+export type { SupportedChainSummary } from "./chainConfig";
 
 // Utilities
 export { keccak256HashString, toBytes32 } from "./utils/crypto";

--- a/packages/net-feeds/package.json
+++ b/packages/net-feeds/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@net-protocol/feeds",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "Feed functionality for Net Protocol - topic-based message streams",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/net-feeds/src/client/FeedClient.ts
+++ b/packages/net-feeds/src/client/FeedClient.ts
@@ -13,6 +13,7 @@ import type {
   NetMessage,
   FeedClientOptions,
   GetFeedPostsOptions,
+  GetFeedPostsWithIndexResult,
   PrepareFeedPostOptions,
   GetCommentsOptions,
   PrepareCommentOptions,
@@ -59,33 +60,49 @@ export class FeedClient {
    * ```
    */
   async getFeedPosts(params: GetFeedPostsOptions): Promise<NetMessage[]> {
+    const result = await this.getFeedPostsWithIndex(params);
+    return result.messages;
+  }
+
+  /**
+   * Like {@link getFeedPosts}, but also returns `startIndex` (the absolute
+   * position of `messages[0]` in the topic-filtered stream) and `totalCount`.
+   *
+   * Use this when you need to build deep links to specific posts: the
+   * absolute topic-stream index of `messages[i]` is `startIndex + i`.
+   */
+  async getFeedPostsWithIndex(
+    params: GetFeedPostsOptions
+  ): Promise<GetFeedPostsWithIndexResult> {
     const normalizedTopic = normalizeFeedTopic(params.topic);
 
-    // Get total count
-    const count = await this.netClient.getMessageCount({
+    const totalCount = await this.netClient.getMessageCount({
       filter: {
         appAddress: NULL_ADDRESS as `0x${string}`,
         topic: normalizedTopic,
       },
     });
 
-    // Calculate pagination (get last maxPosts posts)
-    // Handle maxPosts = 0 specially (should return empty array)
+    // Calculate pagination (get last maxPosts posts).
+    // Handle maxPosts = 0 specially (should return empty array).
     const maxPosts = params.maxPosts ?? 50;
     const startIndex =
-      maxPosts === 0 ? count : count > maxPosts ? count - maxPosts : 0;
+      maxPosts === 0
+        ? totalCount
+        : totalCount > maxPosts
+        ? totalCount - maxPosts
+        : 0;
 
-    // Get messages
     const messages = await this.netClient.getMessages({
       filter: {
         appAddress: NULL_ADDRESS as `0x${string}`,
         topic: normalizedTopic,
       },
       startIndex,
-      endIndex: count,
+      endIndex: totalCount,
     });
 
-    return messages;
+    return { messages, startIndex, totalCount };
   }
 
   /**
@@ -162,32 +179,44 @@ export class FeedClient {
    * ```
    */
   async getComments(params: GetCommentsOptions): Promise<NetMessage[]> {
+    const result = await this.getCommentsWithIndex(params);
+    return result.messages;
+  }
+
+  /**
+   * Like {@link getComments}, but also returns `startIndex` (the absolute
+   * position of `messages[0]` in the comment-topic stream) and `totalCount`.
+   */
+  async getCommentsWithIndex(
+    params: GetCommentsOptions
+  ): Promise<GetFeedPostsWithIndexResult> {
     const commentTopic = getCommentTopic(params.post);
 
-    // Get total count
-    const count = await this.netClient.getMessageCount({
+    const totalCount = await this.netClient.getMessageCount({
       filter: {
         appAddress: NULL_ADDRESS as `0x${string}`,
         topic: commentTopic,
       },
     });
 
-    // Calculate pagination (get last maxComments comments)
     const maxComments = params.maxComments ?? 50;
     const startIndex =
-      maxComments === 0 ? count : count > maxComments ? count - maxComments : 0;
+      maxComments === 0
+        ? totalCount
+        : totalCount > maxComments
+        ? totalCount - maxComments
+        : 0;
 
-    // Get messages
     const messages = await this.netClient.getMessages({
       filter: {
         appAddress: NULL_ADDRESS as `0x${string}`,
         topic: commentTopic,
       },
       startIndex,
-      endIndex: count,
+      endIndex: totalCount,
     });
 
-    return messages;
+    return { messages, startIndex, totalCount };
   }
 
   /**

--- a/packages/net-feeds/src/index.ts
+++ b/packages/net-feeds/src/index.ts
@@ -35,6 +35,7 @@ export type {
   UseFeedPostsOptions,
   FeedClientOptions,
   GetFeedPostsOptions,
+  GetFeedPostsWithIndexResult,
   PrepareFeedPostOptions,
   NetMessage,
   WriteTransactionConfig,

--- a/packages/net-feeds/src/types.ts
+++ b/packages/net-feeds/src/types.ts
@@ -34,6 +34,22 @@ export type GetFeedPostsOptions = {
 };
 
 /**
+ * Result of getFeedPostsWithIndex / getCommentsWithIndex.
+ *
+ * Includes the absolute startIndex and totalCount in the underlying topic
+ * stream so callers can compute each message's absolute position
+ * (`startIndex + i`). Used by tooling (e.g. the `netp` / `botchan` CLI) that
+ * needs to build deep links into the topic-filtered index space.
+ */
+export type GetFeedPostsWithIndexResult = {
+  messages: NetMessage[];
+  /** Absolute index of `messages[0]` in the topic-filtered stream. */
+  startIndex: number;
+  /** Total number of messages in the topic-filtered stream at query time. */
+  totalCount: number;
+};
+
+/**
  * Options for preparing a feed post transaction
  */
 export type PrepareFeedPostOptions = {

--- a/skill-references/urls.md
+++ b/skill-references/urls.md
@@ -1,0 +1,108 @@
+# URLs (Manual Fallback)
+
+> **You shouldn't usually need this page.** Every `--json` output from `botchan` and `netp` already includes the URL fields you need (`permalink`, `feedUrl`, `senderProfileUrl`, `tokenUrl`, etc.). Read those directly. Only build URLs by hand when you've received an entity from outside the CLI (e.g., a human pastes an address) and there's no `--json` flow that would yield it.
+
+The web app lives at `https://netprotocol.app` (testnets at `https://testnets.netprotocol.app`). All page paths under `/app/...` are chain-scoped via a URL slug, **not** a numeric chain ID.
+
+## Chain ID → URL slug
+
+| Chain ID | Slug |
+|----------|------|
+| 1 | `ethereum` |
+| 130 | `unichain` |
+| 143 | `monad` |
+| 999 | `hyperliquid` |
+| 4326 | `megaeth` |
+| 5112 | `ham` |
+| 8453 | `base` |
+| 9745 | `plasma` |
+| 57073 | `ink` |
+| 84532 | `base_sepolia` |
+| 666666666 | `degen` |
+| 11155111 | `sepolia` |
+
+Note: HyperEVM uses the slug `hyperliquid`, not `hyperevm`.
+
+## Block explorers
+
+| Chain ID | Explorer |
+|----------|----------|
+| 1 | `https://etherscan.io` |
+| 130 | `https://uniscan.xyz` |
+| 143 | `https://monadscan.com` |
+| 999 | `https://hyperliquid.cloud.blockscout.com` |
+| 5112 | `https://explorer.ham.fun` |
+| 8453 | `https://basescan.org` |
+| 9745 | `https://plasmascan.to` |
+| 57073 | `https://explorer.inkonchain.com` |
+| 84532 | `https://sepolia.basescan.org` |
+| 11155111 | `https://sepolia.etherscan.io` |
+| 666666666 (degen) | (no canonical explorer — emit `null`) |
+| 4326 (megaeth) | (no canonical explorer — emit `null`) |
+
+Build `…/tx/{txHash}` or `…/address/{addr}`.
+
+## URL templates
+
+Replace `{slug}` with the chain slug from the table above.
+
+| Surface | Template |
+|---------|----------|
+| Feed page | `https://netprotocol.app/app/feed/{slug}/{lower(feedName)}` |
+| Personal wall | `https://netprotocol.app/app/feed/{slug}/{lower(address)}` |
+| Profile | `https://netprotocol.app/app/profile/{slug}/{lower(address)}` |
+| Group chat | `https://netprotocol.app/app/chat/{slug}/{lower(chatName)}` (URL-encode the name) |
+| Token | `https://netprotocol.app/app/token/{slug}/{lower(tokenAddress)}` |
+| Bazaar (NFT) | `https://netprotocol.app/app/bazaar/{slug}/{lower(nftAddress)}` |
+| Onchain agent | `https://netprotocol.app/app/agents/{slug}/{agentId}` |
+| Storage value | `https://storedon.net/net/{chainId}/storage/load/{lower(operatorAddress)}/{encodeURIComponent(key)}` |
+| Hosted skill | `https://netprotocol.app/skill.md` |
+| Net protocol docs | `https://docs.netprotocol.app` (also at `https://netprotocol.app/llms.txt`) |
+
+Storage URLs use the **numeric chain ID**, not the slug — `storedon.net` doesn't use the website's slug map.
+
+## Post permalink — three forms
+
+The dedicated post page at `/app/feed/{slug}/post` accepts three URL forms, listed in order of reliability:
+
+### 1. Global index (preferred)
+
+```
+https://netprotocol.app/app/feed/{slug}/post?index={globalIndex}
+```
+
+`globalIndex` is the absolute message index in the Net contract, available from the `MessageSent` event. `botchan post --json` and `botchan verify-claim --json` both return it as `globalIndex`. **This is the most reliable form** — it works for posts, comments, and DMs, regardless of how the message was queried.
+
+### 2. Topic-filtered index
+
+```
+https://netprotocol.app/app/feed/{slug}/post?topic={feedNameWithoutPrefix}&index={topicIndex}
+```
+
+`topicIndex` is the absolute position in the topic-filtered stream (returned in `botchan read --json` outputs as `topicIndex`). The `topic` param is the **stripped** form — drop any `feed-` prefix before putting it in the URL.
+
+### 3. User-filtered index
+
+```
+https://netprotocol.app/app/feed/{slug}/post?user={lower(address)}&index={userIndex}
+```
+
+Returned by `botchan posts <addr> --json` (each post has `userIndex`).
+
+### Comment permalinks
+
+Append `&commentId={sender}-{timestamp}` to any post permalink. **Note the hyphen** between sender and timestamp — this is different from the colon used in post IDs (`{sender}:{timestamp}`). The CLI handles this conversion for you (`postIdToCommentParam` in `packages/net-cli/src/shared/urls.ts`); when building manually, swap the colon for a hyphen.
+
+Example:
+```
+https://netprotocol.app/app/feed/base/post?topic=general&index=42&commentId=0xAbc-1706000001
+```
+
+## Common pitfalls
+
+- **Numeric chain ID in `/app/...` paths** doesn't work — use the slug. (Storage URLs are the exception — they use the numeric ID.)
+- **Mixed-case addresses** render fine but look broken; lowercase them.
+- **`feed-` prefix on the `?topic=` query param** breaks the page — strip it. The on-chain topic stores `feed-general` but the URL uses `general`.
+- **Off-by-one on `topicIndex`** — when computing manually, the formula is `topicIndex = totalCount - posts.length + i` for the `i`-th post in a `getFeedPosts` result. Always prefer `globalIndex` if you have it.
+- **HyperEVM slug** is `hyperliquid`, not `hyperevm`.
+- **Degen and MegaETH** don't have canonical block explorers in our map — emit `null` rather than guess.

--- a/yarn.lock
+++ b/yarn.lock
@@ -1263,7 +1263,7 @@ __metadata:
 
 "@net-protocol/chats@file:../net-chats::locator=botchan%40workspace%3Apackages%2Fbotchan":
   version: 0.1.1
-  resolution: "@net-protocol/chats@file:../net-chats#../net-chats::hash=a0da87&locator=botchan%40workspace%3Apackages%2Fbotchan"
+  resolution: "@net-protocol/chats@file:../net-chats#../net-chats::hash=1c9d26&locator=botchan%40workspace%3Apackages%2Fbotchan"
   dependencies:
     "@net-protocol/core": "file:../net-core"
   peerDependencies:
@@ -1275,7 +1275,7 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: 9caa7d44c78ea9be9ff5bc71f0f71898b964d3cd23f8cec688c07b6aabfb5e12c8cb8e9e7fd39e65cbbb59243cdbd0b41a1336842cfb0765614763a2f6c0102c
+  checksum: 61b4e07341a9daa688d35fe756ca0fc13cec7c0d2dc95583ff1f638785c83b822ecd3c2f71a475b54a797e4141ee097e48c4c6b522719dbf6e20ae7d3f9ee593
   languageName: node
   linkType: hard
 
@@ -1302,8 +1302,8 @@ __metadata:
   linkType: soft
 
 "@net-protocol/cli@file:../net-cli::locator=botchan%40workspace%3Apackages%2Fbotchan":
-  version: 0.1.42
-  resolution: "@net-protocol/cli@file:../net-cli#../net-cli::hash=83abcd&locator=botchan%40workspace%3Apackages%2Fbotchan"
+  version: 0.1.44
+  resolution: "@net-protocol/cli@file:../net-cli#../net-cli::hash=1f7189&locator=botchan%40workspace%3Apackages%2Fbotchan"
   dependencies:
     "@net-protocol/agents": "npm:^0.1.0"
     "@net-protocol/bazaar": "npm:^0.1.17"
@@ -1324,7 +1324,7 @@ __metadata:
     viem: "npm:^2.45.0"
   bin:
     netp: ./dist/cli/index.mjs
-  checksum: 29211248e88c683d6b7cd3242519a0e61a4e68c222106dda81faf7096374fe9acdd872145d40f41e23cbc1607f2ca050d61f41fb5af4936902dca58e57bc533d
+  checksum: 3bd97d96e0cb6ccd4e190fe5fd05b85f9a4fb8701ef43f89f00812957409caa513ec990f41167623a9b96247facfb02c2a4b6d0cbcc195868b5fd2dad324f04f
   languageName: node
   linkType: hard
 
@@ -1362,7 +1362,7 @@ __metadata:
 
 "@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fagents%40workspace%3Apackages%2Fnet-agents":
   version: 0.1.11
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=705545&locator=%40net-protocol%2Fagents%40workspace%3Apackages%2Fnet-agents"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=6944fc&locator=%40net-protocol%2Fagents%40workspace%3Apackages%2Fnet-agents"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1374,13 +1374,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: 719129e83424aa03fc5bb305801b54e8768153033468e7b66e9746d3f4d2b1b52f5069e796d42cc6ed6e332cd07aa6dc7809ac783d9afba828011f35b854ae21
+  checksum: 75874ee78b341f9e747b32de62793d3a12b79c072d47bb738d68bed771e8a4505997caa955f6aa7f6fe1ada0b5af399bd475b402bb88fc83c552eb292c7b6478
   languageName: node
   linkType: hard
 
-"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fchats%40file%3A..%2Fnet-chats%23..%2Fnet-chats%3A%3Ahash%3Da0da87%26locator%3Dbotchan%2540workspace%253Apackages%252Fbotchan":
+"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fchats%40file%3A..%2Fnet-chats%23..%2Fnet-chats%3A%3Ahash%3D1c9d26%26locator%3Dbotchan%2540workspace%253Apackages%252Fbotchan":
   version: 0.1.11
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=705545&locator=%40net-protocol%2Fchats%40file%3A..%2Fnet-chats%23..%2Fnet-chats%3A%3Ahash%3Da0da87%26locator%3Dbotchan%2540workspace%253Apackages%252Fbotchan"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=6944fc&locator=%40net-protocol%2Fchats%40file%3A..%2Fnet-chats%23..%2Fnet-chats%3A%3Ahash%3D1c9d26%26locator%3Dbotchan%2540workspace%253Apackages%252Fbotchan"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1392,13 +1392,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: 719129e83424aa03fc5bb305801b54e8768153033468e7b66e9746d3f4d2b1b52f5069e796d42cc6ed6e332cd07aa6dc7809ac783d9afba828011f35b854ae21
+  checksum: 75874ee78b341f9e747b32de62793d3a12b79c072d47bb738d68bed771e8a4505997caa955f6aa7f6fe1ada0b5af399bd475b402bb88fc83c552eb292c7b6478
   languageName: node
   linkType: hard
 
 "@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fchats%40workspace%3Apackages%2Fnet-chats":
   version: 0.1.11
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=705545&locator=%40net-protocol%2Fchats%40workspace%3Apackages%2Fnet-chats"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=6944fc&locator=%40net-protocol%2Fchats%40workspace%3Apackages%2Fnet-chats"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1410,13 +1410,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: 719129e83424aa03fc5bb305801b54e8768153033468e7b66e9746d3f4d2b1b52f5069e796d42cc6ed6e332cd07aa6dc7809ac783d9afba828011f35b854ae21
+  checksum: 75874ee78b341f9e747b32de62793d3a12b79c072d47bb738d68bed771e8a4505997caa955f6aa7f6fe1ada0b5af399bd475b402bb88fc83c552eb292c7b6478
   languageName: node
   linkType: hard
 
-"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Ffeeds%40file%3A..%2Fnet-feeds%23..%2Fnet-feeds%3A%3Ahash%3Dca4627%26locator%3Dbotchan%2540workspace%253Apackages%252Fbotchan":
+"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Ffeeds%40file%3A..%2Fnet-feeds%23..%2Fnet-feeds%3A%3Ahash%3D3efc44%26locator%3Dbotchan%2540workspace%253Apackages%252Fbotchan":
   version: 0.1.11
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=705545&locator=%40net-protocol%2Ffeeds%40file%3A..%2Fnet-feeds%23..%2Fnet-feeds%3A%3Ahash%3Dca4627%26locator%3Dbotchan%2540workspace%253Apackages%252Fbotchan"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=6944fc&locator=%40net-protocol%2Ffeeds%40file%3A..%2Fnet-feeds%23..%2Fnet-feeds%3A%3Ahash%3D3efc44%26locator%3Dbotchan%2540workspace%253Apackages%252Fbotchan"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1428,13 +1428,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: 719129e83424aa03fc5bb305801b54e8768153033468e7b66e9746d3f4d2b1b52f5069e796d42cc6ed6e332cd07aa6dc7809ac783d9afba828011f35b854ae21
+  checksum: 75874ee78b341f9e747b32de62793d3a12b79c072d47bb738d68bed771e8a4505997caa955f6aa7f6fe1ada0b5af399bd475b402bb88fc83c552eb292c7b6478
   languageName: node
   linkType: hard
 
 "@net-protocol/core@file:../net-core::locator=%40net-protocol%2Ffeeds%40workspace%3Apackages%2Fnet-feeds":
   version: 0.1.11
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=705545&locator=%40net-protocol%2Ffeeds%40workspace%3Apackages%2Fnet-feeds"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=6944fc&locator=%40net-protocol%2Ffeeds%40workspace%3Apackages%2Fnet-feeds"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1446,13 +1446,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: 719129e83424aa03fc5bb305801b54e8768153033468e7b66e9746d3f4d2b1b52f5069e796d42cc6ed6e332cd07aa6dc7809ac783d9afba828011f35b854ae21
+  checksum: 75874ee78b341f9e747b32de62793d3a12b79c072d47bb738d68bed771e8a4505997caa955f6aa7f6fe1ada0b5af399bd475b402bb88fc83c552eb292c7b6478
   languageName: node
   linkType: hard
 
 "@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fnetr%40workspace%3Apackages%2Fnet-netr":
   version: 0.1.11
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=705545&locator=%40net-protocol%2Fnetr%40workspace%3Apackages%2Fnet-netr"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=6944fc&locator=%40net-protocol%2Fnetr%40workspace%3Apackages%2Fnet-netr"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1464,13 +1464,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: 719129e83424aa03fc5bb305801b54e8768153033468e7b66e9746d3f4d2b1b52f5069e796d42cc6ed6e332cd07aa6dc7809ac783d9afba828011f35b854ae21
+  checksum: 75874ee78b341f9e747b32de62793d3a12b79c072d47bb738d68bed771e8a4505997caa955f6aa7f6fe1ada0b5af399bd475b402bb88fc83c552eb292c7b6478
   languageName: node
   linkType: hard
 
 "@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fprofiles%40workspace%3Apackages%2Fnet-profiles":
   version: 0.1.11
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=705545&locator=%40net-protocol%2Fprofiles%40workspace%3Apackages%2Fnet-profiles"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=6944fc&locator=%40net-protocol%2Fprofiles%40workspace%3Apackages%2Fnet-profiles"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1482,13 +1482,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: 719129e83424aa03fc5bb305801b54e8768153033468e7b66e9746d3f4d2b1b52f5069e796d42cc6ed6e332cd07aa6dc7809ac783d9afba828011f35b854ae21
+  checksum: 75874ee78b341f9e747b32de62793d3a12b79c072d47bb738d68bed771e8a4505997caa955f6aa7f6fe1ada0b5af399bd475b402bb88fc83c552eb292c7b6478
   languageName: node
   linkType: hard
 
-"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Frelay%40file%3A..%2Fnet-relay%23..%2Fnet-relay%3A%3Ahash%3D69b2fc%26locator%3D%2540net-protocol%252Fagents%2540workspace%253Apackages%252Fnet-agents":
+"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Frelay%40file%3A..%2Fnet-relay%23..%2Fnet-relay%3A%3Ahash%3D3e8c83%26locator%3D%2540net-protocol%252Fagents%2540workspace%253Apackages%252Fnet-agents":
   version: 0.1.11
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=705545&locator=%40net-protocol%2Frelay%40file%3A..%2Fnet-relay%23..%2Fnet-relay%3A%3Ahash%3D69b2fc%26locator%3D%2540net-protocol%252Fagents%2540workspace%253Apackages%252Fnet-agents"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=6944fc&locator=%40net-protocol%2Frelay%40file%3A..%2Fnet-relay%23..%2Fnet-relay%3A%3Ahash%3D3e8c83%26locator%3D%2540net-protocol%252Fagents%2540workspace%253Apackages%252Fnet-agents"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1500,13 +1500,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: 719129e83424aa03fc5bb305801b54e8768153033468e7b66e9746d3f4d2b1b52f5069e796d42cc6ed6e332cd07aa6dc7809ac783d9afba828011f35b854ae21
+  checksum: 75874ee78b341f9e747b32de62793d3a12b79c072d47bb738d68bed771e8a4505997caa955f6aa7f6fe1ada0b5af399bd475b402bb88fc83c552eb292c7b6478
   languageName: node
   linkType: hard
 
 "@net-protocol/core@file:../net-core::locator=%40net-protocol%2Frelay%40workspace%3Apackages%2Fnet-relay":
   version: 0.1.11
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=705545&locator=%40net-protocol%2Frelay%40workspace%3Apackages%2Fnet-relay"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=6944fc&locator=%40net-protocol%2Frelay%40workspace%3Apackages%2Fnet-relay"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1518,13 +1518,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: 719129e83424aa03fc5bb305801b54e8768153033468e7b66e9746d3f4d2b1b52f5069e796d42cc6ed6e332cd07aa6dc7809ac783d9afba828011f35b854ae21
+  checksum: 75874ee78b341f9e747b32de62793d3a12b79c072d47bb738d68bed771e8a4505997caa955f6aa7f6fe1ada0b5af399bd475b402bb88fc83c552eb292c7b6478
   languageName: node
   linkType: hard
 
 "@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fscore%40workspace%3Apackages%2Fnet-score":
   version: 0.1.11
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=705545&locator=%40net-protocol%2Fscore%40workspace%3Apackages%2Fnet-score"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=6944fc&locator=%40net-protocol%2Fscore%40workspace%3Apackages%2Fnet-score"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1536,13 +1536,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: 719129e83424aa03fc5bb305801b54e8768153033468e7b66e9746d3f4d2b1b52f5069e796d42cc6ed6e332cd07aa6dc7809ac783d9afba828011f35b854ae21
+  checksum: 75874ee78b341f9e747b32de62793d3a12b79c072d47bb738d68bed771e8a4505997caa955f6aa7f6fe1ada0b5af399bd475b402bb88fc83c552eb292c7b6478
   languageName: node
   linkType: hard
 
-"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3D186c76%26locator%3D%2540net-protocol%252Fnetr%2540workspace%253Apackages%252Fnet-netr":
+"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3Ddd718f%26locator%3D%2540net-protocol%252Fnetr%2540workspace%253Apackages%252Fnet-netr":
   version: 0.1.11
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=705545&locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3D186c76%26locator%3D%2540net-protocol%252Fnetr%2540workspace%253Apackages%252Fnet-netr"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=6944fc&locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3Ddd718f%26locator%3D%2540net-protocol%252Fnetr%2540workspace%253Apackages%252Fnet-netr"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1554,13 +1554,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: 719129e83424aa03fc5bb305801b54e8768153033468e7b66e9746d3f4d2b1b52f5069e796d42cc6ed6e332cd07aa6dc7809ac783d9afba828011f35b854ae21
+  checksum: 75874ee78b341f9e747b32de62793d3a12b79c072d47bb738d68bed771e8a4505997caa955f6aa7f6fe1ada0b5af399bd475b402bb88fc83c552eb292c7b6478
   languageName: node
   linkType: hard
 
-"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3D186c76%26locator%3D%2540net-protocol%252Fprofiles%2540workspace%253Apackages%252Fnet-profiles":
+"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3Ddd718f%26locator%3D%2540net-protocol%252Fprofiles%2540workspace%253Apackages%252Fnet-profiles":
   version: 0.1.11
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=705545&locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3D186c76%26locator%3D%2540net-protocol%252Fprofiles%2540workspace%253Apackages%252Fnet-profiles"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=6944fc&locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3Ddd718f%26locator%3D%2540net-protocol%252Fprofiles%2540workspace%253Apackages%252Fnet-profiles"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1572,13 +1572,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: 719129e83424aa03fc5bb305801b54e8768153033468e7b66e9746d3f4d2b1b52f5069e796d42cc6ed6e332cd07aa6dc7809ac783d9afba828011f35b854ae21
+  checksum: 75874ee78b341f9e747b32de62793d3a12b79c072d47bb738d68bed771e8a4505997caa955f6aa7f6fe1ada0b5af399bd475b402bb88fc83c552eb292c7b6478
   languageName: node
   linkType: hard
 
-"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3D186c76%26locator%3D%2540net-protocol%252Fscore%2540workspace%253Apackages%252Fnet-score":
+"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3Ddd718f%26locator%3D%2540net-protocol%252Fscore%2540workspace%253Apackages%252Fnet-score":
   version: 0.1.11
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=705545&locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3D186c76%26locator%3D%2540net-protocol%252Fscore%2540workspace%253Apackages%252Fnet-score"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=6944fc&locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3Ddd718f%26locator%3D%2540net-protocol%252Fscore%2540workspace%253Apackages%252Fnet-score"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1590,13 +1590,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: 719129e83424aa03fc5bb305801b54e8768153033468e7b66e9746d3f4d2b1b52f5069e796d42cc6ed6e332cd07aa6dc7809ac783d9afba828011f35b854ae21
+  checksum: 75874ee78b341f9e747b32de62793d3a12b79c072d47bb738d68bed771e8a4505997caa955f6aa7f6fe1ada0b5af399bd475b402bb88fc83c552eb292c7b6478
   languageName: node
   linkType: hard
 
 "@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fstorage%40workspace%3Apackages%2Fnet-storage":
   version: 0.1.11
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=705545&locator=%40net-protocol%2Fstorage%40workspace%3Apackages%2Fnet-storage"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=6944fc&locator=%40net-protocol%2Fstorage%40workspace%3Apackages%2Fnet-storage"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1608,13 +1608,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: 719129e83424aa03fc5bb305801b54e8768153033468e7b66e9746d3f4d2b1b52f5069e796d42cc6ed6e332cd07aa6dc7809ac783d9afba828011f35b854ae21
+  checksum: 75874ee78b341f9e747b32de62793d3a12b79c072d47bb738d68bed771e8a4505997caa955f6aa7f6fe1ada0b5af399bd475b402bb88fc83c552eb292c7b6478
   languageName: node
   linkType: hard
 
 "@net-protocol/core@file:../net-core::locator=botchan%40workspace%3Apackages%2Fbotchan":
   version: 0.1.11
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=705545&locator=botchan%40workspace%3Apackages%2Fbotchan"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=6944fc&locator=botchan%40workspace%3Apackages%2Fbotchan"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1626,7 +1626,7 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: 719129e83424aa03fc5bb305801b54e8768153033468e7b66e9746d3f4d2b1b52f5069e796d42cc6ed6e332cd07aa6dc7809ac783d9afba828011f35b854ae21
+  checksum: 75874ee78b341f9e747b32de62793d3a12b79c072d47bb738d68bed771e8a4505997caa955f6aa7f6fe1ada0b5af399bd475b402bb88fc83c552eb292c7b6478
   languageName: node
   linkType: hard
 
@@ -1655,8 +1655,8 @@ __metadata:
   linkType: soft
 
 "@net-protocol/feeds@file:../net-feeds::locator=botchan%40workspace%3Apackages%2Fbotchan":
-  version: 0.1.16
-  resolution: "@net-protocol/feeds@file:../net-feeds#../net-feeds::hash=ca4627&locator=botchan%40workspace%3Apackages%2Fbotchan"
+  version: 0.1.17
+  resolution: "@net-protocol/feeds@file:../net-feeds#../net-feeds::hash=3efc44&locator=botchan%40workspace%3Apackages%2Fbotchan"
   dependencies:
     "@net-protocol/core": "file:../net-core"
   peerDependencies:
@@ -1668,7 +1668,7 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: 24389c6978e414db1e7eeca09259348c7fed7a5f88469b1ba959ad3a9aca9eff8f482de1804fd8a476efdd40e41596d4303f136afefbe0d7043515fa37bc4496
+  checksum: b9279613fe9e96c03323c8e8c0e435dcdc898b193c2f57f9fab85f3d352db199fb05c3ca57278e17d691c5e668d7e3eb9e6f3bf236b291617b3dd9252679ebf0
   languageName: node
   linkType: hard
 
@@ -1758,14 +1758,14 @@ __metadata:
 
 "@net-protocol/relay@file:../net-relay::locator=%40net-protocol%2Fagents%40workspace%3Apackages%2Fnet-agents":
   version: 0.1.5
-  resolution: "@net-protocol/relay@file:../net-relay#../net-relay::hash=69b2fc&locator=%40net-protocol%2Fagents%40workspace%3Apackages%2Fnet-agents"
+  resolution: "@net-protocol/relay@file:../net-relay#../net-relay::hash=3e8c83&locator=%40net-protocol%2Fagents%40workspace%3Apackages%2Fnet-agents"
   dependencies:
     "@net-protocol/core": "file:../net-core"
     "@x402/evm": "npm:^2.1.0"
     "@x402/fetch": "npm:^2.1.0"
   peerDependencies:
     viem: ^2.31.4
-  checksum: 1f56f27b2b8c19be74ac62b41db36f386ed1ea988a87469975c53f6c95de9f8e46a73c06cad674e37903e9e079365f73cfc5e0a49f72019f170f20c00a7693a6
+  checksum: 76d78898f3fed000cebc8e8623bd1268b83ab402e236b09c6b009254d9db4e4ac1b21f101e300d2b7b4f53144b8d2fdeb295203bb653d8ad94061a3495271ace
   languageName: node
   linkType: hard
 
@@ -1822,7 +1822,7 @@ __metadata:
 
 "@net-protocol/storage@file:../net-storage::locator=%40net-protocol%2Fnetr%40workspace%3Apackages%2Fnet-netr":
   version: 0.1.16
-  resolution: "@net-protocol/storage@file:../net-storage#../net-storage::hash=186c76&locator=%40net-protocol%2Fnetr%40workspace%3Apackages%2Fnet-netr"
+  resolution: "@net-protocol/storage@file:../net-storage#../net-storage::hash=dd718f&locator=%40net-protocol%2Fnetr%40workspace%3Apackages%2Fnet-netr"
   dependencies:
     "@net-protocol/core": "file:../net-core"
     pako: "npm:^2.1.0"
@@ -1836,13 +1836,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: e3b2fc256d09dd2cc92d0d23fca5b61bf1617f25b9767a48f1a32d71333526e47751d19789f466647204abc1929c495d55089491802a915fb33636f947018e9b
+  checksum: e687801852cd5e3b457c4a20e8ad475a6545b2dab2cadb440a01d87c5ca357fef74fae2f98a64c2dd6e215ff6658e9516b0b8962abb3a36b0bc0b8c161b5ad76
   languageName: node
   linkType: hard
 
 "@net-protocol/storage@file:../net-storage::locator=%40net-protocol%2Fprofiles%40workspace%3Apackages%2Fnet-profiles":
   version: 0.1.16
-  resolution: "@net-protocol/storage@file:../net-storage#../net-storage::hash=186c76&locator=%40net-protocol%2Fprofiles%40workspace%3Apackages%2Fnet-profiles"
+  resolution: "@net-protocol/storage@file:../net-storage#../net-storage::hash=dd718f&locator=%40net-protocol%2Fprofiles%40workspace%3Apackages%2Fnet-profiles"
   dependencies:
     "@net-protocol/core": "file:../net-core"
     pako: "npm:^2.1.0"
@@ -1856,13 +1856,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: e3b2fc256d09dd2cc92d0d23fca5b61bf1617f25b9767a48f1a32d71333526e47751d19789f466647204abc1929c495d55089491802a915fb33636f947018e9b
+  checksum: e687801852cd5e3b457c4a20e8ad475a6545b2dab2cadb440a01d87c5ca357fef74fae2f98a64c2dd6e215ff6658e9516b0b8962abb3a36b0bc0b8c161b5ad76
   languageName: node
   linkType: hard
 
 "@net-protocol/storage@file:../net-storage::locator=%40net-protocol%2Fscore%40workspace%3Apackages%2Fnet-score":
   version: 0.1.16
-  resolution: "@net-protocol/storage@file:../net-storage#../net-storage::hash=186c76&locator=%40net-protocol%2Fscore%40workspace%3Apackages%2Fnet-score"
+  resolution: "@net-protocol/storage@file:../net-storage#../net-storage::hash=dd718f&locator=%40net-protocol%2Fscore%40workspace%3Apackages%2Fnet-score"
   dependencies:
     "@net-protocol/core": "file:../net-core"
     pako: "npm:^2.1.0"
@@ -1876,7 +1876,7 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: e3b2fc256d09dd2cc92d0d23fca5b61bf1617f25b9767a48f1a32d71333526e47751d19789f466647204abc1929c495d55089491802a915fb33636f947018e9b
+  checksum: e687801852cd5e3b457c4a20e8ad475a6545b2dab2cadb440a01d87c5ca357fef74fae2f98a64c2dd6e215ff6658e9516b0b8962abb3a36b0bc0b8c161b5ad76
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1303,7 +1303,7 @@ __metadata:
 
 "@net-protocol/cli@file:../net-cli::locator=botchan%40workspace%3Apackages%2Fbotchan":
   version: 0.1.44
-  resolution: "@net-protocol/cli@file:../net-cli#../net-cli::hash=1f7189&locator=botchan%40workspace%3Apackages%2Fbotchan"
+  resolution: "@net-protocol/cli@file:../net-cli#../net-cli::hash=40461e&locator=botchan%40workspace%3Apackages%2Fbotchan"
   dependencies:
     "@net-protocol/agents": "npm:^0.1.0"
     "@net-protocol/bazaar": "npm:^0.1.17"
@@ -1324,7 +1324,7 @@ __metadata:
     viem: "npm:^2.45.0"
   bin:
     netp: ./dist/cli/index.mjs
-  checksum: 3bd97d96e0cb6ccd4e190fe5fd05b85f9a4fb8701ef43f89f00812957409caa513ec990f41167623a9b96247facfb02c2a4b6d0cbcc195868b5fd2dad324f04f
+  checksum: ff720e6b7dcd543e0f810c1d931f76be379734ad91a809103965b0b6797ea03790a87a751219e4227891c9d73b48ab96de09a8fd0c6a5e60040d2077787da0cc
   languageName: node
   linkType: hard
 
@@ -1361,8 +1361,8 @@ __metadata:
   linkType: soft
 
 "@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fagents%40workspace%3Apackages%2Fnet-agents":
-  version: 0.1.11
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=6944fc&locator=%40net-protocol%2Fagents%40workspace%3Apackages%2Fnet-agents"
+  version: 0.1.12
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=8c5e49&locator=%40net-protocol%2Fagents%40workspace%3Apackages%2Fnet-agents"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1374,13 +1374,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: 75874ee78b341f9e747b32de62793d3a12b79c072d47bb738d68bed771e8a4505997caa955f6aa7f6fe1ada0b5af399bd475b402bb88fc83c552eb292c7b6478
+  checksum: a168502766f3243b6a2699e81a5b9ce874fcc1217538423ed2e2797aa674953edf8b30fbf01c1bd0e08acdd304782463e6963466a73634a9d89ff85c0d32b897
   languageName: node
   linkType: hard
 
 "@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fchats%40file%3A..%2Fnet-chats%23..%2Fnet-chats%3A%3Ahash%3D1c9d26%26locator%3Dbotchan%2540workspace%253Apackages%252Fbotchan":
-  version: 0.1.11
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=6944fc&locator=%40net-protocol%2Fchats%40file%3A..%2Fnet-chats%23..%2Fnet-chats%3A%3Ahash%3D1c9d26%26locator%3Dbotchan%2540workspace%253Apackages%252Fbotchan"
+  version: 0.1.12
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=8c5e49&locator=%40net-protocol%2Fchats%40file%3A..%2Fnet-chats%23..%2Fnet-chats%3A%3Ahash%3D1c9d26%26locator%3Dbotchan%2540workspace%253Apackages%252Fbotchan"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1392,13 +1392,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: 75874ee78b341f9e747b32de62793d3a12b79c072d47bb738d68bed771e8a4505997caa955f6aa7f6fe1ada0b5af399bd475b402bb88fc83c552eb292c7b6478
+  checksum: a168502766f3243b6a2699e81a5b9ce874fcc1217538423ed2e2797aa674953edf8b30fbf01c1bd0e08acdd304782463e6963466a73634a9d89ff85c0d32b897
   languageName: node
   linkType: hard
 
 "@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fchats%40workspace%3Apackages%2Fnet-chats":
-  version: 0.1.11
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=6944fc&locator=%40net-protocol%2Fchats%40workspace%3Apackages%2Fnet-chats"
+  version: 0.1.12
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=8c5e49&locator=%40net-protocol%2Fchats%40workspace%3Apackages%2Fnet-chats"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1410,13 +1410,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: 75874ee78b341f9e747b32de62793d3a12b79c072d47bb738d68bed771e8a4505997caa955f6aa7f6fe1ada0b5af399bd475b402bb88fc83c552eb292c7b6478
+  checksum: a168502766f3243b6a2699e81a5b9ce874fcc1217538423ed2e2797aa674953edf8b30fbf01c1bd0e08acdd304782463e6963466a73634a9d89ff85c0d32b897
   languageName: node
   linkType: hard
 
 "@net-protocol/core@file:../net-core::locator=%40net-protocol%2Ffeeds%40file%3A..%2Fnet-feeds%23..%2Fnet-feeds%3A%3Ahash%3D3efc44%26locator%3Dbotchan%2540workspace%253Apackages%252Fbotchan":
-  version: 0.1.11
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=6944fc&locator=%40net-protocol%2Ffeeds%40file%3A..%2Fnet-feeds%23..%2Fnet-feeds%3A%3Ahash%3D3efc44%26locator%3Dbotchan%2540workspace%253Apackages%252Fbotchan"
+  version: 0.1.12
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=8c5e49&locator=%40net-protocol%2Ffeeds%40file%3A..%2Fnet-feeds%23..%2Fnet-feeds%3A%3Ahash%3D3efc44%26locator%3Dbotchan%2540workspace%253Apackages%252Fbotchan"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1428,13 +1428,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: 75874ee78b341f9e747b32de62793d3a12b79c072d47bb738d68bed771e8a4505997caa955f6aa7f6fe1ada0b5af399bd475b402bb88fc83c552eb292c7b6478
+  checksum: a168502766f3243b6a2699e81a5b9ce874fcc1217538423ed2e2797aa674953edf8b30fbf01c1bd0e08acdd304782463e6963466a73634a9d89ff85c0d32b897
   languageName: node
   linkType: hard
 
 "@net-protocol/core@file:../net-core::locator=%40net-protocol%2Ffeeds%40workspace%3Apackages%2Fnet-feeds":
-  version: 0.1.11
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=6944fc&locator=%40net-protocol%2Ffeeds%40workspace%3Apackages%2Fnet-feeds"
+  version: 0.1.12
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=8c5e49&locator=%40net-protocol%2Ffeeds%40workspace%3Apackages%2Fnet-feeds"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1446,13 +1446,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: 75874ee78b341f9e747b32de62793d3a12b79c072d47bb738d68bed771e8a4505997caa955f6aa7f6fe1ada0b5af399bd475b402bb88fc83c552eb292c7b6478
+  checksum: a168502766f3243b6a2699e81a5b9ce874fcc1217538423ed2e2797aa674953edf8b30fbf01c1bd0e08acdd304782463e6963466a73634a9d89ff85c0d32b897
   languageName: node
   linkType: hard
 
 "@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fnetr%40workspace%3Apackages%2Fnet-netr":
-  version: 0.1.11
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=6944fc&locator=%40net-protocol%2Fnetr%40workspace%3Apackages%2Fnet-netr"
+  version: 0.1.12
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=8c5e49&locator=%40net-protocol%2Fnetr%40workspace%3Apackages%2Fnet-netr"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1464,13 +1464,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: 75874ee78b341f9e747b32de62793d3a12b79c072d47bb738d68bed771e8a4505997caa955f6aa7f6fe1ada0b5af399bd475b402bb88fc83c552eb292c7b6478
+  checksum: a168502766f3243b6a2699e81a5b9ce874fcc1217538423ed2e2797aa674953edf8b30fbf01c1bd0e08acdd304782463e6963466a73634a9d89ff85c0d32b897
   languageName: node
   linkType: hard
 
 "@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fprofiles%40workspace%3Apackages%2Fnet-profiles":
-  version: 0.1.11
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=6944fc&locator=%40net-protocol%2Fprofiles%40workspace%3Apackages%2Fnet-profiles"
+  version: 0.1.12
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=8c5e49&locator=%40net-protocol%2Fprofiles%40workspace%3Apackages%2Fnet-profiles"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1482,13 +1482,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: 75874ee78b341f9e747b32de62793d3a12b79c072d47bb738d68bed771e8a4505997caa955f6aa7f6fe1ada0b5af399bd475b402bb88fc83c552eb292c7b6478
+  checksum: a168502766f3243b6a2699e81a5b9ce874fcc1217538423ed2e2797aa674953edf8b30fbf01c1bd0e08acdd304782463e6963466a73634a9d89ff85c0d32b897
   languageName: node
   linkType: hard
 
 "@net-protocol/core@file:../net-core::locator=%40net-protocol%2Frelay%40file%3A..%2Fnet-relay%23..%2Fnet-relay%3A%3Ahash%3D3e8c83%26locator%3D%2540net-protocol%252Fagents%2540workspace%253Apackages%252Fnet-agents":
-  version: 0.1.11
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=6944fc&locator=%40net-protocol%2Frelay%40file%3A..%2Fnet-relay%23..%2Fnet-relay%3A%3Ahash%3D3e8c83%26locator%3D%2540net-protocol%252Fagents%2540workspace%253Apackages%252Fnet-agents"
+  version: 0.1.12
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=8c5e49&locator=%40net-protocol%2Frelay%40file%3A..%2Fnet-relay%23..%2Fnet-relay%3A%3Ahash%3D3e8c83%26locator%3D%2540net-protocol%252Fagents%2540workspace%253Apackages%252Fnet-agents"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1500,13 +1500,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: 75874ee78b341f9e747b32de62793d3a12b79c072d47bb738d68bed771e8a4505997caa955f6aa7f6fe1ada0b5af399bd475b402bb88fc83c552eb292c7b6478
+  checksum: a168502766f3243b6a2699e81a5b9ce874fcc1217538423ed2e2797aa674953edf8b30fbf01c1bd0e08acdd304782463e6963466a73634a9d89ff85c0d32b897
   languageName: node
   linkType: hard
 
 "@net-protocol/core@file:../net-core::locator=%40net-protocol%2Frelay%40workspace%3Apackages%2Fnet-relay":
-  version: 0.1.11
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=6944fc&locator=%40net-protocol%2Frelay%40workspace%3Apackages%2Fnet-relay"
+  version: 0.1.12
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=8c5e49&locator=%40net-protocol%2Frelay%40workspace%3Apackages%2Fnet-relay"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1518,13 +1518,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: 75874ee78b341f9e747b32de62793d3a12b79c072d47bb738d68bed771e8a4505997caa955f6aa7f6fe1ada0b5af399bd475b402bb88fc83c552eb292c7b6478
+  checksum: a168502766f3243b6a2699e81a5b9ce874fcc1217538423ed2e2797aa674953edf8b30fbf01c1bd0e08acdd304782463e6963466a73634a9d89ff85c0d32b897
   languageName: node
   linkType: hard
 
 "@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fscore%40workspace%3Apackages%2Fnet-score":
-  version: 0.1.11
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=6944fc&locator=%40net-protocol%2Fscore%40workspace%3Apackages%2Fnet-score"
+  version: 0.1.12
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=8c5e49&locator=%40net-protocol%2Fscore%40workspace%3Apackages%2Fnet-score"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1536,13 +1536,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: 75874ee78b341f9e747b32de62793d3a12b79c072d47bb738d68bed771e8a4505997caa955f6aa7f6fe1ada0b5af399bd475b402bb88fc83c552eb292c7b6478
+  checksum: a168502766f3243b6a2699e81a5b9ce874fcc1217538423ed2e2797aa674953edf8b30fbf01c1bd0e08acdd304782463e6963466a73634a9d89ff85c0d32b897
   languageName: node
   linkType: hard
 
 "@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3Ddd718f%26locator%3D%2540net-protocol%252Fnetr%2540workspace%253Apackages%252Fnet-netr":
-  version: 0.1.11
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=6944fc&locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3Ddd718f%26locator%3D%2540net-protocol%252Fnetr%2540workspace%253Apackages%252Fnet-netr"
+  version: 0.1.12
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=8c5e49&locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3Ddd718f%26locator%3D%2540net-protocol%252Fnetr%2540workspace%253Apackages%252Fnet-netr"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1554,13 +1554,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: 75874ee78b341f9e747b32de62793d3a12b79c072d47bb738d68bed771e8a4505997caa955f6aa7f6fe1ada0b5af399bd475b402bb88fc83c552eb292c7b6478
+  checksum: a168502766f3243b6a2699e81a5b9ce874fcc1217538423ed2e2797aa674953edf8b30fbf01c1bd0e08acdd304782463e6963466a73634a9d89ff85c0d32b897
   languageName: node
   linkType: hard
 
 "@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3Ddd718f%26locator%3D%2540net-protocol%252Fprofiles%2540workspace%253Apackages%252Fnet-profiles":
-  version: 0.1.11
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=6944fc&locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3Ddd718f%26locator%3D%2540net-protocol%252Fprofiles%2540workspace%253Apackages%252Fnet-profiles"
+  version: 0.1.12
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=8c5e49&locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3Ddd718f%26locator%3D%2540net-protocol%252Fprofiles%2540workspace%253Apackages%252Fnet-profiles"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1572,13 +1572,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: 75874ee78b341f9e747b32de62793d3a12b79c072d47bb738d68bed771e8a4505997caa955f6aa7f6fe1ada0b5af399bd475b402bb88fc83c552eb292c7b6478
+  checksum: a168502766f3243b6a2699e81a5b9ce874fcc1217538423ed2e2797aa674953edf8b30fbf01c1bd0e08acdd304782463e6963466a73634a9d89ff85c0d32b897
   languageName: node
   linkType: hard
 
 "@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3Ddd718f%26locator%3D%2540net-protocol%252Fscore%2540workspace%253Apackages%252Fnet-score":
-  version: 0.1.11
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=6944fc&locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3Ddd718f%26locator%3D%2540net-protocol%252Fscore%2540workspace%253Apackages%252Fnet-score"
+  version: 0.1.12
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=8c5e49&locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3Ddd718f%26locator%3D%2540net-protocol%252Fscore%2540workspace%253Apackages%252Fnet-score"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1590,13 +1590,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: 75874ee78b341f9e747b32de62793d3a12b79c072d47bb738d68bed771e8a4505997caa955f6aa7f6fe1ada0b5af399bd475b402bb88fc83c552eb292c7b6478
+  checksum: a168502766f3243b6a2699e81a5b9ce874fcc1217538423ed2e2797aa674953edf8b30fbf01c1bd0e08acdd304782463e6963466a73634a9d89ff85c0d32b897
   languageName: node
   linkType: hard
 
 "@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fstorage%40workspace%3Apackages%2Fnet-storage":
-  version: 0.1.11
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=6944fc&locator=%40net-protocol%2Fstorage%40workspace%3Apackages%2Fnet-storage"
+  version: 0.1.12
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=8c5e49&locator=%40net-protocol%2Fstorage%40workspace%3Apackages%2Fnet-storage"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1608,13 +1608,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: 75874ee78b341f9e747b32de62793d3a12b79c072d47bb738d68bed771e8a4505997caa955f6aa7f6fe1ada0b5af399bd475b402bb88fc83c552eb292c7b6478
+  checksum: a168502766f3243b6a2699e81a5b9ce874fcc1217538423ed2e2797aa674953edf8b30fbf01c1bd0e08acdd304782463e6963466a73634a9d89ff85c0d32b897
   languageName: node
   linkType: hard
 
 "@net-protocol/core@file:../net-core::locator=botchan%40workspace%3Apackages%2Fbotchan":
-  version: 0.1.11
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=6944fc&locator=botchan%40workspace%3Apackages%2Fbotchan"
+  version: 0.1.12
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=8c5e49&locator=botchan%40workspace%3Apackages%2Fbotchan"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1626,7 +1626,7 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: 75874ee78b341f9e747b32de62793d3a12b79c072d47bb738d68bed771e8a4505997caa955f6aa7f6fe1ada0b5af399bd475b402bb88fc83c552eb292c7b6478
+  checksum: a168502766f3243b6a2699e81a5b9ce874fcc1217538423ed2e2797aa674953edf8b30fbf01c1bd0e08acdd304782463e6963466a73634a9d89ff85c0d32b897
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

This PR introduces a comprehensive URL building system for the Net Protocol CLI that enables seamless integration with the web app. It centralizes all URL construction logic (chain ID → slug mapping, topic prefix handling, comment ID normalization, etc.) in a single module, ensuring consistency across the CLI and preventing silent URL construction errors.

## Key Changes

- **New `urls.ts` module** (`packages/net-cli/src/shared/urls.ts`): Centralized URL builders for all Net Protocol web surfaces
  - Chain ID → OpenSea-style slug mapping (ethereum, base, degen, etc.)
  - Feed, wallet, profile, chat, token, bazaar, and agent URL builders
  - Block explorer URL builders for supported chains
  - Post permalink builder with three fallback forms (global index → topic index → user index)
  - Storage URL builder via storedon.net
  - Comprehensive JSDoc with URL grammar quirks documented

- **New `messageIndex.ts` helper** (`packages/net-cli/src/shared/messageIndex.ts`): Extracts global Net message indices from transaction receipts
  - Decodes `MessageSent` events to recover the most reliable permalink index
  - Used by post/comment write commands to build accurate deep links

- **Updated `FeedClient`** to expose `getFeedPostsWithIndex()` alongside `getFeedPosts()`
  - Returns `startIndex` and `totalCount` so callers can compute absolute topic-stream positions
  - Enables accurate permalink construction even after filtering

- **Enhanced JSON output** across all feed commands (read, posts, comments, post, comment-write, verify-claim, replies)
  - Posts now include: `postId`, `permalink`, `feedUrl`, `senderProfileUrl`, `senderWalletUrl`, `topicIndex`, `userIndex`, `globalIndex`
  - Comments include: `permalink`, `parentPostUrl`, `senderProfileUrl`, `explorerTxUrl`
  - Feeds include: `feedUrl`
  - All URLs are pre-built and ready to share with humans

- **New `--json` flag support** for write commands (post, comment-write, verify-claim)
  - Suppresses console output when JSON mode is active
  - Returns structured success responses with permalinks and explorer links

- **Updated skill documentation** (SKILL.md)
  - New "Sharing Links With Humans" section explaining URL field usage
  - Updated JSON output format examples
  - Reference to new `skill-references/urls.md` for manual URL construction fallback

- **New reference guide** (`skill-references/urls.md`): Manual URL templates for the rare cases where the CLI doesn't already build the link

## Notable Implementation Details

- URL builders return `null` for unsupported chains rather than throwing, allowing graceful degradation
- The `stripFeedPrefix()` helper normalizes on-chain topic names (which include "feed-" prefix) to URL form
- Post permalinks intelligently prefer global index (most reliable) → topic index → user index based on available data
- Comment deep-links normalize post IDs from colon-separated (`sender:timestamp`) to hyphen-separated (`sender-timestamp`) form
- Storage URLs use numeric chain IDs (not slugs) since storedon.net doesn't use the website's slug map
- All address and feed name inputs are lowercased for URL consistency
- Comprehensive test coverage for all URL builders and edge cases

https://claude.ai/code/session_01Xn9bya4ftVWAvWsXy8QPgH