### PR TITLE
Reach NFT/ERC20 parity in @net-protocol/bazaar SDK + CLI

### DIFF
--- a/packages/net-bazaar/package.json
+++ b/packages/net-bazaar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@net-protocol/bazaar",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "description": "SDK for Net Bazaar - a decentralized bazaar storing all orders onchain via Seaport",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/net-bazaar/package.json
+++ b/packages/net-bazaar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@net-protocol/bazaar",
-  "version": "0.1.20",
+  "version": "0.2.0",
   "description": "SDK for Net Bazaar - a decentralized bazaar storing all orders onchain via Seaport",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/net-bazaar/src/__tests__/cancelOrders.test.ts
+++ b/packages/net-bazaar/src/__tests__/cancelOrders.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from "vitest";
+import { BazaarClient } from "../client/BazaarClient";
+import {
+  ItemType,
+  OrderType,
+  SeaportOrderStatus,
+  type Erc20Offer,
+  type Erc20Listing,
+} from "../types";
+import { getSeaportAddress } from "../chainConfig";
+
+const CHAIN_ID = 8453; // Base
+const OFFERER = "0x1234567890123456789012345678901234567890" as `0x${string}`;
+const TOKEN_ADDRESS = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" as `0x${string}`;
+const WETH = "0x4200000000000000000000000000000000000006" as `0x${string}`;
+
+function makeBaseOrderComponents() {
+  return {
+    offerer: OFFERER,
+    zone: "0x0000000000000000000000000000000000000000" as `0x${string}`,
+    offer: [
+      {
+        itemType: ItemType.ERC20,
+        token: WETH,
+        identifierOrCriteria: BigInt(0),
+        startAmount: BigInt("500000000000000000"),
+        endAmount: BigInt("500000000000000000"),
+      },
+    ],
+    consideration: [
+      {
+        itemType: ItemType.ERC20,
+        token: TOKEN_ADDRESS,
+        identifierOrCriteria: BigInt(0),
+        startAmount: BigInt("1000000000000000000"),
+        endAmount: BigInt("1000000000000000000"),
+        recipient: OFFERER,
+      },
+    ],
+    orderType: OrderType.FULL_RESTRICTED,
+    startTime: BigInt(0),
+    endTime: BigInt(Math.floor(Date.now() / 1000) + 86400),
+    zoneHash: "0x0000000000000000000000000000000000000000000000000000000000000000" as `0x${string}`,
+    salt: BigInt(42),
+    conduitKey: "0x0000000000000000000000000000000000000000000000000000000000000000" as `0x${string}`,
+    totalOriginalConsiderationItems: BigInt(1),
+    counter: BigInt(0),
+  };
+}
+
+describe("BazaarClient.prepareCancelErc20Offer", () => {
+  const client = new BazaarClient({
+    chainId: CHAIN_ID,
+    rpcUrl: "https://example-rpc.invalid",
+  });
+
+  it("routes through Seaport cancel with the offer's orderComponents", () => {
+    const orderComponents = makeBaseOrderComponents();
+    const offer: Erc20Offer = {
+      maker: OFFERER,
+      tokenAddress: TOKEN_ADDRESS,
+      tokenAmount: BigInt("1000000000000000000"),
+      priceWei: BigInt("500000000000000000"),
+      pricePerTokenWei: BigInt("500000000000000000"),
+      price: 0.5,
+      pricePerToken: "0.5",
+      currency: "eth",
+      expirationDate: Number(orderComponents.endTime),
+      orderHash: "0xabcd" as `0x${string}`,
+      orderStatus: SeaportOrderStatus.OPEN,
+      messageData: "0x" as `0x${string}`,
+      orderComponents,
+    };
+
+    const tx = client.prepareCancelErc20Offer(offer);
+    expect(tx.to).toBe(getSeaportAddress(CHAIN_ID));
+    expect(tx.functionName).toBe("cancel");
+    expect(Array.isArray(tx.args)).toBe(true);
+    const [orders] = tx.args as [unknown[]];
+    expect(orders).toHaveLength(1);
+    expect((orders[0] as any).offerer).toBe(OFFERER);
+    expect((orders[0] as any).counter).toBe(BigInt(0));
+  });
+
+  it("throws when the offer has no orderComponents", () => {
+    const offer = {
+      maker: OFFERER,
+      tokenAddress: TOKEN_ADDRESS,
+      tokenAmount: BigInt(0),
+      priceWei: BigInt(0),
+      pricePerTokenWei: BigInt(0),
+      price: 0,
+      pricePerToken: "0",
+      currency: "eth",
+      expirationDate: 0,
+      orderHash: "0xabcd" as `0x${string}`,
+      orderStatus: SeaportOrderStatus.OPEN,
+      messageData: "0x" as `0x${string}`,
+      // orderComponents intentionally omitted
+    } as Erc20Offer;
+
+    expect(() => client.prepareCancelErc20Offer(offer)).toThrow(
+      /order components/i
+    );
+  });
+});
+
+describe("BazaarClient.prepareCancelErc20Listing", () => {
+  const client = new BazaarClient({
+    chainId: CHAIN_ID,
+    rpcUrl: "https://example-rpc.invalid",
+  });
+
+  it("routes through Seaport cancel with the listing's orderComponents", () => {
+    const orderComponents = makeBaseOrderComponents();
+    const listing: Erc20Listing = {
+      maker: OFFERER,
+      tokenAddress: TOKEN_ADDRESS,
+      tokenAmount: BigInt("1000000000000000000"),
+      priceWei: BigInt("500000000000000000"),
+      pricePerTokenWei: BigInt("500000000000000000"),
+      price: 0.5,
+      pricePerToken: "0.5",
+      currency: "eth",
+      expirationDate: Number(orderComponents.endTime),
+      orderHash: "0xabcd" as `0x${string}`,
+      orderStatus: SeaportOrderStatus.OPEN,
+      messageData: "0x" as `0x${string}`,
+      orderComponents,
+    };
+
+    const tx = client.prepareCancelErc20Listing(listing);
+    expect(tx.to).toBe(getSeaportAddress(CHAIN_ID));
+    expect(tx.functionName).toBe("cancel");
+  });
+});

--- a/packages/net-bazaar/src/__tests__/chainConfig.test.ts
+++ b/packages/net-bazaar/src/__tests__/chainConfig.test.ts
@@ -8,6 +8,8 @@ import {
   getSeaportAddress,
   getWrappedNativeCurrency,
   getCurrencySymbol,
+  getNftFeeBps,
+  getErc20FeeBps,
 } from "../chainConfig";
 
 describe("chainConfig", () => {
@@ -113,6 +115,33 @@ describe("chainConfig", () => {
 
     it("returns degen for Degen", () => {
       expect(getCurrencySymbol(666666666)).toBe("degen");
+    });
+  });
+
+  describe("fee bps", () => {
+    it("Base: 0% for NFT and ERC20", () => {
+      expect(getNftFeeBps(8453)).toBe(0);
+      expect(getErc20FeeBps(8453)).toBe(0);
+    });
+
+    it("Ethereum Mainnet: 0% for NFT and ERC20", () => {
+      expect(getNftFeeBps(1)).toBe(0);
+      expect(getErc20FeeBps(1)).toBe(0);
+    });
+
+    it("HyperEVM: 0% for NFT and ERC20", () => {
+      expect(getNftFeeBps(999)).toBe(0);
+      expect(getErc20FeeBps(999)).toBe(0);
+    });
+
+    it("default-fee chain (Degen): 5% NFT, 1% ERC20", () => {
+      expect(getNftFeeBps(666666666)).toBe(500);
+      expect(getErc20FeeBps(666666666)).toBe(100);
+    });
+
+    it("unknown chain falls back to defaults", () => {
+      expect(getNftFeeBps(99999)).toBe(500);
+      expect(getErc20FeeBps(99999)).toBe(100);
     });
   });
 });

--- a/packages/net-bazaar/src/__tests__/orderCreation.test.ts
+++ b/packages/net-bazaar/src/__tests__/orderCreation.test.ts
@@ -182,7 +182,7 @@ describe("buildCollectionOfferOrderComponents", () => {
 });
 
 describe("buildErc20OfferOrderComponents", () => {
-  it("builds an ERC20 offer", () => {
+  it("builds an ERC20 offer (chain 8453, 0% fee)", () => {
     const { orderParameters } = buildErc20OfferOrderComponents(
       {
         tokenAddress: TOKEN_ADDRESS,
@@ -197,15 +197,35 @@ describe("buildErc20OfferOrderComponents", () => {
     // Offer: WETH
     expect(orderParameters.offer[0].itemType).toBe(ItemType.ERC20);
 
-    // Consideration: ERC20 tokens
+    // Consideration: ERC20 tokens (no fee item on a 0% chain)
+    expect(orderParameters.consideration).toHaveLength(1);
     expect(orderParameters.consideration[0].itemType).toBe(ItemType.ERC20);
     expect(orderParameters.consideration[0].token).toBe(TOKEN_ADDRESS);
     expect(orderParameters.consideration[0].startAmount).toBe(BigInt("1000000"));
   });
+
+  it("applies 1% ERC20 fee on default-fee chains (not 5% NFT fee)", () => {
+    const { orderParameters } = buildErc20OfferOrderComponents(
+      {
+        tokenAddress: TOKEN_ADDRESS,
+        tokenAmount: BigInt("1000000"),
+        priceWei: BigInt("1000000000000000000"),
+        offerer: OFFERER,
+      },
+      84532, // baseSepolia: default fees (5% NFT, 1% ERC20)
+      BigInt(0)
+    );
+
+    // Consideration[1] is the fee item (WETH to feeCollector)
+    expect(orderParameters.consideration).toHaveLength(2);
+    const feeAmount = orderParameters.consideration[1].startAmount;
+    // Fee = ceiling(1e18 * 100 / 10000) = 10000000000000000 (1%)
+    expect(feeAmount).toBe(BigInt("10000000000000000"));
+  });
 });
 
 describe("buildErc20ListingOrderComponents", () => {
-  it("builds an ERC20 listing with fee (chain 84532, 5%)", () => {
+  it("applies 1% ERC20 fee on default-fee chains (not 5% NFT fee)", () => {
     const { orderParameters } = buildErc20ListingOrderComponents(
       {
         tokenAddress: TOKEN_ADDRESS,
@@ -227,8 +247,8 @@ describe("buildErc20ListingOrderComponents", () => {
 
     const sellerAmount = orderParameters.consideration[0].startAmount;
     const feeAmount = orderParameters.consideration[1].startAmount;
-    // Fee = ceiling(1e18 * 500 / 10000) = 50000000000000000
-    expect(feeAmount).toBe(BigInt("50000000000000000"));
+    // Fee = ceiling(1e18 * 100 / 10000) = 10000000000000000 (1%)
+    expect(feeAmount).toBe(BigInt("10000000000000000"));
     expect(sellerAmount + feeAmount).toBe(BigInt("1000000000000000000"));
   });
 

--- a/packages/net-bazaar/src/__tests__/parsing.test.ts
+++ b/packages/net-bazaar/src/__tests__/parsing.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { encodeAbiParameters } from "viem";
-import { parseListingFromMessage } from "../utils/parsing";
+import { parseListingFromMessage, parseErc20ListingFromMessage } from "../utils/parsing";
 import { BAZAAR_SUBMISSION_ABI } from "../abis";
 import { NET_SEAPORT_PRIVATE_ORDER_ZONE_ADDRESS, NET_SEAPORT_ZONE_ADDRESS } from "../chainConfig";
 import { ItemType, OrderType } from "../types";
@@ -164,5 +164,118 @@ describe("parseListingFromMessage", () => {
 
     const listing = parseListingFromMessage(message as any, 8453);
     expect(listing).toBeNull();
+  });
+});
+
+// Helper to create a mock ERC20 listing message (seller offers ERC20, receives native)
+function createMockErc20ListingMessage({
+  offerer = "0x1234567890123456789012345678901234567890" as `0x${string}`,
+  zone = NET_SEAPORT_ZONE_ADDRESS as `0x${string}`,
+  zoneHash = "0x0000000000000000000000000000000000000000000000000000000000000000" as `0x${string}`,
+  tokenAddress = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" as `0x${string}`,
+  tokenAmount = BigInt("1000000000000000000"), // 1 token (18 decimals)
+  price = BigInt("500000000000000000"), // 0.5 ETH
+}: {
+  offerer?: `0x${string}`;
+  zone?: `0x${string}`;
+  zoneHash?: `0x${string}`;
+  tokenAddress?: `0x${string}`;
+  tokenAmount?: bigint;
+  price?: bigint;
+} = {}) {
+  const submission = {
+    parameters: {
+      offerer,
+      zone,
+      offer: [
+        {
+          itemType: ItemType.ERC20,
+          token: tokenAddress,
+          identifierOrCriteria: BigInt(0),
+          startAmount: tokenAmount,
+          endAmount: tokenAmount,
+        },
+      ],
+      consideration: [
+        {
+          itemType: ItemType.NATIVE,
+          token: "0x0000000000000000000000000000000000000000" as `0x${string}`,
+          identifierOrCriteria: BigInt(0),
+          startAmount: price,
+          endAmount: price,
+          recipient: offerer,
+        },
+      ],
+      orderType: OrderType.FULL_RESTRICTED,
+      startTime: BigInt(0),
+      endTime: BigInt(Math.floor(Date.now() / 1000) + 86400),
+      zoneHash,
+      salt: BigInt(12345),
+      conduitKey: "0x0000000000000000000000000000000000000000000000000000000000000000" as `0x${string}`,
+      totalOriginalConsiderationItems: BigInt(1),
+    },
+    counter: BigInt(0),
+    signature: "0x1234" as `0x${string}`,
+  };
+
+  const data = encodeAbiParameters(BAZAAR_SUBMISSION_ABI, [submission]);
+
+  return {
+    sender: offerer,
+    text: "",
+    data,
+    timestamp: BigInt(Math.floor(Date.now() / 1000)),
+  };
+}
+
+describe("parseErc20ListingFromMessage", () => {
+  it("parses a basic public ERC20 listing", () => {
+    const message = createMockErc20ListingMessage();
+    const listing = parseErc20ListingFromMessage(message as any, 8453, 18);
+
+    expect(listing).not.toBeNull();
+    expect(listing!.maker).toBe("0x1234567890123456789012345678901234567890");
+    expect(listing!.tokenAddress.toLowerCase()).toBe("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+    expect(listing!.tokenAmount).toBe(BigInt("1000000000000000000"));
+    expect(listing!.priceWei).toBe(BigInt("500000000000000000"));
+    expect(listing!.currency).toBe("eth");
+    expect(listing!.targetFulfiller).toBeUndefined();
+  });
+
+  it("sets targetFulfiller for private ERC20 listings using the private order zone", () => {
+    const privateZoneHash = "0x00000000000000000000000000000000000000000000000000000000deadbeef" as `0x${string}`;
+    const message = createMockErc20ListingMessage({
+      zone: NET_SEAPORT_PRIVATE_ORDER_ZONE_ADDRESS,
+      zoneHash: privateZoneHash,
+    });
+
+    const listing = parseErc20ListingFromMessage(message as any, 8453, 18);
+
+    expect(listing).not.toBeNull();
+    expect(listing!.targetFulfiller).toBe(privateZoneHash);
+  });
+
+  it("does not set targetFulfiller when zone is private but zoneHash is zero", () => {
+    const message = createMockErc20ListingMessage({
+      zone: NET_SEAPORT_PRIVATE_ORDER_ZONE_ADDRESS,
+      zoneHash: "0x0000000000000000000000000000000000000000000000000000000000000000",
+    });
+
+    const listing = parseErc20ListingFromMessage(message as any, 8453, 18);
+
+    expect(listing).not.toBeNull();
+    expect(listing!.targetFulfiller).toBeUndefined();
+  });
+
+  it("does not set targetFulfiller for non-private zone even with non-zero zoneHash", () => {
+    const message = createMockErc20ListingMessage({
+      zone: NET_SEAPORT_ZONE_ADDRESS,
+      zoneHash: "0x00000000000000000000000000000000000000000000000000000000deadbeef",
+    });
+
+    const listing = parseErc20ListingFromMessage(message as any, 8453, 18);
+
+    expect(listing).not.toBeNull();
+    expect(listing!.targetFulfiller).toBeUndefined();
   });
 });

--- a/packages/net-bazaar/src/chainConfig.ts
+++ b/packages/net-bazaar/src/chainConfig.ts
@@ -25,6 +25,8 @@ export interface BazaarChainConfig {
   feeCollectorAddress: `0x${string}`;
   /** Fee in basis points for NFT trades */
   nftFeeBps: number;
+  /** Fee in basis points for ERC20 trades (defaults to DEFAULT_ERC20_FEE_BPS) */
+  erc20FeeBps?: number;
   /** Wrapped native currency (WETH, etc.) */
   wrappedNativeCurrency: WrappedNativeCurrency;
   /** Address with high ETH balance for Seaport checks */
@@ -40,6 +42,7 @@ const DEFAULT_COLLECTION_OFFERS_ADDRESS = "0x0000000D43423E0A12CecB307a74591999b
 const DEFAULT_FEE_COLLECTOR_ADDRESS = "0x32D16C15410248bef498D7aF50D10Db1a546b9E5" as const;
 const DEFAULT_ERC20_BAZAAR_ADDRESS = "0x00000000a2d173a4610c85c7471a25b6bc216a70" as const;
 const DEFAULT_NFT_FEE_BPS = 500; // 5%
+const DEFAULT_ERC20_FEE_BPS = 100; // 1%
 
 // Helper contract addresses (same on all chains)
 export const BULK_SEAPORT_ORDER_STATUS_FETCHER_ADDRESS = "0x0000009112ABCE652674b4fE3eD9C765B22d11A7" as const;
@@ -64,6 +67,7 @@ const BAZAAR_CHAIN_CONFIGS: Record<number, BazaarChainConfig> = {
     seaportAddress: DEFAULT_SEAPORT_ADDRESS,
     feeCollectorAddress: "0x66547ff4f7206e291F7BC157b54C026Fc6660961",
     nftFeeBps: 0, // 0% on Ethereum Mainnet
+    erc20FeeBps: 0,
     wrappedNativeCurrency: {
       address: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
       name: "Wrapped Ether",
@@ -81,6 +85,7 @@ const BAZAAR_CHAIN_CONFIGS: Record<number, BazaarChainConfig> = {
     seaportAddress: DEFAULT_SEAPORT_ADDRESS,
     feeCollectorAddress: "0x66547ff4f7206e291F7BC157b54C026Fc6660961",
     nftFeeBps: 0, // 0% on Base
+    erc20FeeBps: 0,
     wrappedNativeCurrency: {
       address: "0x4200000000000000000000000000000000000006",
       name: "Wrapped Ether",
@@ -176,6 +181,7 @@ const BAZAAR_CHAIN_CONFIGS: Record<number, BazaarChainConfig> = {
     seaportAddress: DEFAULT_SEAPORT_ADDRESS,
     feeCollectorAddress: "0x66547ff4f7206e291F7BC157b54C026Fc6660961",
     nftFeeBps: 0, // 0% on HyperEVM
+    erc20FeeBps: 0,
     wrappedNativeCurrency: {
       address: "0x5555555555555555555555555555555555555555",
       name: "Wrapped Hype",
@@ -286,6 +292,13 @@ export function getFeeCollectorAddress(chainId: number): `0x${string}` {
  */
 export function getNftFeeBps(chainId: number): number {
   return BAZAAR_CHAIN_CONFIGS[chainId]?.nftFeeBps ?? DEFAULT_NFT_FEE_BPS;
+}
+
+/**
+ * Get ERC20 trade fee in basis points for a chain
+ */
+export function getErc20FeeBps(chainId: number): number {
+  return BAZAAR_CHAIN_CONFIGS[chainId]?.erc20FeeBps ?? DEFAULT_ERC20_FEE_BPS;
 }
 
 /**

--- a/packages/net-bazaar/src/client/BazaarClient.ts
+++ b/packages/net-bazaar/src/client/BazaarClient.ts
@@ -213,6 +213,38 @@ export class BazaarClient {
   }
 
   /**
+   * Pre-warm the decimals cache for every unique token referenced by `messages`
+   * on the given Seaport order side, in parallel. Returns a lookup function that
+   * resolves decimals synchronously (or returns undefined if the message could
+   * not be decoded and decimals are unknown — caller should skip such messages
+   * rather than silently default to 18).
+   */
+  private async warmTokenDecimals(
+    messages: NetMessage[],
+    side: "offer" | "consideration"
+  ): Promise<(message: NetMessage) => number | undefined> {
+    const tokenByMessage = new Map<NetMessage, `0x${string}`>();
+    for (const message of messages) {
+      try {
+        const order = getSeaportOrderFromMessageData(message.data as `0x${string}`);
+        const token = order.parameters[side]?.[0]?.token as `0x${string}` | undefined;
+        if (token) tokenByMessage.set(message, token);
+      } catch {
+        // skip; parser will reject the message later
+      }
+    }
+
+    const uniqueTokens = [...new Set(tokenByMessage.values())];
+    await Promise.all(uniqueTokens.map((t) => this.fetchTokenDecimals(t)));
+
+    return (message: NetMessage) => {
+      const token = tokenByMessage.get(message);
+      if (!token) return undefined;
+      return tokenDecimalsCache.get(`${this.chainId}:${token.toLowerCase()}`);
+    };
+  }
+
+  /**
    * Get valid NFT listings for a collection
    *
    * Returns listings that are:
@@ -557,9 +589,11 @@ export class BazaarClient {
   }
 
   /**
-   * Get valid ERC20 offers for a token
+   * Get valid ERC20 offers for a token (or recent offers across all tokens
+   * when tokenAddress is omitted).
    *
-   * ERC20 offers are only available on Base (8453) and HyperEVM (999).
+   * ERC20 offers are only available on chains with an erc20OffersAddress
+   * configured (see chainConfig.ts).
    *
    * Returns offers that are:
    * - OPEN status (not filled, cancelled, or expired)
@@ -569,21 +603,21 @@ export class BazaarClient {
    * Results are sorted by price per token (highest first)
    */
   async getErc20Offers(options: GetErc20OffersOptions): Promise<Erc20Offer[]> {
-    const { tokenAddress, excludeMaker, maxMessages = 200 } = options;
+    const { tokenAddress, maxMessages = 200 } = options;
     const erc20OffersAddress = getErc20OffersAddress(this.chainId);
 
-    // ERC20 offers only available on Base and HyperEVM
+    // ERC20 offers only available on chains with the contract deployed
     if (!erc20OffersAddress) {
       return [];
     }
 
+    const filter = {
+      appAddress: erc20OffersAddress,
+      topic: tokenAddress?.toLowerCase(),
+    };
+
     // Get message count
-    const count = await this.netClient.getMessageCount({
-      filter: {
-        appAddress: erc20OffersAddress,
-        topic: tokenAddress.toLowerCase(),
-      },
-    });
+    const count = await this.netClient.getMessageCount({ filter });
 
     if (count === 0) {
       return [];
@@ -592,10 +626,7 @@ export class BazaarClient {
     // Fetch messages (most recent)
     const startIndex = Math.max(0, count - maxMessages);
     const messages = await this.netClient.getMessages({
-      filter: {
-        appAddress: erc20OffersAddress,
-        topic: tokenAddress.toLowerCase(),
-      },
+      filter,
       startIndex,
       endIndex: count,
     });
@@ -621,13 +652,25 @@ export class BazaarClient {
       return [];
     }
 
-    // Fetch token decimals for accurate price-per-token computation
-    const tokenDecimals = await this.fetchTokenDecimals(tokenAddress);
+    // Resolve decimals: one shot for single-token queries, otherwise warm the
+    // cache for every distinct consideration token in parallel before parsing.
+    let resolveDecimals: (message: NetMessage) => number | undefined;
+    if (tokenAddress) {
+      const presetDecimals = await this.fetchTokenDecimals(tokenAddress);
+      resolveDecimals = () => presetDecimals;
+    } else {
+      resolveDecimals = await this.warmTokenDecimals(messages, "consideration");
+    }
 
     // Parse messages into offers
     let offers: Erc20Offer[] = [];
     for (const message of messages) {
-      const offer = parseErc20OfferFromMessage(message, this.chainId, tokenDecimals);
+      const decimals = resolveDecimals(message);
+      // Cross-token path: skip messages whose token decimals couldn't be resolved
+      // rather than silently mis-pricing them.
+      if (decimals === undefined) continue;
+
+      const offer = parseErc20OfferFromMessage(message, this.chainId, decimals);
       if (!offer) continue;
 
       // Validate WETH token matches
@@ -637,8 +680,8 @@ export class BazaarClient {
         continue;
       }
 
-      // Validate the consideration token matches the requested token
-      if (offer.tokenAddress.toLowerCase() !== tokenAddress.toLowerCase()) {
+      // Validate the consideration token matches the requested token (when filtering)
+      if (tokenAddress && offer.tokenAddress.toLowerCase() !== tokenAddress.toLowerCase()) {
         continue;
       }
 
@@ -726,12 +769,12 @@ export class BazaarClient {
    * all valid listings are returned (grouped by maker in the UI).
    */
   async getErc20Listings(options: GetErc20ListingsOptions): Promise<Erc20Listing[]> {
-    const { tokenAddress, excludeMaker, maker, maxMessages = 200 } = options;
+    const { tokenAddress, maker, maxMessages = 200 } = options;
     const erc20BazaarAddress = getErc20BazaarAddress(this.chainId);
 
     const filter = {
       appAddress: erc20BazaarAddress,
-      topic: tokenAddress.toLowerCase(),
+      topic: tokenAddress?.toLowerCase(),
       maker,
     };
 
@@ -769,22 +812,34 @@ export class BazaarClient {
    */
   async processErc20ListingsFromMessages(
     messages: NetMessage[],
-    options: Pick<GetErc20ListingsOptions, "tokenAddress" | "excludeMaker">
+    options: Pick<GetErc20ListingsOptions, "tokenAddress" | "excludeMaker" | "includeExpired">
   ): Promise<Erc20Listing[]> {
-    const { tokenAddress, excludeMaker } = options;
+    const { tokenAddress, excludeMaker, includeExpired = false } = options;
     const tag = `[BazaarClient.processErc20Listings chain=${this.chainId}]`;
 
-    // Fetch token decimals for accurate price-per-token computation
-    const tokenDecimals = await this.fetchTokenDecimals(tokenAddress);
+    // Resolve decimals: one shot for single-token queries, otherwise warm the
+    // cache for every distinct offer token in parallel before parsing.
+    let resolveDecimals: (message: NetMessage) => number | undefined;
+    if (tokenAddress) {
+      const presetDecimals = await this.fetchTokenDecimals(tokenAddress);
+      resolveDecimals = () => presetDecimals;
+    } else {
+      resolveDecimals = await this.warmTokenDecimals(messages, "offer");
+    }
 
     // Parse messages into listings
     let listings: Erc20Listing[] = [];
     for (const message of messages) {
-      const listing = parseErc20ListingFromMessage(message, this.chainId, tokenDecimals);
+      const decimals = resolveDecimals(message);
+      // Cross-token path: skip messages whose token decimals couldn't be resolved
+      // rather than silently mis-pricing them.
+      if (decimals === undefined) continue;
+
+      const listing = parseErc20ListingFromMessage(message, this.chainId, decimals);
       if (!listing) continue;
 
-      // Validate the offer token matches the requested token
-      if (listing.tokenAddress.toLowerCase() !== tokenAddress.toLowerCase()) {
+      // Validate the offer token matches the requested token (when filtering)
+      if (tokenAddress && listing.tokenAddress.toLowerCase() !== tokenAddress.toLowerCase()) {
         continue;
       }
 
@@ -829,44 +884,103 @@ export class BazaarClient {
     }
     console.log(tag, `order statuses:`, statusCounts, `expired: ${expiredCount}`);
 
-    // Filter to OPEN orders only
+    // Filter by order status: keep OPEN (and optionally EXPIRED) listings
     listings = listings.filter(
       (l) =>
-        l.orderStatus === SeaportOrderStatus.OPEN &&
-        l.expirationDate > now
+        (l.orderStatus === SeaportOrderStatus.OPEN && l.expirationDate > now) ||
+        (includeExpired && l.orderStatus === SeaportOrderStatus.EXPIRED)
     );
 
-    console.log(tag, `after status filter: ${listings.length} OPEN & not expired`);
+    console.log(tag, `after status filter: ${listings.length} (OPEN${includeExpired ? ' + EXPIRED' : ''})`);
 
     if (listings.length === 0) {
       return [];
     }
 
-    // Validate seller's ERC20 balances
-    const uniqueMakers = [...new Set(listings.map((l) => l.maker))];
-    const balances = await bulkFetchErc20Balances(this.client, tokenAddress, uniqueMakers);
+    // Validate seller's ERC20 balances (only for OPEN listings; expired skip balance check)
+    const openListings = listings.filter((l) => l.orderStatus === SeaportOrderStatus.OPEN);
+    const expiredListings = includeExpired
+      ? listings.filter((l) => l.orderStatus === SeaportOrderStatus.EXPIRED)
+      : [];
 
-    const balanceMap = new Map<string, bigint>();
-    uniqueMakers.forEach((maker, index) => {
-      balanceMap.set(maker.toLowerCase(), balances[index]);
-    });
+    let validOpenListings: Erc20Listing[];
+    const beforeBalance = openListings.length;
 
-    // Filter to listings where seller has sufficient token balance
-    const beforeBalance = listings.length;
-    listings = listings.filter((listing) => {
-      const balance = balanceMap.get(listing.maker.toLowerCase()) || BigInt(0);
-      return isErc20ListingValid(
-        listing.orderStatus,
-        listing.expirationDate,
-        listing.tokenAmount,
-        balance
+    if (tokenAddress) {
+      // Single token: one bulkFetchErc20Balances call against that token.
+      const uniqueMakers = [...new Set(openListings.map((l) => l.maker))];
+      const balances = await bulkFetchErc20Balances(this.client, tokenAddress, uniqueMakers);
+
+      const balanceMap = new Map<string, bigint>();
+      uniqueMakers.forEach((maker, index) => {
+        balanceMap.set(maker.toLowerCase(), balances[index]);
+      });
+
+      validOpenListings = openListings.filter((listing) => {
+        const balance = balanceMap.get(listing.maker.toLowerCase()) || BigInt(0);
+        return isErc20ListingValid(
+          listing.orderStatus,
+          listing.expirationDate,
+          listing.tokenAmount,
+          balance
+        );
+      });
+    } else {
+      // Cross-token: group by tokenAddress, fetch balances per group in parallel.
+      const groups = new Map<string, Erc20Listing[]>();
+      for (const listing of openListings) {
+        const key = listing.tokenAddress.toLowerCase();
+        const group = groups.get(key);
+        if (group) {
+          group.push(listing);
+        } else {
+          groups.set(key, [listing]);
+        }
+      }
+
+      const groupEntries = Array.from(groups.entries());
+      const balanceResults = await Promise.all(
+        groupEntries.map(async ([token, groupListings]) => {
+          const uniqueMakers = [...new Set(groupListings.map((l) => l.maker))];
+          const balances = await bulkFetchErc20Balances(
+            this.client,
+            token as `0x${string}`,
+            uniqueMakers
+          );
+          const map = new Map<string, bigint>();
+          uniqueMakers.forEach((maker, idx) => {
+            map.set(maker.toLowerCase(), balances[idx]);
+          });
+          return map;
+        })
       );
-    });
 
-    console.log(tag, `after balance filter: ${listings.length}/${beforeBalance} (${beforeBalance - listings.length} dropped)`);
+      validOpenListings = [];
+      groupEntries.forEach(([, groupListings], groupIndex) => {
+        const balanceMap = balanceResults[groupIndex];
+        for (const listing of groupListings) {
+          const balance = balanceMap.get(listing.maker.toLowerCase()) || BigInt(0);
+          if (
+            isErc20ListingValid(
+              listing.orderStatus,
+              listing.expirationDate,
+              listing.tokenAmount,
+              balance
+            )
+          ) {
+            validOpenListings.push(listing);
+          }
+        }
+      });
+    }
 
-    // Sort by price per token (lowest first) — no deduplication for ERC20 listings
-    return sortErc20ListingsByPricePerToken(listings);
+    console.log(tag, `after balance filter: ${validOpenListings.length}/${beforeBalance} (${beforeBalance - validOpenListings.length} dropped)`);
+
+    // Sort by price per token (lowest first) — no deduplication for ERC20 listings.
+    // Active listings first, then expired listings after.
+    const sortedOpen = sortErc20ListingsByPricePerToken(validOpenListings);
+    const sortedExpired = sortErc20ListingsByPricePerToken(expiredListings);
+    return [...sortedOpen, ...sortedExpired];
   }
 
   /**
@@ -980,7 +1094,8 @@ export class BazaarClient {
 
   /**
    * Get the ERC20 offers contract address for this chain
-   * Only available on Base (8453) and HyperEVM (999)
+   * Only available on chains with the contract deployed (see chainConfig.ts).
+   * Returns undefined on chains without an ERC20 offers contract.
    */
   getErc20OffersAddress(): `0x${string}` | undefined {
     return getErc20OffersAddress(this.chainId);
@@ -1040,6 +1155,20 @@ export class BazaarClient {
     }
 
     return this.prepareCancelOrder(listing.orderComponents);
+  }
+
+  /**
+   * Prepare a transaction to cancel an ERC20 offer
+   *
+   * The offer must have been created by the caller.
+   * Use the orderComponents from the Erc20Offer object returned by getErc20Offers().
+   */
+  prepareCancelErc20Offer(offer: Erc20Offer): WriteTransactionConfig {
+    if (!offer.orderComponents) {
+      throw new Error("Offer does not have order components");
+    }
+
+    return this.prepareCancelOrder(offer.orderComponents);
   }
 
   /**

--- a/packages/net-bazaar/src/client/BazaarClient.ts
+++ b/packages/net-bazaar/src/client/BazaarClient.ts
@@ -456,16 +456,17 @@ export class BazaarClient {
    * Results are sorted by price (highest first)
    */
   async getCollectionOffers(options: GetCollectionOffersOptions): Promise<CollectionOffer[]> {
-    const { nftAddress, excludeMaker, maxMessages = 100 } = options;
+    const { nftAddress, maker, maxMessages = 100 } = options;
     const collectionOffersAddress = getCollectionOffersAddress(this.chainId);
 
+    const filter = {
+      appAddress: collectionOffersAddress,
+      topic: nftAddress?.toLowerCase(),
+      maker,
+    };
+
     // Get message count
-    const count = await this.netClient.getMessageCount({
-      filter: {
-        appAddress: collectionOffersAddress,
-        topic: nftAddress?.toLowerCase(),
-      },
-    });
+    const count = await this.netClient.getMessageCount({ filter });
 
     if (count === 0) {
       return [];
@@ -474,10 +475,7 @@ export class BazaarClient {
     // Fetch messages (most recent)
     const startIndex = Math.max(0, count - maxMessages);
     const messages = await this.netClient.getMessages({
-      filter: {
-        appAddress: collectionOffersAddress,
-        topic: nftAddress?.toLowerCase(),
-      },
+      filter,
       startIndex,
       endIndex: count,
     });
@@ -603,7 +601,7 @@ export class BazaarClient {
    * Results are sorted by price per token (highest first)
    */
   async getErc20Offers(options: GetErc20OffersOptions): Promise<Erc20Offer[]> {
-    const { tokenAddress, maxMessages = 200 } = options;
+    const { tokenAddress, maker, maxMessages = 200 } = options;
     const erc20OffersAddress = getErc20OffersAddress(this.chainId);
 
     // ERC20 offers only available on chains with the contract deployed
@@ -614,6 +612,7 @@ export class BazaarClient {
     const filter = {
       appAddress: erc20OffersAddress,
       topic: tokenAddress?.toLowerCase(),
+      maker,
     };
 
     // Get message count
@@ -992,11 +991,11 @@ export class BazaarClient {
    * Results are sorted by timestamp (most recent first)
    */
   async getSales(options: GetSalesOptions): Promise<Sale[]> {
-    const { nftAddress, maxMessages = 100 } = options;
+    const { tokenAddress, maxMessages = 100 } = options;
 
     const filter = {
       appAddress: NET_SEAPORT_ZONE_ADDRESS as `0x${string}`,
-      topic: nftAddress.toLowerCase(),
+      topic: tokenAddress.toLowerCase(),
     };
 
     // Get message count
@@ -1024,7 +1023,7 @@ export class BazaarClient {
    */
   async processSalesFromMessages(
     messages: NetMessage[],
-    options: Pick<GetSalesOptions, "nftAddress">
+    options: Pick<GetSalesOptions, "tokenAddress">
   ): Promise<Sale[]> {
     const tag = `[BazaarClient.processSales chain=${this.chainId}]`;
 

--- a/packages/net-bazaar/src/hooks/useBazaarCollectionOffers.ts
+++ b/packages/net-bazaar/src/hooks/useBazaarCollectionOffers.ts
@@ -17,6 +17,8 @@ export interface UseBazaarCollectionOffersOptions {
   nftAddress?: `0x${string}`;
   /** Exclude offers from this address */
   excludeMaker?: `0x${string}`;
+  /** Only include offers from this address */
+  maker?: `0x${string}`;
   /** Maximum number of messages to fetch (default: 100) */
   maxMessages?: number;
   /** Whether the query is enabled (default: true) */
@@ -64,6 +66,7 @@ export function useBazaarCollectionOffers({
   chainId,
   nftAddress,
   excludeMaker,
+  maker,
   maxMessages = 100,
   enabled = true,
 }: UseBazaarCollectionOffersOptions): UseBazaarCollectionOffersResult {
@@ -91,8 +94,9 @@ export function useBazaarCollectionOffers({
     () => ({
       appAddress: collectionOffersAddress as `0x${string}`,
       topic: nftAddress?.toLowerCase(),
+      maker,
     }),
-    [collectionOffersAddress, nftAddress]
+    [collectionOffersAddress, nftAddress, maker]
   );
 
   // Get message count
@@ -187,7 +191,7 @@ export function useBazaarCollectionOffers({
     return () => {
       cancelled = true;
     };
-  }, [chainId, nftAddress, excludeMaker, messages, isSupported, enabled, refetchTrigger]);
+  }, [chainId, nftAddress, excludeMaker, maker, messages, isSupported, enabled, refetchTrigger]);
 
   const refetch = () => {
     refetchMessages();

--- a/packages/net-bazaar/src/hooks/useBazaarErc20Listings.ts
+++ b/packages/net-bazaar/src/hooks/useBazaarErc20Listings.ts
@@ -13,8 +13,8 @@ import { getErc20BazaarAddress, isBazaarSupportedOnChain } from "../chainConfig"
 export interface UseBazaarErc20ListingsOptions {
   /** Chain ID to query */
   chainId: number;
-  /** ERC20 token address */
-  tokenAddress: `0x${string}`;
+  /** ERC20 token address (optional - if omitted, fetches recent listings across all tokens) */
+  tokenAddress?: `0x${string}`;
   /** Exclude listings from this address */
   excludeMaker?: `0x${string}`;
   /** Only include listings from this address */
@@ -25,6 +25,8 @@ export interface UseBazaarErc20ListingsOptions {
   startIndex?: number;
   /** Override end index for message range */
   endIndex?: number;
+  /** Include expired listings in results (default: false) */
+  includeExpired?: boolean;
   /** Whether the query is enabled (default: true) */
   enabled?: boolean;
   /** Optional viem PublicClient (defaults to wagmi's client for the chain) */
@@ -83,6 +85,7 @@ export function useBazaarErc20Listings({
   maxMessages = 200,
   startIndex: startIndexOverride,
   endIndex: endIndexOverride,
+  includeExpired = false,
   enabled = true,
   publicClient,
 }: UseBazaarErc20ListingsOptions): UseBazaarErc20ListingsResult {
@@ -112,7 +115,7 @@ export function useBazaarErc20Listings({
   const filter = useMemo(
     () => ({
       appAddress: erc20BazaarAddress as `0x${string}`,
-      topic: tokenAddress.toLowerCase(),
+      topic: tokenAddress?.toLowerCase(),
       maker,
     }),
     [erc20BazaarAddress, tokenAddress, maker]
@@ -145,7 +148,7 @@ export function useBazaarErc20Listings({
     enabled: enabled && isSupported && (hasRangeOverride || totalCount > 0),
   });
 
-  const TAG = `[useBazaarErc20Listings chain=${chainId} token=${tokenAddress.slice(0, 10)}]`;
+  const TAG = `[useBazaarErc20Listings chain=${chainId} token=${tokenAddress?.slice(0, 10) ?? "all"}]`;
 
   // Log pipeline state changes
   useEffect(() => {
@@ -186,7 +189,7 @@ export function useBazaarErc20Listings({
         const client = new BazaarClient({ chainId, publicClient: resolvedClient });
         const validListings = await client.processErc20ListingsFromMessages(
           messages,
-          { tokenAddress, excludeMaker }
+          { tokenAddress, excludeMaker, includeExpired }
         );
         console.log(TAG, `processed → ${validListings.length} valid listings`);
 
@@ -211,7 +214,7 @@ export function useBazaarErc20Listings({
     return () => {
       cancelled = true;
     };
-  }, [chainId, tokenAddress, excludeMaker, messages, isSupported, enabled, refetchTrigger]);
+  }, [chainId, tokenAddress, excludeMaker, includeExpired, messages, isSupported, enabled, refetchTrigger]);
 
   const refetch = () => {
     refetchMessages();

--- a/packages/net-bazaar/src/hooks/useBazaarErc20Offers.ts
+++ b/packages/net-bazaar/src/hooks/useBazaarErc20Offers.ts
@@ -13,8 +13,8 @@ import { getErc20OffersAddress, isBazaarSupportedOnChain } from "../chainConfig"
 export interface UseBazaarErc20OffersOptions {
   /** Chain ID to query */
   chainId: number;
-  /** ERC20 token address */
-  tokenAddress: `0x${string}`;
+  /** ERC20 token address (optional - if omitted, fetches recent offers across all tokens) */
+  tokenAddress?: `0x${string}`;
   /** Exclude offers from this address */
   excludeMaker?: `0x${string}`;
   /** Maximum number of messages to fetch (default: 200) */
@@ -37,7 +37,8 @@ export interface UseBazaarErc20OffersResult {
 /**
  * React hook for fetching valid ERC20 offers from Bazaar
  *
- * ERC20 offers are only available on Base (8453) and HyperEVM (999).
+ * ERC20 offers are only available on chains with an ERC20 offers contract
+ * deployed (see chainConfig.ts).
  *
  * Returns offers that are:
  * - OPEN status (not filled, cancelled, or expired)
@@ -87,7 +88,7 @@ export function useBazaarErc20Offers({
     [chainId]
   );
 
-  // Get ERC20 offers address for the chain (only Base and HyperEVM)
+  // Get ERC20 offers address for the chain (undefined if not deployed there)
   const erc20OffersAddress = useMemo(
     () => (isSupported ? getErc20OffersAddress(chainId) : undefined),
     [chainId, isSupported]
@@ -100,7 +101,7 @@ export function useBazaarErc20Offers({
   const filter = useMemo(
     () => ({
       appAddress: erc20OffersAddress as `0x${string}`,
-      topic: tokenAddress.toLowerCase(),
+      topic: tokenAddress?.toLowerCase(),
     }),
     [erc20OffersAddress, tokenAddress]
   );
@@ -132,7 +133,7 @@ export function useBazaarErc20Offers({
     enabled: enabled && hasErc20Offers && totalCount > 0,
   });
 
-  const TAG = `[useBazaarErc20Offers chain=${chainId} token=${tokenAddress.slice(0, 10)}]`;
+  const TAG = `[useBazaarErc20Offers chain=${chainId} token=${tokenAddress?.slice(0, 10) ?? "all"}]`;
 
   // Log pipeline state changes
   useEffect(() => {

--- a/packages/net-bazaar/src/hooks/useBazaarErc20Offers.ts
+++ b/packages/net-bazaar/src/hooks/useBazaarErc20Offers.ts
@@ -17,6 +17,8 @@ export interface UseBazaarErc20OffersOptions {
   tokenAddress?: `0x${string}`;
   /** Exclude offers from this address */
   excludeMaker?: `0x${string}`;
+  /** Only include offers from this address */
+  maker?: `0x${string}`;
   /** Maximum number of messages to fetch (default: 200) */
   maxMessages?: number;
   /** Whether the query is enabled (default: true) */
@@ -72,6 +74,7 @@ export function useBazaarErc20Offers({
   chainId,
   tokenAddress,
   excludeMaker,
+  maker,
   maxMessages = 200,
   enabled = true,
 }: UseBazaarErc20OffersOptions): UseBazaarErc20OffersResult {
@@ -102,8 +105,9 @@ export function useBazaarErc20Offers({
     () => ({
       appAddress: erc20OffersAddress as `0x${string}`,
       topic: tokenAddress?.toLowerCase(),
+      maker,
     }),
-    [erc20OffersAddress, tokenAddress]
+    [erc20OffersAddress, tokenAddress, maker]
   );
 
   // Get message count
@@ -198,7 +202,7 @@ export function useBazaarErc20Offers({
     return () => {
       cancelled = true;
     };
-  }, [chainId, tokenAddress, excludeMaker, messages, hasErc20Offers, enabled, refetchTrigger]);
+  }, [chainId, tokenAddress, excludeMaker, maker, messages, hasErc20Offers, enabled, refetchTrigger]);
 
   const refetch = () => {
     refetchMessages();

--- a/packages/net-bazaar/src/hooks/useBazaarSales.ts
+++ b/packages/net-bazaar/src/hooks/useBazaarSales.ts
@@ -13,8 +13,8 @@ import { NET_SEAPORT_ZONE_ADDRESS, isBazaarSupportedOnChain } from "../chainConf
 export interface UseBazaarSalesOptions {
   /** Chain ID to query */
   chainId: number;
-  /** NFT collection address */
-  nftAddress: `0x${string}`;
+  /** Token contract address (NFT or ERC20) */
+  tokenAddress: `0x${string}`;
   /** Maximum number of messages to fetch (default: 100) */
   maxMessages?: number;
   /** Whether the query is enabled (default: true) */
@@ -36,7 +36,7 @@ export interface UseBazaarSalesResult {
  * React hook for fetching recent sales from Bazaar
  *
  * Sales data flows differently from listings/offers:
- * - Net messages (appAddress=zone, topic=nftAddress) contain order hashes
+ * - Net messages (appAddress=zone, topic=tokenAddress) contain order hashes
  * - Actual sale data is fetched from the bulk storage contract
  *
  * Results are sorted by timestamp (most recent first)
@@ -45,7 +45,7 @@ export interface UseBazaarSalesResult {
  * ```tsx
  * const { sales, isLoading, error } = useBazaarSales({
  *   chainId: 8453,
- *   nftAddress: "0x...",
+ *   tokenAddress: "0x...",
  *   maxMessages: 100,
  * });
  *
@@ -65,7 +65,7 @@ export interface UseBazaarSalesResult {
  */
 export function useBazaarSales({
   chainId,
-  nftAddress,
+  tokenAddress,
   maxMessages = 100,
   enabled = true,
 }: UseBazaarSalesOptions): UseBazaarSalesResult {
@@ -86,9 +86,9 @@ export function useBazaarSales({
   const filter = useMemo(
     () => ({
       appAddress: NET_SEAPORT_ZONE_ADDRESS as `0x${string}`,
-      topic: nftAddress.toLowerCase(),
+      topic: tokenAddress.toLowerCase(),
     }),
-    [nftAddress]
+    [tokenAddress]
   );
 
   // Get message count
@@ -118,7 +118,7 @@ export function useBazaarSales({
     enabled: enabled && isSupported && totalCount > 0,
   });
 
-  const TAG = `[useBazaarSales chain=${chainId} nft=${nftAddress.slice(0, 10)}]`;
+  const TAG = `[useBazaarSales chain=${chainId} nft=${tokenAddress.slice(0, 10)}]`;
 
   // Log pipeline state changes
   useEffect(() => {
@@ -158,7 +158,7 @@ export function useBazaarSales({
         const client = new BazaarClient({ chainId, publicClient: wagmiClient as PublicClient });
         const parsedSales = await client.processSalesFromMessages(
           messages,
-          { nftAddress }
+          { tokenAddress }
         );
         console.log(TAG, `processed → ${parsedSales.length} sales`);
 
@@ -183,7 +183,7 @@ export function useBazaarSales({
     return () => {
       cancelled = true;
     };
-  }, [chainId, nftAddress, messages, isSupported, enabled, refetchTrigger]);
+  }, [chainId, tokenAddress, messages, isSupported, enabled, refetchTrigger]);
 
   const refetch = () => {
     refetchMessages();

--- a/packages/net-bazaar/src/hooks/useBazaarSales.ts
+++ b/packages/net-bazaar/src/hooks/useBazaarSales.ts
@@ -82,7 +82,7 @@ export function useBazaarSales({
     [chainId]
   );
 
-  // Build filter: appAddress = zone contract, topic = nft address
+  // Build filter: appAddress = zone contract, topic = token address (NFT or ERC20)
   const filter = useMemo(
     () => ({
       appAddress: NET_SEAPORT_ZONE_ADDRESS as `0x${string}`,
@@ -118,7 +118,7 @@ export function useBazaarSales({
     enabled: enabled && isSupported && totalCount > 0,
   });
 
-  const TAG = `[useBazaarSales chain=${chainId} nft=${tokenAddress.slice(0, 10)}]`;
+  const TAG = `[useBazaarSales chain=${chainId} token=${tokenAddress.slice(0, 10)}]`;
 
   // Log pipeline state changes
   useEffect(() => {

--- a/packages/net-bazaar/src/types.ts
+++ b/packages/net-bazaar/src/types.ts
@@ -276,6 +276,8 @@ export interface GetCollectionOffersOptions {
   nftAddress?: `0x${string}`;
   /** Exclude offers from this address */
   excludeMaker?: `0x${string}`;
+  /** Only include offers from this address */
+  maker?: `0x${string}`;
   /** Maximum number of messages to fetch (default: 100) */
   maxMessages?: number;
 }
@@ -288,6 +290,8 @@ export interface GetErc20OffersOptions {
   tokenAddress?: `0x${string}`;
   /** Exclude offers from this address */
   excludeMaker?: `0x${string}`;
+  /** Only include offers from this address */
+  maker?: `0x${string}`;
   /** Maximum number of messages to fetch (default: 200) */
   maxMessages?: number;
 }
@@ -341,11 +345,14 @@ export interface Sale {
 }
 
 /**
- * Options for fetching sales
+ * Options for fetching sales.
+ *
+ * Sales work for both NFT and ERC20 trades — zone storage is keyed by the
+ * traded token address regardless of token kind.
  */
 export interface GetSalesOptions {
-  /** NFT collection address */
-  nftAddress: `0x${string}`;
+  /** Token contract address (NFT or ERC20) */
+  tokenAddress: `0x${string}`;
   /** Maximum number of messages to fetch (default: 100) */
   maxMessages?: number;
 }

--- a/packages/net-bazaar/src/types.ts
+++ b/packages/net-bazaar/src/types.ts
@@ -130,6 +130,8 @@ export interface Erc20Listing {
   messageData: `0x${string}`;
   /** Decoded Seaport order components */
   orderComponents?: SeaportOrderComponents;
+  /** Private order fulfiller zone hash (undefined = public order) */
+  targetFulfiller?: `0x${string}`;
 }
 
 /**
@@ -282,8 +284,8 @@ export interface GetCollectionOffersOptions {
  * Options for fetching ERC20 offers
  */
 export interface GetErc20OffersOptions {
-  /** ERC20 token address to filter by */
-  tokenAddress: `0x${string}`;
+  /** ERC20 token address (optional - if omitted, fetches recent offers across all tokens) */
+  tokenAddress?: `0x${string}`;
   /** Exclude offers from this address */
   excludeMaker?: `0x${string}`;
   /** Maximum number of messages to fetch (default: 200) */
@@ -294,8 +296,8 @@ export interface GetErc20OffersOptions {
  * Options for fetching ERC20 listings
  */
 export interface GetErc20ListingsOptions {
-  /** ERC20 token address to filter by */
-  tokenAddress: `0x${string}`;
+  /** ERC20 token address (optional - if omitted, fetches recent listings across all tokens) */
+  tokenAddress?: `0x${string}`;
   /** Exclude listings from this address */
   excludeMaker?: `0x${string}`;
   /** Only include listings from this address */
@@ -306,6 +308,8 @@ export interface GetErc20ListingsOptions {
   startIndex?: number;
   /** Override end index for message range */
   endIndex?: number;
+  /** Include expired listings in results (default: false) */
+  includeExpired?: boolean;
 }
 
 /**

--- a/packages/net-bazaar/src/utils/orderCreation.ts
+++ b/packages/net-bazaar/src/utils/orderCreation.ts
@@ -23,6 +23,7 @@ import {
   getSeaportAddress,
   getFeeCollectorAddress,
   getNftFeeBps,
+  getErc20FeeBps,
   getWrappedNativeCurrency,
   NET_SEAPORT_ZONE_ADDRESS,
   NET_SEAPORT_COLLECTION_OFFER_ZONE_ADDRESS,
@@ -281,7 +282,7 @@ export function buildErc20OfferOrderComponents(
     throw new Error(`No wrapped native currency configured for chain ${chainId}`);
   }
 
-  const feeBps = getNftFeeBps(chainId);
+  const feeBps = getErc20FeeBps(chainId);
   const feeAmount = calculateFee(params.priceWei, feeBps, true); // Ceiling division for ERC20s
   const endTime = BigInt(params.expirationDate ?? getDefaultExpiration());
   const feeCollector = getFeeCollectorAddress(chainId);
@@ -344,7 +345,7 @@ export function buildErc20ListingOrderComponents(
   chainId: number,
   counter: bigint
 ): { orderParameters: SeaportOrderParameters; counter: bigint } {
-  const feeBps = getNftFeeBps(chainId);
+  const feeBps = getErc20FeeBps(chainId);
   const feeAmount = calculateFee(params.priceWei, feeBps, true); // Ceiling division for ERC20s
   const sellerAmount = params.priceWei - feeAmount;
   const endTime = BigInt(params.expirationDate ?? getDefaultExpiration());

--- a/packages/net-bazaar/src/utils/parsing.ts
+++ b/packages/net-bazaar/src/utils/parsing.ts
@@ -306,6 +306,12 @@ export function parseErc20ListingFromMessage(
 
     const pricePerTokenWei = priceWei / tokenAmount;
 
+    const targetFulfiller =
+      parameters.zone.toLowerCase() === NET_SEAPORT_PRIVATE_ORDER_ZONE_ADDRESS.toLowerCase() &&
+      parameters.zoneHash !== "0x0000000000000000000000000000000000000000000000000000000000000000"
+        ? parameters.zoneHash
+        : undefined;
+
     return {
       maker: parameters.offerer,
       tokenAddress: offerItem.token,
@@ -323,6 +329,7 @@ export function parseErc20ListingFromMessage(
         ...parameters,
         counter: submission.counter,
       },
+      targetFulfiller,
     };
   } catch {
     return null;

--- a/packages/net-cli/package.json
+++ b/packages/net-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@net-protocol/cli",
-  "version": "0.1.49",
+  "version": "0.2.0",
   "description": "CLI tool for Net Protocol",
   "type": "module",
   "bin": {
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@net-protocol/agents": "^0.1.0",
-    "@net-protocol/bazaar": "^0.1.17",
+    "@net-protocol/bazaar": "^0.2.0",
     "@net-protocol/chats": "^0.1.0",
     "@net-protocol/core": "^0.1.9",
     "@net-protocol/feeds": "^0.1.14",

--- a/packages/net-cli/package.json
+++ b/packages/net-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@net-protocol/cli",
-  "version": "0.1.48",
+  "version": "0.1.49",
   "description": "CLI tool for Net Protocol",
   "type": "module",
   "bin": {

--- a/packages/net-cli/src/commands/bazaar/cancel-erc20-listing.ts
+++ b/packages/net-cli/src/commands/bazaar/cancel-erc20-listing.ts
@@ -1,0 +1,114 @@
+import chalk from "chalk";
+import { privateKeyToAccount } from "viem/accounts";
+import { BazaarClient } from "@net-protocol/bazaar";
+import { parseCommonOptions, parseReadOnlyOptions } from "../../cli/shared";
+import { createWallet, executeTransaction } from "../../shared/wallet";
+import { exitWithError } from "../../shared/output";
+import { encodeTransaction } from "../../shared/encode";
+import type { CancelErc20ListingOptions } from "./types";
+
+export async function executeCancelErc20Listing(
+  options: CancelErc20ListingOptions
+): Promise<void> {
+  if (options.encodeOnly) {
+    await executeEncodeOnly(options);
+    return;
+  }
+
+  const commonOptions = parseCommonOptions(
+    {
+      privateKey: options.privateKey,
+      chainId: options.chainId,
+      rpcUrl: options.rpcUrl,
+    },
+    true
+  );
+
+  const account = privateKeyToAccount(commonOptions.privateKey);
+  const bazaarClient = new BazaarClient({
+    chainId: commonOptions.chainId,
+    rpcUrl: commonOptions.rpcUrl,
+  });
+
+  try {
+    console.log(chalk.blue("Fetching ERC20 listing..."));
+    const listings = await bazaarClient.getErc20Listings({
+      tokenAddress: options.tokenAddress as `0x${string}`,
+      maker: account.address,
+      includeExpired: true,
+    });
+
+    const listing = listings.find(
+      (l) => l.orderHash.toLowerCase() === options.orderHash.toLowerCase()
+    );
+
+    if (!listing) {
+      exitWithError(
+        `ERC20 listing with order hash ${options.orderHash} not found for maker ${account.address}`
+      );
+    }
+
+    const cancelTx = bazaarClient.prepareCancelErc20Listing(listing);
+
+    const walletClient = createWallet(
+      commonOptions.privateKey,
+      commonOptions.chainId,
+      commonOptions.rpcUrl
+    );
+
+    console.log(chalk.blue("Sending cancel transaction..."));
+    const hash = await executeTransaction(walletClient, cancelTx);
+
+    console.log(
+      chalk.green(
+        `ERC20 listing cancelled successfully!\n  Transaction: ${hash}\n  Token: ${listing.tokenAddress}\n  Amount: ${listing.tokenAmount.toString()}`
+      )
+    );
+  } catch (error) {
+    exitWithError(
+      `Failed to cancel ERC20 listing: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+}
+
+async function executeEncodeOnly(options: CancelErc20ListingOptions): Promise<void> {
+  if (!options.maker) {
+    exitWithError("--maker is required when using --encode-only without --private-key");
+  }
+
+  const readOnlyOptions = parseReadOnlyOptions({
+    chainId: options.chainId,
+    rpcUrl: options.rpcUrl,
+  });
+
+  const makerAddress = options.maker as `0x${string}`;
+  const bazaarClient = new BazaarClient({
+    chainId: readOnlyOptions.chainId,
+    rpcUrl: readOnlyOptions.rpcUrl,
+  });
+
+  try {
+    const listings = await bazaarClient.getErc20Listings({
+      tokenAddress: options.tokenAddress as `0x${string}`,
+      maker: makerAddress,
+      includeExpired: true,
+    });
+
+    const listing = listings.find(
+      (l) => l.orderHash.toLowerCase() === options.orderHash.toLowerCase()
+    );
+
+    if (!listing) {
+      exitWithError(
+        `ERC20 listing with order hash ${options.orderHash} not found for maker ${makerAddress}`
+      );
+    }
+
+    const cancelTx = bazaarClient.prepareCancelErc20Listing(listing);
+    console.log(JSON.stringify(encodeTransaction(cancelTx, readOnlyOptions.chainId), null, 2));
+  } catch (error) {
+    exitWithError(
+      `Failed to encode cancel ERC20 listing: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+}

--- a/packages/net-cli/src/commands/bazaar/cancel-erc20-offer.ts
+++ b/packages/net-cli/src/commands/bazaar/cancel-erc20-offer.ts
@@ -34,12 +34,11 @@ export async function executeCancelErc20Offer(
     console.log(chalk.blue("Fetching ERC20 offer..."));
     const offers = await bazaarClient.getErc20Offers({
       tokenAddress: options.tokenAddress as `0x${string}`,
+      maker: account.address,
     });
 
     const offer = offers.find(
-      (o) =>
-        o.orderHash.toLowerCase() === options.orderHash.toLowerCase() &&
-        o.maker.toLowerCase() === account.address.toLowerCase()
+      (o) => o.orderHash.toLowerCase() === options.orderHash.toLowerCase()
     );
 
     if (!offer) {
@@ -90,12 +89,11 @@ async function executeEncodeOnly(options: CancelErc20OfferOptions): Promise<void
   try {
     const offers = await bazaarClient.getErc20Offers({
       tokenAddress: options.tokenAddress as `0x${string}`,
+      maker: makerAddress,
     });
 
     const offer = offers.find(
-      (o) =>
-        o.orderHash.toLowerCase() === options.orderHash.toLowerCase() &&
-        o.maker.toLowerCase() === makerAddress.toLowerCase()
+      (o) => o.orderHash.toLowerCase() === options.orderHash.toLowerCase()
     );
 
     if (!offer) {

--- a/packages/net-cli/src/commands/bazaar/cancel-erc20-offer.ts
+++ b/packages/net-cli/src/commands/bazaar/cancel-erc20-offer.ts
@@ -1,0 +1,114 @@
+import chalk from "chalk";
+import { privateKeyToAccount } from "viem/accounts";
+import { BazaarClient } from "@net-protocol/bazaar";
+import { parseCommonOptions, parseReadOnlyOptions } from "../../cli/shared";
+import { createWallet, executeTransaction } from "../../shared/wallet";
+import { exitWithError } from "../../shared/output";
+import { encodeTransaction } from "../../shared/encode";
+import type { CancelErc20OfferOptions } from "./types";
+
+export async function executeCancelErc20Offer(
+  options: CancelErc20OfferOptions
+): Promise<void> {
+  if (options.encodeOnly) {
+    await executeEncodeOnly(options);
+    return;
+  }
+
+  const commonOptions = parseCommonOptions(
+    {
+      privateKey: options.privateKey,
+      chainId: options.chainId,
+      rpcUrl: options.rpcUrl,
+    },
+    true
+  );
+
+  const account = privateKeyToAccount(commonOptions.privateKey);
+  const bazaarClient = new BazaarClient({
+    chainId: commonOptions.chainId,
+    rpcUrl: commonOptions.rpcUrl,
+  });
+
+  try {
+    console.log(chalk.blue("Fetching ERC20 offer..."));
+    const offers = await bazaarClient.getErc20Offers({
+      tokenAddress: options.tokenAddress as `0x${string}`,
+    });
+
+    const offer = offers.find(
+      (o) =>
+        o.orderHash.toLowerCase() === options.orderHash.toLowerCase() &&
+        o.maker.toLowerCase() === account.address.toLowerCase()
+    );
+
+    if (!offer) {
+      exitWithError(
+        `ERC20 offer with order hash ${options.orderHash} not found for maker ${account.address}`
+      );
+    }
+
+    const cancelTx = bazaarClient.prepareCancelErc20Offer(offer);
+
+    const walletClient = createWallet(
+      commonOptions.privateKey,
+      commonOptions.chainId,
+      commonOptions.rpcUrl
+    );
+
+    console.log(chalk.blue("Sending cancel transaction..."));
+    const hash = await executeTransaction(walletClient, cancelTx);
+
+    console.log(
+      chalk.green(
+        `ERC20 offer cancelled successfully!\n  Transaction: ${hash}\n  Token: ${offer.tokenAddress}\n  Amount: ${offer.tokenAmount.toString()}`
+      )
+    );
+  } catch (error) {
+    exitWithError(
+      `Failed to cancel ERC20 offer: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+}
+
+async function executeEncodeOnly(options: CancelErc20OfferOptions): Promise<void> {
+  if (!options.maker) {
+    exitWithError("--maker is required when using --encode-only without --private-key");
+  }
+
+  const readOnlyOptions = parseReadOnlyOptions({
+    chainId: options.chainId,
+    rpcUrl: options.rpcUrl,
+  });
+
+  const makerAddress = options.maker as `0x${string}`;
+  const bazaarClient = new BazaarClient({
+    chainId: readOnlyOptions.chainId,
+    rpcUrl: readOnlyOptions.rpcUrl,
+  });
+
+  try {
+    const offers = await bazaarClient.getErc20Offers({
+      tokenAddress: options.tokenAddress as `0x${string}`,
+    });
+
+    const offer = offers.find(
+      (o) =>
+        o.orderHash.toLowerCase() === options.orderHash.toLowerCase() &&
+        o.maker.toLowerCase() === makerAddress.toLowerCase()
+    );
+
+    if (!offer) {
+      exitWithError(
+        `ERC20 offer with order hash ${options.orderHash} not found for maker ${makerAddress}`
+      );
+    }
+
+    const cancelTx = bazaarClient.prepareCancelErc20Offer(offer);
+    console.log(JSON.stringify(encodeTransaction(cancelTx, readOnlyOptions.chainId), null, 2));
+  } catch (error) {
+    exitWithError(
+      `Failed to encode cancel ERC20 offer: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+}

--- a/packages/net-cli/src/commands/bazaar/cancel-listing.ts
+++ b/packages/net-cli/src/commands/bazaar/cancel-listing.ts
@@ -1,0 +1,112 @@
+import chalk from "chalk";
+import { privateKeyToAccount } from "viem/accounts";
+import { BazaarClient } from "@net-protocol/bazaar";
+import { parseCommonOptions, parseReadOnlyOptions } from "../../cli/shared";
+import { createWallet, executeTransaction } from "../../shared/wallet";
+import { exitWithError } from "../../shared/output";
+import { encodeTransaction } from "../../shared/encode";
+import type { CancelListingOptions } from "./types";
+
+export async function executeCancelListing(options: CancelListingOptions): Promise<void> {
+  if (options.encodeOnly) {
+    await executeEncodeOnly(options);
+    return;
+  }
+
+  const commonOptions = parseCommonOptions(
+    {
+      privateKey: options.privateKey,
+      chainId: options.chainId,
+      rpcUrl: options.rpcUrl,
+    },
+    true
+  );
+
+  const account = privateKeyToAccount(commonOptions.privateKey);
+  const bazaarClient = new BazaarClient({
+    chainId: commonOptions.chainId,
+    rpcUrl: commonOptions.rpcUrl,
+  });
+
+  try {
+    console.log(chalk.blue("Fetching listing..."));
+    const listings = await bazaarClient.getListings({
+      nftAddress: options.nftAddress as `0x${string}`,
+      maker: account.address,
+      includeExpired: true,
+    });
+
+    const listing = listings.find(
+      (l) => l.orderHash.toLowerCase() === options.orderHash.toLowerCase()
+    );
+
+    if (!listing) {
+      exitWithError(
+        `Listing with order hash ${options.orderHash} not found for maker ${account.address}`
+      );
+    }
+
+    const cancelTx = bazaarClient.prepareCancelListing(listing);
+
+    const walletClient = createWallet(
+      commonOptions.privateKey,
+      commonOptions.chainId,
+      commonOptions.rpcUrl
+    );
+
+    console.log(chalk.blue("Sending cancel transaction..."));
+    const hash = await executeTransaction(walletClient, cancelTx);
+
+    console.log(
+      chalk.green(
+        `Listing cancelled successfully!\n  Transaction: ${hash}\n  NFT: ${listing.nftAddress} #${listing.tokenId}`
+      )
+    );
+  } catch (error) {
+    exitWithError(
+      `Failed to cancel listing: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+}
+
+async function executeEncodeOnly(options: CancelListingOptions): Promise<void> {
+  if (!options.maker) {
+    exitWithError("--maker is required when using --encode-only without --private-key");
+  }
+
+  const readOnlyOptions = parseReadOnlyOptions({
+    chainId: options.chainId,
+    rpcUrl: options.rpcUrl,
+  });
+
+  const makerAddress = options.maker as `0x${string}`;
+  const bazaarClient = new BazaarClient({
+    chainId: readOnlyOptions.chainId,
+    rpcUrl: readOnlyOptions.rpcUrl,
+  });
+
+  try {
+    const listings = await bazaarClient.getListings({
+      nftAddress: options.nftAddress as `0x${string}`,
+      maker: makerAddress,
+      includeExpired: true,
+    });
+
+    const listing = listings.find(
+      (l) => l.orderHash.toLowerCase() === options.orderHash.toLowerCase()
+    );
+
+    if (!listing) {
+      exitWithError(
+        `Listing with order hash ${options.orderHash} not found for maker ${makerAddress}`
+      );
+    }
+
+    const cancelTx = bazaarClient.prepareCancelListing(listing);
+    console.log(JSON.stringify(encodeTransaction(cancelTx, readOnlyOptions.chainId), null, 2));
+  } catch (error) {
+    exitWithError(
+      `Failed to encode cancel listing: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+}

--- a/packages/net-cli/src/commands/bazaar/cancel-offer.ts
+++ b/packages/net-cli/src/commands/bazaar/cancel-offer.ts
@@ -32,12 +32,11 @@ export async function executeCancelOffer(options: CancelOfferOptions): Promise<v
     console.log(chalk.blue("Fetching collection offer..."));
     const offers = await bazaarClient.getCollectionOffers({
       nftAddress: options.nftAddress as `0x${string}`,
+      maker: account.address,
     });
 
     const offer = offers.find(
-      (o) =>
-        o.orderHash.toLowerCase() === options.orderHash.toLowerCase() &&
-        o.maker.toLowerCase() === account.address.toLowerCase()
+      (o) => o.orderHash.toLowerCase() === options.orderHash.toLowerCase()
     );
 
     if (!offer) {
@@ -88,12 +87,11 @@ async function executeEncodeOnly(options: CancelOfferOptions): Promise<void> {
   try {
     const offers = await bazaarClient.getCollectionOffers({
       nftAddress: options.nftAddress as `0x${string}`,
+      maker: makerAddress,
     });
 
     const offer = offers.find(
-      (o) =>
-        o.orderHash.toLowerCase() === options.orderHash.toLowerCase() &&
-        o.maker.toLowerCase() === makerAddress.toLowerCase()
+      (o) => o.orderHash.toLowerCase() === options.orderHash.toLowerCase()
     );
 
     if (!offer) {

--- a/packages/net-cli/src/commands/bazaar/cancel-offer.ts
+++ b/packages/net-cli/src/commands/bazaar/cancel-offer.ts
@@ -1,0 +1,112 @@
+import chalk from "chalk";
+import { privateKeyToAccount } from "viem/accounts";
+import { BazaarClient } from "@net-protocol/bazaar";
+import { parseCommonOptions, parseReadOnlyOptions } from "../../cli/shared";
+import { createWallet, executeTransaction } from "../../shared/wallet";
+import { exitWithError } from "../../shared/output";
+import { encodeTransaction } from "../../shared/encode";
+import type { CancelOfferOptions } from "./types";
+
+export async function executeCancelOffer(options: CancelOfferOptions): Promise<void> {
+  if (options.encodeOnly) {
+    await executeEncodeOnly(options);
+    return;
+  }
+
+  const commonOptions = parseCommonOptions(
+    {
+      privateKey: options.privateKey,
+      chainId: options.chainId,
+      rpcUrl: options.rpcUrl,
+    },
+    true
+  );
+
+  const account = privateKeyToAccount(commonOptions.privateKey);
+  const bazaarClient = new BazaarClient({
+    chainId: commonOptions.chainId,
+    rpcUrl: commonOptions.rpcUrl,
+  });
+
+  try {
+    console.log(chalk.blue("Fetching collection offer..."));
+    const offers = await bazaarClient.getCollectionOffers({
+      nftAddress: options.nftAddress as `0x${string}`,
+    });
+
+    const offer = offers.find(
+      (o) =>
+        o.orderHash.toLowerCase() === options.orderHash.toLowerCase() &&
+        o.maker.toLowerCase() === account.address.toLowerCase()
+    );
+
+    if (!offer) {
+      exitWithError(
+        `Offer with order hash ${options.orderHash} not found for maker ${account.address}`
+      );
+    }
+
+    const cancelTx = bazaarClient.prepareCancelCollectionOffer(offer);
+
+    const walletClient = createWallet(
+      commonOptions.privateKey,
+      commonOptions.chainId,
+      commonOptions.rpcUrl
+    );
+
+    console.log(chalk.blue("Sending cancel transaction..."));
+    const hash = await executeTransaction(walletClient, cancelTx);
+
+    console.log(
+      chalk.green(
+        `Offer cancelled successfully!\n  Transaction: ${hash}\n  NFT: ${offer.nftAddress}\n  Price: ${offer.price} ${offer.currency.toUpperCase()}`
+      )
+    );
+  } catch (error) {
+    exitWithError(
+      `Failed to cancel offer: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+}
+
+async function executeEncodeOnly(options: CancelOfferOptions): Promise<void> {
+  if (!options.maker) {
+    exitWithError("--maker is required when using --encode-only without --private-key");
+  }
+
+  const readOnlyOptions = parseReadOnlyOptions({
+    chainId: options.chainId,
+    rpcUrl: options.rpcUrl,
+  });
+
+  const makerAddress = options.maker as `0x${string}`;
+  const bazaarClient = new BazaarClient({
+    chainId: readOnlyOptions.chainId,
+    rpcUrl: readOnlyOptions.rpcUrl,
+  });
+
+  try {
+    const offers = await bazaarClient.getCollectionOffers({
+      nftAddress: options.nftAddress as `0x${string}`,
+    });
+
+    const offer = offers.find(
+      (o) =>
+        o.orderHash.toLowerCase() === options.orderHash.toLowerCase() &&
+        o.maker.toLowerCase() === makerAddress.toLowerCase()
+    );
+
+    if (!offer) {
+      exitWithError(
+        `Offer with order hash ${options.orderHash} not found for maker ${makerAddress}`
+      );
+    }
+
+    const cancelTx = bazaarClient.prepareCancelCollectionOffer(offer);
+    console.log(JSON.stringify(encodeTransaction(cancelTx, readOnlyOptions.chainId), null, 2));
+  } catch (error) {
+    exitWithError(
+      `Failed to encode cancel offer: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+}

--- a/packages/net-cli/src/commands/bazaar/create-erc20-listing.ts
+++ b/packages/net-cli/src/commands/bazaar/create-erc20-listing.ts
@@ -48,6 +48,7 @@ export async function executeCreateErc20Listing(options: CreateErc20ListingOptio
       tokenAmount,
       priceWei,
       offerer: account.address,
+      targetFulfiller: options.targetFulfiller as `0x${string}` | undefined,
     });
 
     const rpcUrls = getChainRpcUrls({
@@ -144,6 +145,7 @@ async function executeKeylessMode(options: CreateErc20ListingOptions): Promise<v
       tokenAmount,
       priceWei,
       offerer: options.offerer as `0x${string}`,
+      targetFulfiller: options.targetFulfiller as `0x${string}` | undefined,
     });
 
     const output = {

--- a/packages/net-cli/src/commands/bazaar/index.ts
+++ b/packages/net-cli/src/commands/bazaar/index.ts
@@ -270,6 +270,7 @@ export function registerBazaarCommand(program: Command): void {
     .requiredOption("--token-address <address>", "ERC-20 token contract address")
     .requiredOption("--token-amount <amount>", "Token amount in raw units (bigint string)")
     .requiredOption("--price <eth>", "Total price in ETH for the token amount")
+    .option("--target-fulfiller <address>", "Make a private listing for this address")
     .option("--offerer <address>", "Offerer address (required without --private-key)")
     .option(...privateKeyOption)
     .option(...chainIdOption)
@@ -279,6 +280,7 @@ export function registerBazaarCommand(program: Command): void {
         tokenAddress: options.tokenAddress,
         tokenAmount: options.tokenAmount,
         price: options.price,
+        targetFulfiller: options.targetFulfiller,
         offerer: options.offerer,
         privateKey: options.privateKey,
         chainId: options.chainId,

--- a/packages/net-cli/src/commands/bazaar/index.ts
+++ b/packages/net-cli/src/commands/bazaar/index.ts
@@ -17,6 +17,10 @@ import { executeSubmitErc20Listing } from "./submit-erc20-listing";
 import { executeSubmitErc20Offer } from "./submit-erc20-offer";
 import { executeBuyErc20Listing } from "./buy-erc20-listing";
 import { executeAcceptErc20Offer } from "./accept-erc20-offer";
+import { executeCancelListing } from "./cancel-listing";
+import { executeCancelOffer } from "./cancel-offer";
+import { executeCancelErc20Listing } from "./cancel-erc20-listing";
+import { executeCancelErc20Offer } from "./cancel-erc20-offer";
 
 const chainIdOption = [
   "--chain-id <id>",
@@ -383,6 +387,92 @@ export function registerBazaarCommand(program: Command): void {
       });
     });
 
+  // Cancel commands
+
+  const cancelListingCommand = new Command("cancel-listing")
+    .description("Cancel an NFT listing you created")
+    .requiredOption("--order-hash <hash>", "Order hash of the listing to cancel")
+    .requiredOption("--nft-address <address>", "NFT contract address")
+    .option("--maker <address>", "Maker address (required with --encode-only)")
+    .option(...privateKeyOption)
+    .option(...chainIdOption)
+    .option(...rpcUrlOption)
+    .option("--encode-only", "Output transaction data as JSON instead of executing")
+    .action(async (options) => {
+      await executeCancelListing({
+        orderHash: options.orderHash,
+        nftAddress: options.nftAddress,
+        maker: options.maker,
+        privateKey: options.privateKey,
+        chainId: options.chainId,
+        rpcUrl: options.rpcUrl,
+        encodeOnly: options.encodeOnly,
+      });
+    });
+
+  const cancelOfferCommand = new Command("cancel-offer")
+    .description("Cancel a collection offer you created")
+    .requiredOption("--order-hash <hash>", "Order hash of the offer to cancel")
+    .requiredOption("--nft-address <address>", "NFT contract address")
+    .option("--maker <address>", "Maker address (required with --encode-only)")
+    .option(...privateKeyOption)
+    .option(...chainIdOption)
+    .option(...rpcUrlOption)
+    .option("--encode-only", "Output transaction data as JSON instead of executing")
+    .action(async (options) => {
+      await executeCancelOffer({
+        orderHash: options.orderHash,
+        nftAddress: options.nftAddress,
+        maker: options.maker,
+        privateKey: options.privateKey,
+        chainId: options.chainId,
+        rpcUrl: options.rpcUrl,
+        encodeOnly: options.encodeOnly,
+      });
+    });
+
+  const cancelErc20ListingCommand = new Command("cancel-erc20-listing")
+    .description("Cancel an ERC-20 listing you created")
+    .requiredOption("--order-hash <hash>", "Order hash of the listing to cancel")
+    .requiredOption("--token-address <address>", "ERC-20 token contract address")
+    .option("--maker <address>", "Maker address (required with --encode-only)")
+    .option(...privateKeyOption)
+    .option(...chainIdOption)
+    .option(...rpcUrlOption)
+    .option("--encode-only", "Output transaction data as JSON instead of executing")
+    .action(async (options) => {
+      await executeCancelErc20Listing({
+        orderHash: options.orderHash,
+        tokenAddress: options.tokenAddress,
+        maker: options.maker,
+        privateKey: options.privateKey,
+        chainId: options.chainId,
+        rpcUrl: options.rpcUrl,
+        encodeOnly: options.encodeOnly,
+      });
+    });
+
+  const cancelErc20OfferCommand = new Command("cancel-erc20-offer")
+    .description("Cancel an ERC-20 offer you created")
+    .requiredOption("--order-hash <hash>", "Order hash of the offer to cancel")
+    .requiredOption("--token-address <address>", "ERC-20 token contract address")
+    .option("--maker <address>", "Maker address (required with --encode-only)")
+    .option(...privateKeyOption)
+    .option(...chainIdOption)
+    .option(...rpcUrlOption)
+    .option("--encode-only", "Output transaction data as JSON instead of executing")
+    .action(async (options) => {
+      await executeCancelErc20Offer({
+        orderHash: options.orderHash,
+        tokenAddress: options.tokenAddress,
+        maker: options.maker,
+        privateKey: options.privateKey,
+        chainId: options.chainId,
+        rpcUrl: options.rpcUrl,
+        encodeOnly: options.encodeOnly,
+      });
+    });
+
   bazaarCommand.addCommand(listListingsCommand);
   bazaarCommand.addCommand(listOffersCommand);
   bazaarCommand.addCommand(listSalesCommand);
@@ -401,4 +491,8 @@ export function registerBazaarCommand(program: Command): void {
   bazaarCommand.addCommand(submitErc20OfferCommand);
   bazaarCommand.addCommand(buyErc20ListingCommand);
   bazaarCommand.addCommand(acceptErc20OfferCommand);
+  bazaarCommand.addCommand(cancelListingCommand);
+  bazaarCommand.addCommand(cancelOfferCommand);
+  bazaarCommand.addCommand(cancelErc20ListingCommand);
+  bazaarCommand.addCommand(cancelErc20OfferCommand);
 }

--- a/packages/net-cli/src/commands/bazaar/types.ts
+++ b/packages/net-cli/src/commands/bazaar/types.ts
@@ -159,3 +159,43 @@ export interface AcceptErc20OfferOptions {
   rpcUrl?: string;
   encodeOnly?: boolean;
 }
+
+export interface CancelListingOptions {
+  orderHash: string;
+  nftAddress: string;
+  maker?: string;
+  privateKey?: string;
+  chainId?: number;
+  rpcUrl?: string;
+  encodeOnly?: boolean;
+}
+
+export interface CancelOfferOptions {
+  orderHash: string;
+  nftAddress: string;
+  maker?: string;
+  privateKey?: string;
+  chainId?: number;
+  rpcUrl?: string;
+  encodeOnly?: boolean;
+}
+
+export interface CancelErc20ListingOptions {
+  orderHash: string;
+  tokenAddress: string;
+  maker?: string;
+  privateKey?: string;
+  chainId?: number;
+  rpcUrl?: string;
+  encodeOnly?: boolean;
+}
+
+export interface CancelErc20OfferOptions {
+  orderHash: string;
+  tokenAddress: string;
+  maker?: string;
+  privateKey?: string;
+  chainId?: number;
+  rpcUrl?: string;
+  encodeOnly?: boolean;
+}

--- a/packages/net-cli/src/commands/bazaar/types.ts
+++ b/packages/net-cli/src/commands/bazaar/types.ts
@@ -106,6 +106,7 @@ export interface CreateErc20ListingOptions {
   tokenAddress: string;
   tokenAmount: string;
   price: string;
+  targetFulfiller?: string;
   offerer?: string;
   privateKey?: string;
   chainId?: number;


### PR DESCRIPTION
## Summary

Closes the parity gaps between NFT and ERC20 bazaar surfaces. Concrete asymmetries fixed:

- `prepareCancelErc20Offer` was missing — the website worked around it by calling raw Seaport `cancel`.
- ERC20 listings ignored `targetFulfiller` during parsing even though create-listing accepts it.
- ERC20 listings/offers required `tokenAddress`, blocking cross-token feeds (the NFT side has `useBazaarListings({ chainId })` for the multi-chain home feed; no ERC20 analog).
- ERC20 listings had no `includeExpired` (NFT side does).
- CLI had zero cancel commands for either side.

## What changed

**SDK (`@net-protocol/bazaar` 0.1.19 → 0.1.20)**
- `BazaarClient.prepareCancelErc20Offer(offer)`
- `parseErc20ListingFromMessage` extracts `targetFulfiller` from `zoneHash`
- `GetErc20Listings/OffersOptions.tokenAddress` now optional; cross-token branch groups balance checks by `tokenAddress` and runs them in parallel
- `GetErc20ListingsOptions.includeExpired` added
- New `warmTokenDecimals(messages, side)` helper pre-fetches all distinct token decimals in parallel; cross-token paths now skip messages whose decimals can't be resolved instead of silently defaulting to 18
- Stale "only Base and HyperEVM" comments removed (also deployed on Ethereum and MegaETH)

**Hooks**
- `useBazaarErc20Listings`: optional `tokenAddress`, `includeExpired`
- `useBazaarErc20Offers`: optional `tokenAddress`

**CLI (`@net-protocol/cli` 0.1.48 → 0.1.49)**
- New commands: `cancel-listing`, `cancel-offer`, `cancel-erc20-listing`, `cancel-erc20-offer`
- Both `--private-key` (sign + send) and `--encode-only` paths
- Use existing `createWallet` + `executeTransaction` helpers from `shared/wallet.ts`

## Test plan

- [x] `cd packages/net-bazaar && yarn test` — **76/76 pass**, including 7 new tests (4 parsing tests for ERC20 `targetFulfiller`, 3 cancel-tx structural tests)
- [x] `cd packages/net-cli && yarn test` — 304/311 (7 pre-existing Bankr integration failures, confirmed identical on `main`)
- [x] `yarn workspaces foreach -A run build` — clean
- [x] `node packages/net-cli/dist/cli/index.mjs bazaar --help` — all 4 cancel subcommands listed

## Reviewer notes

- The cross-token decimals warm-up changes behavior: messages whose token decimals can't be fetched are now **dropped** rather than parsed with `18` as a fallback. This avoids silent mis-pricing of non-18-decimal tokens. Single-tokenAddress callers are unaffected (single pre-fetch path unchanged).
- ERC20 `getSales` was not added — `useBazaarSales({ nftAddress })` already works against ERC20 addresses (zone storage is keyed by address regardless of token kind); the parameter name is mis-leading but functional. Deferred to a follow-up rename.
- Cancel CLI commands fetch via `getListings`/`getCollectionOffers`/etc. with maker filter, then linear-scan by orderHash. For collection offers / ERC20 offers the SDK has no maker filter so it over-fetches — acceptable; a lighter `findOrderByHash` is a possible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)