### PR TITLE
Add useDiscoverPools React hook to @net-protocol/score

### DIFF
--- a/packages/net-score/package.json
+++ b/packages/net-score/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@net-protocol/score",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Score/upvoting functionality for Net Protocol - on-chain scoring system",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/net-score/src/hooks/useDiscoverPools.ts
+++ b/packages/net-score/src/hooks/useDiscoverPools.ts
@@ -1,0 +1,34 @@
+import { useQuery, skipToken } from "@tanstack/react-query";
+import { usePublicClient } from "wagmi";
+import { discoverPools } from "../utils/poolDiscovery";
+import type { UseDiscoverPoolsOptions } from "../types";
+
+export function useDiscoverPools({
+  chainId,
+  pairs,
+  enabled = true,
+}: UseDiscoverPoolsOptions) {
+  const publicClient = usePublicClient({ chainId });
+  const canRun = enabled && !!publicClient && pairs.length > 0;
+
+  // Normalize addresses in the queryKey so case drift doesn't fragment the cache.
+  // discoverPools itself is already case-insensitive internally.
+  const keyPairs = pairs.map((p) => [
+    p.tokenAddress.toLowerCase(),
+    p.baseTokenAddress?.toLowerCase(),
+  ]);
+
+  const { data, isLoading, error, refetch } = useQuery({
+    queryKey: ["discoverPools", chainId, keyPairs],
+    queryFn: canRun
+      ? () => discoverPools({ publicClient, pairs, chainId })
+      : skipToken,
+  });
+
+  return {
+    pools: data ?? [],
+    isLoading,
+    error,
+    refetch,
+  };
+}

--- a/packages/net-score/src/index.ts
+++ b/packages/net-score/src/index.ts
@@ -63,6 +63,7 @@ export type {
   DecodedStrategyMetadata,
   DecodedUpvoteBlob,
   PoolDiscoveryResult,
+  PoolDiscoveryPair,
   ScoreClientOptions,
   GetUpvotesOptions,
   GetUpvotesForItemsOptions,

--- a/packages/net-score/src/react.ts
+++ b/packages/net-score/src/react.ts
@@ -11,6 +11,9 @@ export { useUserUpvotesReceivedPerTokenBatch } from "./hooks/useUserUpvotesRecei
 export { useUpvoteUser } from "./hooks/useUpvoteUser";
 export { useUpvotePrice } from "./hooks/useUpvotePrice";
 
+// Pool discovery hook
+export { useDiscoverPools } from "./hooks/useDiscoverPools";
+
 // Re-export utilities commonly needed with hooks
 export {
   getTokenScoreKey,
@@ -31,4 +34,8 @@ export type {
   UseUserUpvotesReceivedPerTokenBatchOptions,
   UseUpvoteUserOptions,
   UseUpvotePriceOptions,
+  UseDiscoverPoolsOptions,
+  PoolDiscoveryPair,
+  PoolDiscoveryResult,
+  PoolKey,
 } from "./types";

--- a/packages/net-score/src/types.ts
+++ b/packages/net-score/src/types.ts
@@ -169,3 +169,14 @@ export type UseUpvotePriceOptions = {
   chainId: number;
   enabled?: boolean;
 };
+
+export type PoolDiscoveryPair = {
+  tokenAddress: string;
+  baseTokenAddress?: string;
+};
+
+export type UseDiscoverPoolsOptions = {
+  chainId: number;
+  pairs: PoolDiscoveryPair[];
+  enabled?: boolean;
+};

--- a/packages/net-score/src/utils/poolDiscovery.ts
+++ b/packages/net-score/src/utils/poolDiscovery.ts
@@ -6,13 +6,13 @@ import {
   getWethAddress,
   NULL_ADDRESS,
 } from "../constants";
-import type { PoolKey, PoolDiscoveryResult } from "../types";
+import type { PoolKey, PoolDiscoveryResult, PoolDiscoveryPair } from "../types";
 
 // ============================================================================
 // Internal types
 // ============================================================================
 
-type PairInput = { tokenAddress: string; baseTokenAddress?: string };
+type PairInput = PoolDiscoveryPair;
 
 type V4PoolKeyLike = {
   currency0: Address;
@@ -452,7 +452,7 @@ export async function discoverPools({
   chainId = 8453,
 }: {
   publicClient: PublicClient;
-  pairs: { tokenAddress: string; baseTokenAddress?: string }[];
+  pairs: PoolDiscoveryPair[];
   /** Chain ID used to resolve the WETH address. Defaults to Base (8453). */
   chainId?: number;
 }): Promise<PoolDiscoveryResult[]> {


### PR DESCRIPTION
## Summary

Adds a new React hook `useDiscoverPools` to `@net-protocol/score/react`. It wraps the existing async `discoverPools` utility with a wagmi-compatible interface, returning the same `{ data, isLoading, error, refetch }` shape used by every other hook in the package.

Motivation: the net website currently has its own duplicate of pool discovery in `website/src/uniswapPoolUtils.ts` (the version-preference-vs-depth bug we shipped fixes for in #832/#833 lived in two places at once). With this hook, the website can migrate `useMultiplePoolInfo` consumers to `useDiscoverPools` from the score package and delete the duplicated algorithm. That's a follow-up PR on net.

## Design

```ts
const { pools, isLoading, error, refetch } = useDiscoverPools({
  chainId: 8453,
  pairs: [{ tokenAddress }],
  enabled: true,
});
```

- Uses **TanStack Query's `skipToken`** instead of `enabled: false` + `!` assertions. When the public client isn't ready, `queryFn` is set to `skipToken`, which both prevents execution and narrows the type so `publicClient` is non-null inside the closure.
- Acquires the viem `PublicClient` via wagmi's `usePublicClient({ chainId })`, matching how every other hook in this package gets chain state.
- TanStack Query's deep-equality on `queryKey` means callers don't need to `useMemo` their `pairs` array.

## API additions to `@net-protocol/score/react`

- `useDiscoverPools` — the hook
- `UseDiscoverPoolsOptions` — the options type
- `PoolDiscoveryResult` and `PoolKey` — re-exported from `/react` so hook consumers don't need to dual-import from the main entry

## Test plan

- [x] Existing tests pass — 104/104
- [x] `yarn build` succeeds; `dist/react.d.ts` contains `useDiscoverPools` and `UseDiscoverPoolsOptions`
- [x] `yarn tsc --noEmit` clean
- [ ] Publish `@net-protocol/score@0.1.8`
- [ ] Follow-up: net website PR (on branch `score-package-consolidation`) — migrate `useMultiplePoolInfo` consumers and delete the duplicate algorithm in `uniswapPoolUtils.ts`

## Notes

No hook tests were added — the package has zero React hook tests today (all 9 existing hooks are tested only via the `Client` layer). Adding the first one is a separate scaffolding decision; the hook is a thin wrapper over `discoverPools` which is already covered by `poolDiscovery.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)