### PR TITLE
Migrate Bankr integration from deprecated /agent/* to /wallet/* API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -226,3 +226,45 @@ yarn workspaces foreach -A run build
 ```
 
 This is especially common in git worktrees or after switching branches.
+
+**Additional note (May 2026):** `yarn workspaces foreach -A run build` only builds the `packages/net-*/dist` directories — it does **not** populate the nested `packages/net-X/node_modules/@net-protocol/*` copies. If you see `SyntaxError: The requested module ... does not provide an export named ...` from one of those nested paths, copy the freshly built dist into them:
+
+```bash
+for pkg_json in $(find packages -path '*/node_modules/@net-protocol/*/package.json' -not -path '*/dist/*' 2>/dev/null); do
+  nested_dir=$(dirname "$pkg_json")
+  pkg_name=$(node -p "require('./$pkg_json').name")
+  short_name=${pkg_name#@net-protocol/}
+  src_dist="packages/net-${short_name}/dist"
+  if [ -d "$src_dist" ] && [ ! -d "$nested_dir/dist" ]; then
+    cp -r "$src_dist" "$nested_dir/dist"
+  fi
+done
+```
+
+**Longer-term root-cause TODO:** the nested copies should be symlinks. Investigate the workspace's yarn `nodeLinker` / `enableTransparentWorkspaces` config so workspace-resolved deps don't get materialized as copies.
+
+### `yarn start` fails with `SyntaxError: ... does not provide an export named ...`
+
+**Symptom:** Running `yarn start` (or `tsx src/...`) inside `packages/net-cli` (or any package that imports `@net-protocol/*`) fails parsing a workspace package's TypeScript source.
+
+**Cause:** Most `@net-protocol/*` SDK packages (`net-core`, `net-storage`, `net-bazaar`, `net-feeds`, `net-chats`, `net-netr`, `net-profiles`, `net-relay`, `net-score`, `net-agents`) are missing `"type": "module"` in their `package.json`. When tsx resolves the import, it prefers the TS source (`src/index.ts`) over the built `dist/index.mjs` — and without `type: module`, Node interprets that source as CommonJS, so the named ESM exports are unavailable.
+
+**Workaround:** Run the built CLI instead of `yarn start`:
+
+```bash
+node packages/net-cli/dist/cli/index.mjs <command>
+```
+
+**Longer-term root-cause TODO:** Add `"type": "module"` to each SDK package's `package.json`, rename CJS dist output from `.js` → `.cjs` (in `tsup.config.ts` `outExtension`) and update `main` / `exports.require` to match. `net-cli` already follows this pattern.
+
+## External Integrations
+
+### Bankr Wallet API
+
+For programmatic transaction signing/submission via Bankr, use the **Wallet API** (`/wallet/sign`, `/wallet/submit`, `/wallet/me`) — not the deprecated `/agent/sign` and `/agent/submit` endpoints referenced in older test fixtures. The API key must have `walletApiEnabled`.
+
+- `GET https://api.bankr.bot/wallet/me` — returns wallet addresses (EVM + Solana), socials, club status.
+- `POST https://api.bankr.bot/wallet/submit` — submits a raw tx: `{ transaction: { to, chainId, value, data }, description, waitForConfirmation }`. Supports Base (8453), Ethereum (1), Polygon (137), Unichain (130), World Chain (480), Arbitrum (42161), BNB (56).
+- `POST https://api.bankr.bot/wallet/sign` — supports `personal_sign` and `eth_signTypedData_v4`. Body: `{ signatureType, message }` for personal_sign or `{ signatureType, typedData: { domain, types, primaryType, message } }` for EIP-712. Response: `{ success, signature, signer, signatureType }`.
+
+See `docs.bankr.bot/wallet-api/overview` for the canonical spec.

--- a/packages/net-agents/src/externalSigning.ts
+++ b/packages/net-agents/src/externalSigning.ts
@@ -49,7 +49,7 @@ const EIP712_DOMAIN_TYPE_WITH_VERIFYING_CONTRACT = [
 
 /**
  * Just the EIP-712 typed data structure — exactly what an external signer
- * (e.g., Bankr /agent/sign) expects in its `typedData` field.
+ * expects in its `typedData` field.
  *
  * BigInt values are pre-stringified so JSON.stringify works. Signers
  * normalize decimal strings back to the correct integer representation

--- a/packages/net-cli/src/__tests__/commands/bazaar/erc20-bankr-integration.test.ts
+++ b/packages/net-cli/src/__tests__/commands/bazaar/erc20-bankr-integration.test.ts
@@ -43,8 +43,12 @@ function toJsonSafe(obj: unknown): unknown {
   );
 }
 
+// NOTE: The /agent/sign and /agent/submit endpoints were retired in favor of
+// the Wallet API (/wallet/sign, /wallet/submit). Both personal_sign and
+// eth_signTypedData_v4 are supported by /wallet/sign. The request/response
+// body shapes are unchanged from the old /agent/* endpoints.
 async function bankrSign(body: object) {
-  const res = await fetch(`${BANKR_BASE_URL}/agent/sign`, {
+  const res = await fetch(`${BANKR_BASE_URL}/wallet/sign`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -58,7 +62,7 @@ async function bankrSign(body: object) {
 }
 
 async function bankrSubmit(body: object) {
-  const res = await fetch(`${BANKR_BASE_URL}/agent/submit`, {
+  const res = await fetch(`${BANKR_BASE_URL}/wallet/submit`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -154,16 +158,10 @@ async function submitOnChain(tx: TxConfig, description: string) {
 async function isBankrReachable(): Promise<boolean> {
   if (!BANKR_API_KEY) return false;
   try {
-    const res = await fetch(`${BANKR_BASE_URL}/agent/sign`, {
-      method: "POST",
+    const res = await fetch(`${BANKR_BASE_URL}/wallet/me`, {
       headers: {
-        "Content-Type": "application/json",
         "X-API-Key": BANKR_API_KEY,
       },
-      body: JSON.stringify({
-        signatureType: "personal_sign",
-        message: "ping",
-      }),
       signal: AbortSignal.timeout(10_000),
     });
     const data = await res.json();
@@ -191,11 +189,14 @@ describe.skipIf(!BANKR_API_KEY)(
     beforeAll(async ({ skip }) => {
       if (!canReachBankr) skip();
 
-      const result = await bankrSign({
-        signatureType: "personal_sign",
-        message: "get wallet address",
+      const res = await fetch(`${BANKR_BASE_URL}/wallet/me`, {
+        headers: { "X-API-Key": BANKR_API_KEY! },
       });
-      walletAddress = result.signer as `0x${string}`;
+      const data = await res.json();
+      const evmWallet = (data.wallets ?? []).find(
+        (w: { chain: string; address: string }) => w.chain === "evm"
+      );
+      walletAddress = evmWallet.address as `0x${string}`;
     }, 30_000);
 
     // ── 1. API connectivity ──────────────────────────────────────────

--- a/packages/net-cli/src/__tests__/commands/bazaar/erc20-bankr.test.ts
+++ b/packages/net-cli/src/__tests__/commands/bazaar/erc20-bankr.test.ts
@@ -110,7 +110,7 @@ import { executeSubmitErc20Listing } from "../../../commands/bazaar/submit-erc20
 import { executeSubmitErc20Offer } from "../../../commands/bazaar/submit-erc20-offer";
 
 /**
- * Validate that an object conforms to the Bankr /agent/sign request format
+ * Validate that an object conforms to the Bankr /wallet/sign request format
  * for eth_signTypedData_v4.
  */
 function validateBankrSignRequest(
@@ -135,7 +135,7 @@ function validateBankrSignRequest(
 }
 
 /**
- * Validate that an encoded transaction object conforms to the Bankr /agent/submit
+ * Validate that an encoded transaction object conforms to the Bankr /wallet/submit
  * request format.
  */
 function validateBankrSubmitRequest(
@@ -167,7 +167,7 @@ describe("ERC20 Bazaar commands + Bankr API compatibility", () => {
     consoleErrorSpy.mockClear();
   });
 
-  describe("create-erc20-listing keyless mode → Bankr /agent/sign", () => {
+  describe("create-erc20-listing keyless mode → Bankr /wallet/sign", () => {
     it("should output EIP-712 data compatible with Bankr sign API", async () => {
       const mockPrepared = createMockPreparedOrder();
       mockPrepareCreateErc20Listing.mockResolvedValue(mockPrepared);
@@ -298,7 +298,7 @@ describe("ERC20 Bazaar commands + Bankr API compatibility", () => {
     });
   });
 
-  describe("create-erc20-offer keyless mode → Bankr /agent/sign", () => {
+  describe("create-erc20-offer keyless mode → Bankr /wallet/sign", () => {
     it("should output EIP-712 data compatible with Bankr sign API", async () => {
       const mockPrepared = createMockPreparedOrder();
       mockPrepareCreateErc20Offer.mockResolvedValue(mockPrepared);
@@ -339,7 +339,7 @@ describe("ERC20 Bazaar commands + Bankr API compatibility", () => {
     });
   });
 
-  describe("buy-erc20-listing encode-only mode → Bankr /agent/submit", () => {
+  describe("buy-erc20-listing encode-only mode → Bankr /wallet/submit", () => {
     it("should output encoded transaction compatible with Bankr submit API", async () => {
       const mockListing = createMockErc20Listing();
       mockGetErc20Listings.mockResolvedValue([mockListing]);
@@ -442,7 +442,7 @@ describe("ERC20 Bazaar commands + Bankr API compatibility", () => {
     });
   });
 
-  describe("accept-erc20-offer encode-only mode → Bankr /agent/submit", () => {
+  describe("accept-erc20-offer encode-only mode → Bankr /wallet/submit", () => {
     it("should output encoded transaction compatible with Bankr submit API", async () => {
       const mockOffer = createMockErc20Offer();
       mockGetErc20Offers.mockResolvedValue([mockOffer]);
@@ -486,7 +486,7 @@ describe("ERC20 Bazaar commands + Bankr API compatibility", () => {
     });
   });
 
-  describe("submit-erc20-listing encode-only mode → Bankr /agent/submit", () => {
+  describe("submit-erc20-listing encode-only mode → Bankr /wallet/submit", () => {
     it("should output encoded transaction compatible with Bankr submit API", async () => {
       mockPrepareSubmitErc20Listing.mockReturnValue(
         createMockSubmitTxConfig()
@@ -526,7 +526,7 @@ describe("ERC20 Bazaar commands + Bankr API compatibility", () => {
     });
   });
 
-  describe("submit-erc20-offer encode-only mode → Bankr /agent/submit", () => {
+  describe("submit-erc20-offer encode-only mode → Bankr /wallet/submit", () => {
     it("should output encoded transaction compatible with Bankr submit API", async () => {
       mockPrepareSubmitErc20Offer.mockReturnValue(createMockSubmitTxConfig());
 
@@ -587,7 +587,7 @@ describe("ERC20 Bazaar commands + Bankr API compatibility", () => {
       expect(createCall).toBeDefined();
       const createOutput = JSON.parse(createCall![0]);
 
-      // Step 2: Format for Bankr /agent/sign
+      // Step 2: Format for Bankr /wallet/sign
       const signRequest = validateBankrSignRequest(createOutput.eip712);
       expect(signRequest.signatureType).toBe("eth_signTypedData_v4");
       expect(signRequest.typedData).toBeDefined();
@@ -628,7 +628,7 @@ describe("ERC20 Bazaar commands + Bankr API compatibility", () => {
       expect(submitCall).toBeDefined();
       const submitOutput = JSON.parse(submitCall![0]);
 
-      // Step 4: Format for Bankr /agent/submit
+      // Step 4: Format for Bankr /wallet/submit
       const submitRequest = validateBankrSubmitRequest(
         submitOutput,
         "Submit ERC-20 listing on-chain"
@@ -668,7 +668,7 @@ describe("ERC20 Bazaar commands + Bankr API compatibility", () => {
 
       const output = JSON.parse(jsonCall![0]);
 
-      // Step 2: Submit each approval via Bankr /agent/submit
+      // Step 2: Submit each approval via Bankr /wallet/submit
       for (const approval of output.approvals) {
         const approvalRequest: BankrSubmitRequest = {
           transaction: {
@@ -683,7 +683,7 @@ describe("ERC20 Bazaar commands + Bankr API compatibility", () => {
         expect(approvalRequest.transaction.to).toMatch(/^0x/);
       }
 
-      // Step 3: Submit the fulfillment via Bankr /agent/submit
+      // Step 3: Submit the fulfillment via Bankr /wallet/submit
       const fulfillRequest: BankrSubmitRequest = {
         transaction: {
           to: output.fulfillment.to,

--- a/packages/net-cli/src/commands/agent/dm.ts
+++ b/packages/net-cli/src/commands/agent/dm.ts
@@ -73,7 +73,7 @@ async function executeDm(
         "When using --session-token, you must also provide --topic and --topic-signature.\n" +
           "  Obtain the signature with:\n" +
           "    netp agent dm-auth-encode --agent-address <addr>  → produces { typedData, topic }\n" +
-          "    [sign .typedData with your external signer, e.g. Bankr /agent/sign]\n" +
+          "    [sign .typedData with your external signer]\n" +
           "  Then:\n" +
           "    netp agent dm <addr> <message> --session-token <token> --operator <addr> \\\n" +
           "      --topic <topic> --topic-signature <sig>",

--- a/packages/net-cli/src/commands/agent/session.ts
+++ b/packages/net-cli/src/commands/agent/session.ts
@@ -5,7 +5,7 @@
  * These commands expose the two-step flow so external signers can plug in:
  *
  *   1. `session-encode --operator 0x...` → { typedData, expiresAt }
- *   2. sign typedData externally (Bankr /agent/sign)
+ *   2. sign typedData externally
  *   3. `session-create --signature 0x... --expires-at N` → { sessionToken }
  */
 


### PR DESCRIPTION
## Summary

Updates all Bankr API integration points to use the new Wallet API endpoints (`/wallet/sign`, `/wallet/submit`, `/wallet/me`) in place of the deprecated `/agent/sign` and `/agent/submit` endpoints. The request/response body shapes remain unchanged, making this a straightforward endpoint migration.

## Key Changes

- **Test fixtures & integration tests** (`erc20-bankr-integration.test.ts`, `erc20-bankr.test.ts`):
  - Replaced `POST /agent/sign` → `POST /wallet/sign`
  - Replaced `POST /agent/submit` → `POST /wallet/submit`
  - Updated `isBankrReachable()` health check to use `GET /wallet/me` instead of a dummy `/agent/sign` call
  - Updated wallet address retrieval in `beforeAll` to call `/wallet/me` and extract the EVM wallet from the response

- **Documentation** (`CLAUDE.md`):
  - Added new "External Integrations" section documenting the Bankr Wallet API
  - Documented all three endpoints: `/wallet/me`, `/wallet/submit`, `/wallet/sign`
  - Listed supported chains and signature types
  - Added troubleshooting notes for workspace build issues and ESM/CommonJS module resolution

- **Code comments** (`externalSigning.ts`, `dm.ts`, `session.ts`):
  - Removed specific references to "Bankr /agent/sign" in favor of generic "external signer" language
  - Updated JSDoc and inline comments to reflect the API migration

## Implementation Details

- The `/wallet/me` endpoint returns wallet data with a `wallets` array containing chain-specific addresses (e.g., `{ chain: "evm", address: "0x..." }`)
- Request/response formats for `/wallet/sign` and `/wallet/submit` are backward-compatible with the old `/agent/*` endpoints
- All test descriptions and validation functions updated to reference the new endpoint names

https://claude.ai/code/session_01GsXvdg29ToE9EmxT9SuQX8