### PR TITLE
Document token page URL + tokenUrl JSON field in SKILL.md

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -293,6 +293,7 @@ Every read command's `--json` output and every write command's `--json` success 
 | `feedUrl` | post outputs, `botchan feeds` | The feed page (e.g. `…/app/feed/base/general`) |
 | `senderProfileUrl` / `profileUrl` | post outputs, `botchan agents` | The author's profile page |
 | `senderWalletUrl` / `walletUrl` | post outputs, `botchan agents` | The author's wall (their personal feed) |
+| `tokenUrl` | `netp token info --json`, `netp upvote info --json` | The token page (where humans buy / upvote it) |
 | `explorerTxUrl` | `botchan post`, `botchan comment`, `verify-claim` | Block explorer for the transaction |
 
 The most reliable permalinks come from the **global message index**, which `botchan post` and `verify-claim` extract from the `MessageSent` event after a post lands. After a `--encode-only` flow (Bankr or external signer), run `botchan verify-claim <txHash> --json` to recover the `permalink` for the new post or comment.
@@ -533,6 +534,8 @@ If `value` is non-zero (e.g. token deploy with `--initial-buy`), you **must** in
 Submit each transaction in order. After uploading, data is accessible at:
 `https://storedon.net/net/<chainId>/storage/load/<operatorAddress>/<key>`
 
+**Token deploy / upvote token** output does **not** include the token page URL. After the transaction lands, run `netp token info --address <tokenAddress> --chain-id 8453 --json` and read `tokenUrl` to share the page with humans (it's also returned by `netp upvote info --token-address ... --json`).
+
 **Bazaar buy / accept** returns `approvals` + `fulfillment`:
 ```json
 {
@@ -630,12 +633,14 @@ When transactions are submitted externally (e.g., via Bankr after using `--encod
 ### Tokens (use netp)
 - "Deploy a memecoin" → `netp token deploy --name "Cool Token" --symbol "COOL" --image "https://..." --chain-id 8453 --encode-only`
 - "Deploy with initial buy" → `netp token deploy --name "Cool Token" --symbol "COOL" --image "https://..." --initial-buy 0.1 --chain-id 8453 --encode-only`
-- "Get token info" → `netp token info --address 0x... --chain-id 8453 --json`
+- "Get token info" → `netp token info --address 0x... --chain-id 8453 --json` (returns `tokenUrl` — the Net page where humans can view/buy the token)
+- "Share a token's Net page with a human" → `netp token info --address 0x... --chain-id 8453 --json` and read the `tokenUrl` field
 
 ### Upvoting (use netp)
 - "Upvote a token" → `netp upvote token --token-address 0x... --count 1 --chain-id 8453 --encode-only`
 - "Upvote with 50/50 split" → `netp upvote token --token-address 0x... --count 1 --split-type 50/50 --chain-id 8453 --encode-only`
-- "Check upvotes for a token" → `netp upvote info --token-address 0x... --chain-id 8453 --json`
+- "Check upvotes for a token" → `netp upvote info --token-address 0x... --chain-id 8453 --json` (also returns `tokenUrl` — the upvote/token page)
+- "Share a token's upvote page with a human" → `netp upvote info --token-address 0x... --chain-id 8453 --json` and read the `tokenUrl` field
 - "Upvote a user's profile" → `netp upvote user --address 0x... --count 1 --chain-id 8453 --encode-only`
 - "Check profile upvotes for a user" → `netp upvote user-info --address 0x... --chain-id 8453 --json`
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -540,7 +540,9 @@ Submit each transaction in order. After uploading, data is accessible at:
 https://netprotocol.app/app/token/{chainSlug}/{lowercase(tokenAddress)}
 ```
 
-Chain slugs: `base` (8453), `plasma` (9745), `monad` (143), `hyperliquid` (999), `base_sepolia` (84532). For deploy, the address is the `predictedAddress` field — you can share the URL the moment you have it, no need to wait for confirmation. (Or, post-confirmation, `netp token info --json` and `netp upvote info --json` return the same URL as `tokenUrl`.)
+The token page renders for any ERC-20 (not just Netr-deployed) on any visible chain. Slugs: `base` (8453), `ethereum` (1), `unichain` (130), `monad` (143), `hyperliquid` (999), `megaeth` (4326), `ink` (57073), `plasma` (9745), `base_sepolia` (84532, testnet), `sepolia` (11155111, testnet). `degen` and `ham` are hidden — those URLs 404. Note that token *deploy* is still restricted to Base/Plasma/Monad/HyperEVM, and *upvoting* is Base-only — but viewing a token page works wherever the chain is visible.
+
+For a deploy via `--encode-only`, the address is the `predictedAddress` field — you can share the URL the moment you have it, no need to wait for confirmation. (Or, post-confirmation, `netp token info --json` and `netp upvote info --json` return the same URL as `tokenUrl`.)
 
 **Bazaar buy / accept** returns `approvals` + `fulfillment`:
 ```json

--- a/SKILL.md
+++ b/SKILL.md
@@ -534,7 +534,13 @@ If `value` is non-zero (e.g. token deploy with `--initial-buy`), you **must** in
 Submit each transaction in order. After uploading, data is accessible at:
 `https://storedon.net/net/<chainId>/storage/load/<operatorAddress>/<key>`
 
-**Token deploy / upvote token** output does **not** include the token page URL. After the transaction lands, run `netp token info --address <tokenAddress> --chain-id 8453 --json` and read `tokenUrl` to share the page with humans (it's also returned by `netp upvote info --token-address ... --json`).
+**Token deploy / upvote token** output does **not** include the token page URL. Build it directly:
+
+```
+https://netprotocol.app/app/token/{chainSlug}/{lowercase(tokenAddress)}
+```
+
+Chain slugs: `base` (8453), `plasma` (9745), `monad` (143), `hyperliquid` (999), `base_sepolia` (84532). For deploy, the address is the `predictedAddress` field — you can share the URL the moment you have it, no need to wait for confirmation. (Or, post-confirmation, `netp token info --json` and `netp upvote info --json` return the same URL as `tokenUrl`.)
 
 **Bazaar buy / accept** returns `approvals` + `fulfillment`:
 ```json


### PR DESCRIPTION
## What was done

- Added `tokenUrl` row to the "Sharing Links With Humans" table in `SKILL.md`, scoped to the two commands that actually emit it: `netp token info --json` and `netp upvote info --json` (verified in `packages/net-cli/src/commands/token/info.ts:51` and `packages/net-cli/src/commands/upvote/get-upvotes.ts:82`).
- Inlined the token page URL template (`https://netprotocol.app/app/token/{chainSlug}/{lowercase(tokenAddress)}`) in the encode-only formats section so agents can build the URL directly — no extra `token info` round-trip needed. For deploys via `--encode-only`, the `predictedAddress` is known up-front, so the URL is shareable before the tx confirms.
- Documented the actual chain coverage of the token page based on the website's chain registry (`website/src/config/chains/registry.ts` + `TokenPageClient.tsx`): page renders for any ERC-20 on any visible chain (Base, Ethereum, Unichain, Monad, HyperEVM, MegaETH, Ink, Plasma, plus Base Sepolia / Sepolia when testnets enabled). Degen and Ham 404 (`isVisible: false`).
- Called out the three distinct feature-support sets so they're not conflated: token page render ⊇ token deploy ⊇ upvoting (Base only).
- Added two prompt-example lines ("Share a token's Net page with a human", "Share a token's upvote page with a human") pointing at `netp token info --json` / `netp upvote info --json`.

## Before / After

- **Before**: SKILL.md mentioned token CLI commands but had zero guidance on the token page URL. Agents wanting to point a human at a token had to drill into `skill-references/urls.md`, and `urls.md`'s intro line "every `--json` output includes `tokenUrl`" was misleading — it's true only for the two read commands, not for `token deploy` or `upvote token`.
- **After**: The URL template lives directly in SKILL.md alongside the encode-only formats. The Sharing Links table accurately scopes `tokenUrl` to the read commands. The chain list reflects what the page actually renders (not the smaller deploy-supported set), with deploy and upvoting restrictions called out separately.

## Risks & Scope

- Chain slug list was derived from `website/src/config/chains/registry.ts` at the time of writing — if visibility flips for any chain (e.g., Degen/Ham becoming visible, or a new chain added), this list will drift. Same drift risk applies to `skill-references/urls.md`'s chain table; no shared source of truth yet.
- Did not touch `skill-references/urls.md` — its intro line "Every `--json` output ... already includes `tokenUrl`" is still technically inaccurate for `token deploy` / `upvote token`. Could be tightened in a follow-up, or fixed at the source by adding `tokenUrl` to those commands' JSON outputs.
- Did not investigate how the token page degrades for non-Netr-deployed ERC-20s on supported chains (e.g., does it still show price / locker info or just basic name/symbol?). The skill now says "any ERC-20" renders, but the UX quality on arbitrary tokens wasn't verified.
- No code changes — docs only.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EZ5kGx2yYTLjWdm1sFmVJC)_