### PR TITLE
Select Uniswap pools by WETH depth in @net-protocol/score

### DIFF
--- a/packages/net-cli/package.json
+++ b/packages/net-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@net-protocol/cli",
-  "version": "0.1.47",
+  "version": "0.1.48",
   "description": "CLI tool for Net Protocol",
   "type": "module",
   "bin": {
@@ -56,7 +56,7 @@
     "@net-protocol/netr": "^0.1.3",
     "@net-protocol/profiles": "^0.1.5",
     "@net-protocol/relay": "^0.1.3",
-    "@net-protocol/score": "^0.1.6",
+    "@net-protocol/score": "^0.1.7",
     "@net-protocol/storage": "^0.1.12",
     "@x402/evm": "^2.1.0",
     "@x402/fetch": "^2.1.0",

--- a/packages/net-score/package.json
+++ b/packages/net-score/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@net-protocol/score",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Score/upvoting functionality for Net Protocol - on-chain scoring system",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/net-score/src/__tests__/poolDiscovery.test.ts
+++ b/packages/net-score/src/__tests__/poolDiscovery.test.ts
@@ -172,70 +172,119 @@ describe("selectBestPoolPerPair", () => {
     token1: WETH_ADDRESS as `0x${string}`,
     token0Balance: "1000000000000000000000",
     token1Balance: "1000000000000000000",
+    liquidity: "0",
   };
 
   it("should return single pool when only one exists", () => {
     const pools = [
       {
         ...basePool,
-        poolAddress: "0x1111000000000000000000000000000000000001" as `0x${string}`,
+        poolAddress:
+          "0x1111000000000000000000000000000000000001" as `0x${string}`,
         baseTokenBalance: "1000000000000000000",
         fee: 3000,
+        wethDepthWei: 1_000_000_000_000_000_000n,
       },
     ];
 
-    const result = selectBestPoolPerPair(pools, WETH_ADDRESS);
+    const result = selectBestPoolPerPair(pools);
     expect(result).toHaveLength(1);
     expect(result[0].poolAddress).toBe(
       "0x1111000000000000000000000000000000000001"
     );
   });
 
-  it("should prefer V2/V3 pools with sufficient liquidity over V4", () => {
+  it("should pick the deeper V4 pool over a shallower V2/V3 pool", () => {
     const pools = [
       {
         ...basePool,
-        poolAddress: "0x1111000000000000000000000000000000000001" as `0x${string}`,
-        baseTokenBalance: String(0.2 * 1e18), // Above 0.1 ETH threshold
+        poolAddress:
+          "0x1111000000000000000000000000000000000001" as `0x${string}`,
+        baseTokenBalance: "5740000000000000000",
         fee: 3000,
+        wethDepthWei: 5_740_000_000_000_000_000n,
       },
       {
         ...basePool,
         poolAddress: null,
         baseTokenBalance: "0",
-        fee: 500,
+        fee: 8388608,
+        liquidity: "999999999999999999999",
+        wethDepthWei: 371_000_000_000_000_000_000n,
       },
     ];
 
-    const result = selectBestPoolPerPair(pools, WETH_ADDRESS);
+    const result = selectBestPoolPerPair(pools);
+    expect(result).toHaveLength(1);
+    expect(result[0].poolAddress).toBeNull();
+  });
+
+  it("should pick the deeper V2/V3 pool over a shallower V4 pool", () => {
+    const pools = [
+      {
+        ...basePool,
+        poolAddress:
+          "0x1111000000000000000000000000000000000001" as `0x${string}`,
+        baseTokenBalance: "100000000000000000000",
+        fee: 3000,
+        wethDepthWei: 100_000_000_000_000_000_000n,
+      },
+      {
+        ...basePool,
+        poolAddress: null,
+        baseTokenBalance: "0",
+        fee: 8388608,
+        liquidity: "1000",
+        wethDepthWei: 1_000_000_000_000_000_000n,
+      },
+    ];
+
+    const result = selectBestPoolPerPair(pools);
     expect(result).toHaveLength(1);
     expect(result[0].poolAddress).toBe(
       "0x1111000000000000000000000000000000000001"
     );
   });
 
-  it("should fall back to V4 when V2/V3 pools lack liquidity", () => {
+  it("should reject pools with zero wethDepthWei (V4 ghost pool kill)", () => {
     const pools = [
       {
         ...basePool,
-        poolAddress: "0x1111000000000000000000000000000000000001" as `0x${string}`,
-        baseTokenBalance: String(0.001 * 1e18), // Below both thresholds
-        // token1 is WETH, so getWethBalanceWei uses token1Balance
-        token1Balance: String(0.001 * 1e18), // Below both thresholds
-        fee: 3000,
+        poolAddress: null,
+        baseTokenBalance: "0",
+        fee: 10000,
+        liquidity: "0",
+        wethDepthWei: 0n,
       },
       {
         ...basePool,
         poolAddress: null,
         baseTokenBalance: "0",
-        token1Balance: "0",
-        fee: 500,
+        fee: 8388608,
+        liquidity: "1000000000",
+        wethDepthWei: 11_800_000_000_000_000_000n,
       },
     ];
 
-    const result = selectBestPoolPerPair(pools, WETH_ADDRESS);
+    const result = selectBestPoolPerPair(pools);
     expect(result).toHaveLength(1);
-    expect(result[0].poolAddress).toBeNull(); // V4 pool
+    expect(result[0].fee).toBe(8388608);
+  });
+
+  it("should drop the pair entirely when all pools have zero depth", () => {
+    const pools = [
+      {
+        ...basePool,
+        poolAddress:
+          "0x1111000000000000000000000000000000000001" as `0x${string}`,
+        baseTokenBalance: "0",
+        fee: 3000,
+        wethDepthWei: 0n,
+      },
+    ];
+
+    const result = selectBestPoolPerPair(pools);
+    expect(result).toHaveLength(0);
   });
 });
 

--- a/packages/net-score/src/abis/multi-version-uniswap-pool-info-retriever.json
+++ b/packages/net-score/src/abis/multi-version-uniswap-pool-info-retriever.json
@@ -3,7 +3,59 @@
     "type": "function",
     "name": "V4_POOL_MANAGER",
     "inputs": [],
-    "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "_getV4Liquidity",
+    "inputs": [
+      {
+        "name": "poolKey",
+        "type": "tuple",
+        "internalType": "struct PoolKey",
+        "components": [
+          {
+            "name": "currency0",
+            "type": "address",
+            "internalType": "Currency"
+          },
+          {
+            "name": "currency1",
+            "type": "address",
+            "internalType": "Currency"
+          },
+          {
+            "name": "fee",
+            "type": "uint24",
+            "internalType": "uint24"
+          },
+          {
+            "name": "tickSpacing",
+            "type": "int24",
+            "internalType": "int24"
+          },
+          {
+            "name": "hooks",
+            "type": "address",
+            "internalType": "contract IHooks"
+          }
+        ]
+      }
+    ],
+    "outputs": [
+      {
+        "name": "liquidity",
+        "type": "uint128",
+        "internalType": "uint128"
+      }
+    ],
     "stateMutability": "view"
   },
   {
@@ -25,8 +77,16 @@
             "type": "address",
             "internalType": "Currency"
           },
-          { "name": "fee", "type": "uint24", "internalType": "uint24" },
-          { "name": "tickSpacing", "type": "int24", "internalType": "int24" },
+          {
+            "name": "fee",
+            "type": "uint24",
+            "internalType": "uint24"
+          },
+          {
+            "name": "tickSpacing",
+            "type": "int24",
+            "internalType": "int24"
+          },
           {
             "name": "hooks",
             "type": "address",
@@ -36,7 +96,11 @@
       }
     ],
     "outputs": [
-      { "name": "sqrtPriceX96", "type": "uint160", "internalType": "uint160" }
+      {
+        "name": "sqrtPriceX96",
+        "type": "uint160",
+        "internalType": "uint160"
+      }
     ],
     "stateMutability": "view"
   },
@@ -69,8 +133,16 @@
             "type": "address",
             "internalType": "Currency"
           },
-          { "name": "fee", "type": "uint24", "internalType": "uint24" },
-          { "name": "tickSpacing", "type": "int24", "internalType": "int24" },
+          {
+            "name": "fee",
+            "type": "uint24",
+            "internalType": "uint24"
+          },
+          {
+            "name": "tickSpacing",
+            "type": "int24",
+            "internalType": "int24"
+          },
           {
             "name": "hooks",
             "type": "address",
@@ -78,7 +150,11 @@
           }
         ]
       },
-      { "name": "baseToken", "type": "address", "internalType": "address" }
+      {
+        "name": "baseToken",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
     "outputs": [
       {
@@ -91,8 +167,16 @@
             "type": "address",
             "internalType": "address"
           },
-          { "name": "token0", "type": "address", "internalType": "address" },
-          { "name": "token1", "type": "address", "internalType": "address" },
+          {
+            "name": "token0",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "token1",
+            "type": "address",
+            "internalType": "address"
+          },
           {
             "name": "token0Decimals",
             "type": "uint8",
@@ -122,6 +206,11 @@
             "name": "token1Balance",
             "type": "uint256",
             "internalType": "uint256"
+          },
+          {
+            "name": "liquidity",
+            "type": "uint128",
+            "internalType": "uint128"
           }
         ]
       }

--- a/packages/net-score/src/constants.ts
+++ b/packages/net-score/src/constants.ts
@@ -69,7 +69,7 @@ export const MULTI_VERSION_UNISWAP_BULK_POOL_FINDER = {
 } as const;
 
 export const MULTI_VERSION_UNISWAP_POOL_INFO_RETRIEVER = {
-  address: "0x7A9EF0AC6F6a254cd570B05D62D094D3aa5067f1" as Address,
+  address: "0x00000002986Ca76897216a8A3A7Db10FcB0d29Cf" as Address,
   abi: multiVersionUniswapPoolInfoRetrieverAbi as Abi,
 } as const;
 

--- a/packages/net-score/src/types.ts
+++ b/packages/net-score/src/types.ts
@@ -69,6 +69,8 @@ export type PoolDiscoveryResult = {
   price: number | null;
   fee: number;
   poolKey?: PoolKey;
+  /** V4 in-range concentrated liquidity (uint128) as a decimal string. "0" for V2/V3. */
+  liquidity?: string;
   balances?: {
     baseTokenBalance: string;
     token0Balance: string;

--- a/packages/net-score/src/utils/poolDiscovery.ts
+++ b/packages/net-score/src/utils/poolDiscovery.ts
@@ -42,6 +42,7 @@ type PoolFullInfo = {
   baseTokenBalance: bigint;
   token0Balance: bigint;
   token1Balance: bigint;
+  liquidity: bigint;
 };
 
 type PairMeta = {
@@ -76,8 +77,39 @@ const V4_HOOKS: Address[] = [
   "0xBDF938149ac6a781F94FAa0ed45E6A0e984c6544",
 ];
 
-const LIQUIDITY_THRESHOLD_TO_PREFER_V2_V3_POOLS = 0.1 * 1e18;
-const LIQUIDITY_THRESHOLD_TO_CONSIDER_V2_V3_POOLS = 0.01 * 1e18;
+const Q96 = BigInt(2) ** BigInt(96);
+const ZERO_BI = BigInt(0);
+
+// Derived WETH amount (wei) for a V4 pool at its current price.
+//   WETH = currency1:  L * sqrtPriceX96 / Q96
+//   WETH = currency0:  L * Q96 / sqrtPriceX96
+// Only counts in-range liquidity, which is sufficient for selection.
+function deriveV4WethDepthWei(
+  liquidity: bigint,
+  sqrtPriceX96: bigint,
+  wethIsCurrency1: boolean
+): bigint {
+  if (sqrtPriceX96 === ZERO_BI || liquidity === ZERO_BI) return ZERO_BI;
+  if (wethIsCurrency1) {
+    return (liquidity * sqrtPriceX96) / Q96;
+  }
+  return (liquidity * Q96) / sqrtPriceX96;
+}
+
+// WETH-side balance for a V2/V3 pool. Mirrors the V4 helper so selection can
+// compare both versions on the same `wethDepthWei` axis.
+function deriveV2V3WethDepthWei(
+  info: PoolFullInfo,
+  wethLower: string
+): bigint {
+  if ((info.token0 ?? "").toLowerCase() === wethLower) {
+    return BigInt(info.token0Balance ?? 0);
+  }
+  if ((info.token1 ?? "").toLowerCase() === wethLower) {
+    return BigInt(info.token1Balance ?? 0);
+  }
+  return BigInt(info.baseTokenBalance ?? 0);
+}
 
 // ============================================================================
 // Pure helper functions
@@ -357,58 +389,8 @@ export function constructPoolKey(
 }
 
 // ============================================================================
-// Pool selection helpers
+// Pool selection
 // ============================================================================
-
-function getWethBalanceWei(pool: {
-  token0?: Address;
-  token1?: Address;
-  token0Balance: string;
-  token1Balance: string;
-  baseTokenBalance: string;
-}, wethAddress: Address): number {
-  if (pool.token0?.toLowerCase() === wethAddress.toLowerCase()) {
-    return Number(pool.token0Balance);
-  } else if (pool.token1?.toLowerCase() === wethAddress.toLowerCase()) {
-    return Number(pool.token1Balance);
-  } else {
-    return Number(pool.baseTokenBalance);
-  }
-}
-
-function filterV2V3PoolsByLiquidity(
-  pools: PoolWithMeta[],
-  threshold: number,
-  wethAddress: Address
-): PoolWithMeta[] {
-  return pools.filter((pool) => {
-    if (!pool.poolAddress) return false;
-    const wethBalanceWei = getWethBalanceWei(pool, wethAddress);
-    return wethBalanceWei >= threshold;
-  });
-}
-
-function selectBestV2V3Pool(pools: PoolWithMeta[]): PoolWithMeta {
-  return pools.reduce((a, b) => {
-    const aIsV3 = a.fee > 0;
-    const bIsV3 = b.fee > 0;
-    if (aIsV3 && !bIsV3) return a;
-    if (!aIsV3 && bIsV3) return b;
-    return Number(a.baseTokenBalance) > Number(b.baseTokenBalance) ? a : b;
-  });
-}
-
-function selectBestV4Pool(pools: PoolWithMeta[]): PoolWithMeta {
-  return pools.reduce((a, b) => {
-    return a.fee < b.fee ? a : b;
-  });
-}
-
-function selectBestV2V3PoolByFee(pools: PoolWithMeta[]): PoolWithMeta {
-  return pools.reduce((a, b) => {
-    return a.fee < b.fee ? a : b;
-  });
-}
 
 type PoolWithMeta = {
   tokenAddress: string;
@@ -422,11 +404,15 @@ type PoolWithMeta = {
   token1Balance: string;
   fee: number;
   poolKey?: PoolKey;
+  liquidity: string;
+  wethDepthWei: bigint;
 };
 
+// V2/V3 WETH-side ERC20 balance and V4 in-range virtual reserve are both
+// expressed in WETH wei, so they're directly comparable. Pools with zero depth
+// are rejected to skip V4 ghost pools left behind after liquidity removal.
 export function selectBestPoolPerPair(
-  allPools: PoolWithMeta[],
-  wethAddress: Address
+  allPools: PoolWithMeta[]
 ): PoolWithMeta[] {
   const poolsByPair: Record<string, PoolWithMeta[]> = {};
 
@@ -440,38 +426,13 @@ export function selectBestPoolPerPair(
   }
 
   const bestPools: PoolWithMeta[] = [];
-  for (const [, group] of Object.entries(poolsByPair)) {
-    let best: PoolWithMeta | undefined;
-    if (group.length === 1) {
-      best = group[0];
-    } else {
-      const v2v3PoolsWithPreferredLiquidity = filterV2V3PoolsByLiquidity(
-        group,
-        LIQUIDITY_THRESHOLD_TO_PREFER_V2_V3_POOLS,
-        wethAddress
-      );
-
-      if (v2v3PoolsWithPreferredLiquidity.length > 0) {
-        best = selectBestV2V3Pool(v2v3PoolsWithPreferredLiquidity);
-      } else {
-        const v4Pools = group.filter((pool) => !pool.poolAddress);
-        if (v4Pools.length > 0) {
-          best = selectBestV4Pool(v4Pools);
-        } else {
-          const v2v3PoolsWithAcceptableLiquidity = filterV2V3PoolsByLiquidity(
-            group,
-            LIQUIDITY_THRESHOLD_TO_CONSIDER_V2_V3_POOLS,
-            wethAddress
-          );
-          if (v2v3PoolsWithAcceptableLiquidity.length > 0) {
-            best = selectBestV2V3PoolByFee(v2v3PoolsWithAcceptableLiquidity);
-          }
-        }
-      }
-    }
-    if (best) {
-      bestPools.push(best);
-    }
+  for (const group of Object.values(poolsByPair)) {
+    const withDepth = group.filter((p) => p.wethDepthWei > ZERO_BI);
+    if (withDepth.length === 0) continue;
+    const best = withDepth.reduce((a, b) =>
+      a.wethDepthWei > b.wethDepthWei ? a : b
+    );
+    bestPools.push(best);
   }
 
   return bestPools;
@@ -533,17 +494,34 @@ export async function discoverPools({
 
   if (!Array.isArray(poolInfos) || poolInfos.length === 0) return [];
 
+  const wethLower = wethAddress.toLowerCase();
+
   // Step 3: Map pool infos to enriched format
   const allPools = poolInfos
     .map((info: PoolFullInfo, index: number) => {
       const poolData = determinePoolVersion(discoveries, index);
       if (!poolData || !poolData.pair) return null;
 
+      const isV4 = poolData.version === 4;
+      const liquidity = BigInt(info.liquidity ?? 0);
+
+      let wethDepthWei: bigint;
+      if (isV4) {
+        const wethIsCurrency1 =
+          poolData.v4PoolKey!.currency1.toLowerCase() === wethLower;
+        wethDepthWei = deriveV4WethDepthWei(
+          liquidity,
+          BigInt(info.sqrtPriceX96 ?? 0),
+          wethIsCurrency1
+        );
+      } else {
+        wethDepthWei = deriveV2V3WethDepthWei(info, wethLower);
+      }
+
       return {
         tokenAddress: poolData.pair.tokenAddress,
         baseTokenAddress: poolData.pair.baseTokenAddress || wethAddress,
-        poolAddress:
-          poolData.version === 4 ? null : (info.poolAddress as Address),
+        poolAddress: isV4 ? null : (info.poolAddress as Address),
         price: calculatePoolPrice(info, poolData.pair, poolData.version),
         baseTokenBalance: String(info.baseTokenBalance || 0),
         token0: info.token0,
@@ -557,12 +535,14 @@ export async function discoverPools({
           poolData.version,
           poolData.v4PoolKey
         ),
+        liquidity: String(liquidity),
+        wethDepthWei,
       };
     })
     .filter((p): p is NonNullable<typeof p> => p !== null) as PoolWithMeta[];
 
   // Step 4: Select best pool per pair
-  const bestPools = selectBestPoolPerPair(allPools, wethAddress);
+  const bestPools = selectBestPoolPerPair(allPools);
 
   return bestPools.map(
     (pool): PoolDiscoveryResult => ({
@@ -572,6 +552,7 @@ export async function discoverPools({
       price: pool.price,
       fee: pool.fee,
       poolKey: pool.poolKey,
+      liquidity: pool.liquidity,
       balances: {
         baseTokenBalance: pool.baseTokenBalance,
         token0Balance: pool.token0Balance,


### PR DESCRIPTION
## Summary

The follow-up retriever upgrade into the `@net-protocol/score` package. V4 in-range liquidity is now surfaced by the bulk pool info retriever, so selection can compare V2/V3 and V4 pools on the same WETH-depth axis instead of using version-preference heuristics.

Note: `@net-protocol/score@0.1.6` was previously bumped on main without the underlying code change, so this PR bumps to `0.1.7` (and `@net-protocol/cli` to `0.1.48` with score pin `^0.1.7` so consumers force-upgrade).

## The bug

V4 pools don't expose ERC20 balances per pool (liquidity lives in positions on the singleton PoolManager), so the old retriever returned `0` for V4 `token0Balance` / `token1Balance`. The package compensated with version-preference rules — any V2/V3 pool with ≥ 0.1 ETH won unconditionally, and among V4 pools "lowest fee won" (which makes the dynamic-fee flag `8388608` always lose to static-fee variants, including stale empty ghost pools).

This caused two production failure modes on Base:
1. For tokens whose real liquidity lives in a hook-bearing V4 pool, an empty V4 ghost pool (fee=10000, hooks=0x0, liquidity withdrawn) was selected. Stale `sqrtPriceX96` produced wrong FDVs — e.g. `0xbf8e8f0e8866a7052f948c16508644347c57aba3` showed FDV ~\$263k vs real ~\$11.8M.
2. For tokens with a V2/V3 above 0.1 ETH and a much deeper V4 (e.g. gitlawb `0x5F980D...`: V3 with 5.74 ETH vs V4 with 371 ETH), V2/V3 won unconditionally.

## Changes

- **ABI + address:** `MULTI_VERSION_UNISWAP_POOL_INFO_RETRIEVER` bumped to `0x00000002986Ca76897216a8A3A7Db10FcB0d29Cf` (Base 8453). ABI regenerated with the new `liquidity uint128` field on `PoolFullInfo` and the new `_getV4Liquidity(PoolKey)` external.
- **Selection rewrite (`src/utils/poolDiscovery.ts`):** drop `LIQUIDITY_THRESHOLD_TO_PREFER_V2_V3_POOLS` / `LIQUIDITY_THRESHOLD_TO_CONSIDER_V2_V3_POOLS` and all version-specific tiebreaks. New algorithm: per pair, compute `wethDepthWei` per pool (V2/V3 = WETH-side ERC20 balance; V4 = `L * sqrtPriceX96 / Q96` or `L * Q96 / sqrtPriceX96` when WETH is `currency0`), filter pools with depth > 0 (kills ghost pools), pick the max.
- **Public type (`src/types.ts`):** `PoolDiscoveryResult` gains optional `liquidity?: string` so external consumers can see V4 in-range liquidity. `wethDepthWei` stays internal.
- **Tests:** replaced the two version-preference tests with four depth-based tests covering V4-deeper-than-V2V3, V2V3-deeper-than-V4, the ghost-pool kill, and the all-zero-depth drop case. 104/104 pass.
- **Version bumps:** `@net-protocol/score` 0.1.6 → 0.1.7, `@net-protocol/cli` 0.1.47 → 0.1.48 (score pin `^0.1.6` → `^0.1.7`).

## Net-public consumers

Only `packages/net-cli/src/commands/upvote/upvote-token.ts` consumes `discoverTokenPool` directly, and it only reads `poolKey` / `fee` from the result — fully compatible with the additive type changes. Once published, CLI upvotes will use the corrected pool selection automatically.

## Live verification

Run against Base mainnet:

| Token | Selected pool | hook | fee | wethDepthWei |
|---|---|---|---|---|
| `0xbf8e8f0e8866a7052f948c16508644347c57aba3` | V4 | `0xbB7784A4...` ✓ | 8388608 ✓ | ~216 ETH |
| `0x5F980Dcfc4c0fa3911554cf5ab288ed0eb13DBa3` (gitlawb) | V4 | `0xbB7784A4...` ✓ | 8388608 ✓ | ~388 ETH |

Implied FDV at correct supply matches dexscreener for both.

## Test plan

- [ ] `cd packages/net-score && yarn test` — 104/104 pass
- [ ] `yarn workspace @net-protocol/score build` — clean
- [ ] One-off live fixture check against Base mainnet for `0xbf8e8f...` and `0x5F980D...` — both return V4 with hook `0xbB7784A4...`
- [ ] Publish `@net-protocol/score@0.1.7` and `@net-protocol/cli@0.1.48`
- [ ] Follow-up: bump the net website's `@net-protocol/score` dependency (separate PR on net repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)