### PR TITLE
verify-claim: always emit URL fields, even for already-recorded tx

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -435,7 +435,7 @@ Posts and comments come back with ready-to-use URL fields. Use `permalink`, `fee
 {"address": "0x...", "displayName": "Name", "profilePicture": "https://...", "xUsername": "handle", "bio": "Bio", "tokenAddress": "0x...", "hasProfile": true}
 ```
 
-**Verify-claim (`botchan verify-claim <txHash> --json`):** returns `{ recorded, entries: [...] }` where each entry has `permalink`, `feedUrl`, `senderProfileUrl`, `explorerTxUrl`, plus `postId` (or `parentPostId` for comments) and `globalIndex`. Use this after a Bankr / `--encode-only` submission to recover the permalink for the post or comment that landed.
+**Verify-claim (`botchan verify-claim <txHash> --json`):** returns `{ alreadyRecorded, recorded, entries: [...] }` where each entry has `permalink`, `feedUrl`, `senderProfileUrl`, `explorerTxUrl`, plus `postId` (or `parentPostId` for comments) and `globalIndex`. Use this after a Bankr / `--encode-only` submission to recover the permalink for the post or comment that landed. URL fields are emitted regardless of `alreadyRecorded` — calling verify-claim a second time on the same tx still returns the canonical permalink, only with `recorded: 0` (no new history entry added).
 
 ### Updating
 

--- a/packages/botchan/package.json
+++ b/packages/botchan/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botchan",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "description": "CLI for the onchain agent messaging layer on the Base blockchain, built on Net Protocol",
   "type": "module",
   "bin": {

--- a/packages/net-cli/package.json
+++ b/packages/net-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@net-protocol/cli",
-  "version": "0.1.44",
+  "version": "0.1.45",
   "description": "CLI tool for Net Protocol",
   "type": "module",
   "bin": {

--- a/packages/net-cli/src/commands/feed/verify-claim.ts
+++ b/packages/net-cli/src/commands/feed/verify-claim.ts
@@ -69,13 +69,9 @@ async function executeFeedVerifyClaim(
   const netContract = getNetContract(readOnlyOptions.chainId);
   const netClient = createNetClient(readOnlyOptions);
 
-  // Note whether this tx is already in local history. We still re-derive the
-  // URL fields below in either case — agents that lost the original
-  // `botchan post --json` output (or that posted via Bankr and called
-  // verify-claim twice) need a way to recover the permalink without
-  // requiring it to have been a "fresh" tx.
-  const existingHistory = getHistory();
-  const wasAlreadyRecorded = existingHistory.some(
+  // Re-derive URL fields even if already recorded, so callers that lost the
+  // original --json output can still recover the permalink.
+  const wasAlreadyRecorded = getHistory().some(
     (entry) => entry.txHash === txHash
   );
 

--- a/packages/net-cli/src/commands/feed/verify-claim.ts
+++ b/packages/net-cli/src/commands/feed/verify-claim.ts
@@ -69,17 +69,22 @@ async function executeFeedVerifyClaim(
   const netContract = getNetContract(readOnlyOptions.chainId);
   const netClient = createNetClient(readOnlyOptions);
 
-  // Check if already in history
+  // Note whether this tx is already in local history. We still re-derive the
+  // URL fields below in either case — agents that lost the original
+  // `botchan post --json` output (or that posted via Bankr and called
+  // verify-claim twice) need a way to recover the permalink without
+  // requiring it to have been a "fresh" tx.
   const existingHistory = getHistory();
-  if (existingHistory.some((entry) => entry.txHash === txHash)) {
-    if (options.json) {
-      printJson({ alreadyRecorded: true, txHash });
-    } else {
-      console.log(
-        chalk.yellow("Transaction already recorded in history. Skipping.")
-      );
-    }
-    return;
+  const wasAlreadyRecorded = existingHistory.some(
+    (entry) => entry.txHash === txHash
+  );
+
+  if (wasAlreadyRecorded && !options.json) {
+    console.log(
+      chalk.yellow(
+        "Transaction already in history — re-deriving URLs from on-chain data."
+      )
+    );
   }
 
   // Fetch transaction receipt
@@ -190,15 +195,18 @@ async function executeFeedVerifyClaim(
       permalink = postPermalink(readOnlyOptions.chainId, { globalIndex });
     }
 
-    addHistoryEntry({
-      type,
-      txHash,
-      chainId: readOnlyOptions.chainId,
-      feed: feedName,
-      sender: message.sender,
-      text: message.text,
-      postId: type === "comment" ? parentPostId : postId,
-    });
+    if (!wasAlreadyRecorded) {
+      addHistoryEntry({
+        type,
+        txHash,
+        chainId: readOnlyOptions.chainId,
+        feed: feedName,
+        sender: message.sender,
+        text: message.text,
+        postId: type === "comment" ? parentPostId : postId,
+      });
+      recorded++;
+    }
 
     const entry: RecoveredEntry = {
       type,
@@ -227,11 +235,10 @@ async function executeFeedVerifyClaim(
           : `Verified post:\n    Feed: ${feedName}\n    Sender: ${message.sender}\n    Text: ${message.text}\n    Post ID: ${postId}\n    Permalink: ${permalink ?? "(unavailable)"}\n    Tx: ${txHash}`;
       console.log(chalk.green(`  ${label}`));
     }
-    recorded++;
   }
 
   if (options.json) {
-    printJson({ recorded, entries });
+    printJson({ alreadyRecorded: wasAlreadyRecorded, recorded, entries });
     return;
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1263,7 +1263,7 @@ __metadata:
 
 "@net-protocol/chats@file:../net-chats::locator=botchan%40workspace%3Apackages%2Fbotchan":
   version: 0.1.1
-  resolution: "@net-protocol/chats@file:../net-chats#../net-chats::hash=1c9d26&locator=botchan%40workspace%3Apackages%2Fbotchan"
+  resolution: "@net-protocol/chats@file:../net-chats#../net-chats::hash=46f343&locator=botchan%40workspace%3Apackages%2Fbotchan"
   dependencies:
     "@net-protocol/core": "file:../net-core"
   peerDependencies:
@@ -1275,7 +1275,7 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: 61b4e07341a9daa688d35fe756ca0fc13cec7c0d2dc95583ff1f638785c83b822ecd3c2f71a475b54a797e4141ee097e48c4c6b522719dbf6e20ae7d3f9ee593
+  checksum: d1014f27b8ccd15c9f2174eb7b4aadab01638a1f9336e50eace6407e3b73c0005a508eccfc21d42a42abf78bf27195628eb3238c8a686889fc93388b1ac685a3
   languageName: node
   linkType: hard
 
@@ -1302,8 +1302,8 @@ __metadata:
   linkType: soft
 
 "@net-protocol/cli@file:../net-cli::locator=botchan%40workspace%3Apackages%2Fbotchan":
-  version: 0.1.44
-  resolution: "@net-protocol/cli@file:../net-cli#../net-cli::hash=40461e&locator=botchan%40workspace%3Apackages%2Fbotchan"
+  version: 0.1.45
+  resolution: "@net-protocol/cli@file:../net-cli#../net-cli::hash=bf832a&locator=botchan%40workspace%3Apackages%2Fbotchan"
   dependencies:
     "@net-protocol/agents": "npm:^0.1.0"
     "@net-protocol/bazaar": "npm:^0.1.17"
@@ -1324,7 +1324,7 @@ __metadata:
     viem: "npm:^2.45.0"
   bin:
     netp: ./dist/cli/index.mjs
-  checksum: ff720e6b7dcd543e0f810c1d931f76be379734ad91a809103965b0b6797ea03790a87a751219e4227891c9d73b48ab96de09a8fd0c6a5e60040d2077787da0cc
+  checksum: f784b50a2f77ca9a548302f96352417387136e96a514042cdc20da1983ea40d3d389b531ef29518f5caee8a3d82ebab615b0a8c429fae5041f1f7d1660ffdcce
   languageName: node
   linkType: hard
 
@@ -1378,9 +1378,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fchats%40file%3A..%2Fnet-chats%23..%2Fnet-chats%3A%3Ahash%3D1c9d26%26locator%3Dbotchan%2540workspace%253Apackages%252Fbotchan":
+"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fchats%40file%3A..%2Fnet-chats%23..%2Fnet-chats%3A%3Ahash%3D46f343%26locator%3Dbotchan%2540workspace%253Apackages%252Fbotchan":
   version: 0.1.12
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=8c5e49&locator=%40net-protocol%2Fchats%40file%3A..%2Fnet-chats%23..%2Fnet-chats%3A%3Ahash%3D1c9d26%26locator%3Dbotchan%2540workspace%253Apackages%252Fbotchan"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=8c5e49&locator=%40net-protocol%2Fchats%40file%3A..%2Fnet-chats%23..%2Fnet-chats%3A%3Ahash%3D46f343%26locator%3Dbotchan%2540workspace%253Apackages%252Fbotchan"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1414,9 +1414,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Ffeeds%40file%3A..%2Fnet-feeds%23..%2Fnet-feeds%3A%3Ahash%3D3efc44%26locator%3Dbotchan%2540workspace%253Apackages%252Fbotchan":
+"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Ffeeds%40file%3A..%2Fnet-feeds%23..%2Fnet-feeds%3A%3Ahash%3D1ca43c%26locator%3Dbotchan%2540workspace%253Apackages%252Fbotchan":
   version: 0.1.12
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=8c5e49&locator=%40net-protocol%2Ffeeds%40file%3A..%2Fnet-feeds%23..%2Fnet-feeds%3A%3Ahash%3D3efc44%26locator%3Dbotchan%2540workspace%253Apackages%252Fbotchan"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=8c5e49&locator=%40net-protocol%2Ffeeds%40file%3A..%2Fnet-feeds%23..%2Fnet-feeds%3A%3Ahash%3D1ca43c%26locator%3Dbotchan%2540workspace%253Apackages%252Fbotchan"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1486,9 +1486,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Frelay%40file%3A..%2Fnet-relay%23..%2Fnet-relay%3A%3Ahash%3D3e8c83%26locator%3D%2540net-protocol%252Fagents%2540workspace%253Apackages%252Fnet-agents":
+"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Frelay%40file%3A..%2Fnet-relay%23..%2Fnet-relay%3A%3Ahash%3D23fc4d%26locator%3D%2540net-protocol%252Fagents%2540workspace%253Apackages%252Fnet-agents":
   version: 0.1.12
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=8c5e49&locator=%40net-protocol%2Frelay%40file%3A..%2Fnet-relay%23..%2Fnet-relay%3A%3Ahash%3D3e8c83%26locator%3D%2540net-protocol%252Fagents%2540workspace%253Apackages%252Fnet-agents"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=8c5e49&locator=%40net-protocol%2Frelay%40file%3A..%2Fnet-relay%23..%2Fnet-relay%3A%3Ahash%3D23fc4d%26locator%3D%2540net-protocol%252Fagents%2540workspace%253Apackages%252Fnet-agents"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1540,9 +1540,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3Ddd718f%26locator%3D%2540net-protocol%252Fnetr%2540workspace%253Apackages%252Fnet-netr":
+"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3Dd07f02%26locator%3D%2540net-protocol%252Fnetr%2540workspace%253Apackages%252Fnet-netr":
   version: 0.1.12
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=8c5e49&locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3Ddd718f%26locator%3D%2540net-protocol%252Fnetr%2540workspace%253Apackages%252Fnet-netr"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=8c5e49&locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3Dd07f02%26locator%3D%2540net-protocol%252Fnetr%2540workspace%253Apackages%252Fnet-netr"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1558,9 +1558,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3Ddd718f%26locator%3D%2540net-protocol%252Fprofiles%2540workspace%253Apackages%252Fnet-profiles":
+"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3Dd07f02%26locator%3D%2540net-protocol%252Fprofiles%2540workspace%253Apackages%252Fnet-profiles":
   version: 0.1.12
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=8c5e49&locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3Ddd718f%26locator%3D%2540net-protocol%252Fprofiles%2540workspace%253Apackages%252Fnet-profiles"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=8c5e49&locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3Dd07f02%26locator%3D%2540net-protocol%252Fprofiles%2540workspace%253Apackages%252Fnet-profiles"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1576,9 +1576,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3Ddd718f%26locator%3D%2540net-protocol%252Fscore%2540workspace%253Apackages%252Fnet-score":
+"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3Dd07f02%26locator%3D%2540net-protocol%252Fscore%2540workspace%253Apackages%252Fnet-score":
   version: 0.1.12
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=8c5e49&locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3Ddd718f%26locator%3D%2540net-protocol%252Fscore%2540workspace%253Apackages%252Fnet-score"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=8c5e49&locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3Dd07f02%26locator%3D%2540net-protocol%252Fscore%2540workspace%253Apackages%252Fnet-score"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1656,7 +1656,7 @@ __metadata:
 
 "@net-protocol/feeds@file:../net-feeds::locator=botchan%40workspace%3Apackages%2Fbotchan":
   version: 0.1.17
-  resolution: "@net-protocol/feeds@file:../net-feeds#../net-feeds::hash=3efc44&locator=botchan%40workspace%3Apackages%2Fbotchan"
+  resolution: "@net-protocol/feeds@file:../net-feeds#../net-feeds::hash=1ca43c&locator=botchan%40workspace%3Apackages%2Fbotchan"
   dependencies:
     "@net-protocol/core": "file:../net-core"
   peerDependencies:
@@ -1668,7 +1668,7 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: b9279613fe9e96c03323c8e8c0e435dcdc898b193c2f57f9fab85f3d352db199fb05c3ca57278e17d691c5e668d7e3eb9e6f3bf236b291617b3dd9252679ebf0
+  checksum: 667ee127c0f6a65b85be7405c4107b070089d478aeab579640875f39eb5cb57d0e4c0a81825e574c5041a1216da66bba7457d9e95b10913840e0ee39912f5ab3
   languageName: node
   linkType: hard
 
@@ -1758,14 +1758,14 @@ __metadata:
 
 "@net-protocol/relay@file:../net-relay::locator=%40net-protocol%2Fagents%40workspace%3Apackages%2Fnet-agents":
   version: 0.1.5
-  resolution: "@net-protocol/relay@file:../net-relay#../net-relay::hash=3e8c83&locator=%40net-protocol%2Fagents%40workspace%3Apackages%2Fnet-agents"
+  resolution: "@net-protocol/relay@file:../net-relay#../net-relay::hash=23fc4d&locator=%40net-protocol%2Fagents%40workspace%3Apackages%2Fnet-agents"
   dependencies:
     "@net-protocol/core": "file:../net-core"
     "@x402/evm": "npm:^2.1.0"
     "@x402/fetch": "npm:^2.1.0"
   peerDependencies:
     viem: ^2.31.4
-  checksum: 76d78898f3fed000cebc8e8623bd1268b83ab402e236b09c6b009254d9db4e4ac1b21f101e300d2b7b4f53144b8d2fdeb295203bb653d8ad94061a3495271ace
+  checksum: 9890bb9803724399c3c4cd5ebd4c1a88de09b96bc0acf4d4c754541d09a6f84309eeaeeeec7dfc2edd83bdbfacfbeffc0014159f21807ccf38dca52bd3585e55
   languageName: node
   linkType: hard
 
@@ -1822,7 +1822,7 @@ __metadata:
 
 "@net-protocol/storage@file:../net-storage::locator=%40net-protocol%2Fnetr%40workspace%3Apackages%2Fnet-netr":
   version: 0.1.16
-  resolution: "@net-protocol/storage@file:../net-storage#../net-storage::hash=dd718f&locator=%40net-protocol%2Fnetr%40workspace%3Apackages%2Fnet-netr"
+  resolution: "@net-protocol/storage@file:../net-storage#../net-storage::hash=d07f02&locator=%40net-protocol%2Fnetr%40workspace%3Apackages%2Fnet-netr"
   dependencies:
     "@net-protocol/core": "file:../net-core"
     pako: "npm:^2.1.0"
@@ -1836,13 +1836,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: e687801852cd5e3b457c4a20e8ad475a6545b2dab2cadb440a01d87c5ca357fef74fae2f98a64c2dd6e215ff6658e9516b0b8962abb3a36b0bc0b8c161b5ad76
+  checksum: 8ed0f3cb622a713d4ce5dcd7795aba3cf246cba60945eccdda59a1a98336b3114be77a5358be995e231d8d3cec5b22af7797407e4c68eee667fbf36a7c33dca7
   languageName: node
   linkType: hard
 
 "@net-protocol/storage@file:../net-storage::locator=%40net-protocol%2Fprofiles%40workspace%3Apackages%2Fnet-profiles":
   version: 0.1.16
-  resolution: "@net-protocol/storage@file:../net-storage#../net-storage::hash=dd718f&locator=%40net-protocol%2Fprofiles%40workspace%3Apackages%2Fnet-profiles"
+  resolution: "@net-protocol/storage@file:../net-storage#../net-storage::hash=d07f02&locator=%40net-protocol%2Fprofiles%40workspace%3Apackages%2Fnet-profiles"
   dependencies:
     "@net-protocol/core": "file:../net-core"
     pako: "npm:^2.1.0"
@@ -1856,13 +1856,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: e687801852cd5e3b457c4a20e8ad475a6545b2dab2cadb440a01d87c5ca357fef74fae2f98a64c2dd6e215ff6658e9516b0b8962abb3a36b0bc0b8c161b5ad76
+  checksum: 8ed0f3cb622a713d4ce5dcd7795aba3cf246cba60945eccdda59a1a98336b3114be77a5358be995e231d8d3cec5b22af7797407e4c68eee667fbf36a7c33dca7
   languageName: node
   linkType: hard
 
 "@net-protocol/storage@file:../net-storage::locator=%40net-protocol%2Fscore%40workspace%3Apackages%2Fnet-score":
   version: 0.1.16
-  resolution: "@net-protocol/storage@file:../net-storage#../net-storage::hash=dd718f&locator=%40net-protocol%2Fscore%40workspace%3Apackages%2Fnet-score"
+  resolution: "@net-protocol/storage@file:../net-storage#../net-storage::hash=d07f02&locator=%40net-protocol%2Fscore%40workspace%3Apackages%2Fnet-score"
   dependencies:
     "@net-protocol/core": "file:../net-core"
     pako: "npm:^2.1.0"
@@ -1876,7 +1876,7 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: e687801852cd5e3b457c4a20e8ad475a6545b2dab2cadb440a01d87c5ca357fef74fae2f98a64c2dd6e215ff6658e9516b0b8962abb3a36b0bc0b8c161b5ad76
+  checksum: 8ed0f3cb622a713d4ce5dcd7795aba3cf246cba60945eccdda59a1a98336b3114be77a5358be995e231d8d3cec5b22af7797407e4c68eee667fbf36a7c33dca7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Fixes a UX gap in `botchan verify-claim --json` discovered while smoke-testing the URL emission work from #112.

**Before:** when a tx was already in local history, the command short-circuited with `{ alreadyRecorded: true, txHash }` — no URL fields. This made it useless for its main documented purpose: recovering the canonical permalink for an externally-submitted tx.

**Concrete failure case:** an agent that ran `botchan post --json` (which auto-records to history) then later called `verify-claim` to look up the permalink got back a stub.

**After:** verify-claim always re-derives URL fields from the receipt's `MessageSent` event. `alreadyRecorded` is now informational; `recorded` reports how many entries were newly added (0 when already-recorded).

## Response shape change

```diff
- { alreadyRecorded: true, txHash }
+ { alreadyRecorded: true, recorded: 0, entries: [{ permalink, feedUrl, senderProfileUrl, explorerTxUrl, globalIndex, ... }] }
```

The fresh-tx path is unchanged.

## Smoke test

Against tx `0x6c768408…d330d` on Base (a post made earlier today), already in local history:

- Old (`@net-protocol/cli@0.1.44`): returned only `{ alreadyRecorded: true, txHash }`
- New: emits the full entry with `permalink: "https://netprotocol.app/app/feed/base/post?index=131281"` — the URL resolves 200.

## Bumps

- `@net-protocol/cli` 0.1.44 → 0.1.45
- `botchan` 0.4.9 → 0.4.10 (republish to ship the new cli; no source changes in botchan)

`@net-protocol/core` and `@net-protocol/feeds` are untouched.

## Test plan

- [x] `yarn workspace @net-protocol/cli test` — 307/307 + 4 skipped
- [x] Smoke test against an already-in-history tx returns full entry with permalink
- [x] HEAD-check the emitted permalink → 200
- [ ] CI green