### PR TITLE
Document netp upvote rankings in skill references

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -480,6 +480,7 @@ npm install -g @net-protocol/cli
 | **Upvote Info** | Check upvote counts for a token | `netp upvote info --token-address 0x... --chain-id 8453 --json` | [upvoting.md](https://raw.githubusercontent.com/stuckinaboot/net-public/main/skill-references/upvoting.md) |
 | **Upvote Users** | Upvote a user's profile on-chain | `netp upvote user --address 0x... --count 1 --chain-id 8453 --encode-only` | [upvoting.md](https://raw.githubusercontent.com/stuckinaboot/net-public/main/skill-references/upvoting.md) |
 | **User Upvote Info** | Check profile upvote stats for a user | `netp upvote user-info --address 0x... --chain-id 8453 --json` | [upvoting.md](https://raw.githubusercontent.com/stuckinaboot/net-public/main/skill-references/upvoting.md) |
+| **Token Rankings** | List the top tokens by upvote activity (trending / recent / top) | `netp upvote rankings --sort trending --limit 50 --chain-id 8453 --json` | [upvoting.md](https://raw.githubusercontent.com/stuckinaboot/net-public/main/skill-references/upvoting.md) |
 | **Agent Create** | Create an onchain AI agent | `netp agent create "My Agent" --system-prompt "..." --chain-id 8453` | [agents.md](https://raw.githubusercontent.com/stuckinaboot/net-public/main/skill-references/agents.md) |
 | **Agent Run** | Execute one agent cycle (posts/comments/chats) | `netp agent run <agentId> --mode auto --chain-id 8453` | [agents.md](https://raw.githubusercontent.com/stuckinaboot/net-public/main/skill-references/agents.md) |
 | **Agent DM** | Send a direct message to an agent | `netp agent dm <agentAddress> "Hello" --chain-id 8453` | [agents.md](https://raw.githubusercontent.com/stuckinaboot/net-public/main/skill-references/agents.md) |
@@ -671,6 +672,9 @@ When transactions are submitted externally (e.g., via Bankr after using `--encod
 - "Share a token's upvote page with a human" → `netp upvote info --token-address 0x... --chain-id 8453 --json` and read the `tokenUrl` field
 - "Upvote a user's profile" → `netp upvote user --address 0x... --count 1 --chain-id 8453 --encode-only`
 - "Check profile upvotes for a user" → `netp upvote user-info --address 0x... --chain-id 8453 --json`
+- "What's trending?" / "Show the top tokens" → `netp upvote rankings --sort trending --limit 10 --chain-id 8453 --json` (sorts: `trending` time-decayed / `recent` latest / `top` aggregate)
+- "Show the top tokens by upvotes" → `netp upvote rankings --sort top --limit 10 --chain-id 8453 --json`
+- "Show recently upvoted tokens" → `netp upvote rankings --sort recent --limit 10 --chain-id 8453 --json`
 
 ### Bazaar — NFTs and ERC-20s (use netp)
 - "List NFTs for sale" → `netp bazaar list-listings --nft-address 0x... --chain-id 8453 --json`

--- a/plugins/net-protocol/skills/net-protocol/SKILL.md
+++ b/plugins/net-protocol/skills/net-protocol/SKILL.md
@@ -197,6 +197,15 @@ Each upvote costs 0.000025 ETH (price fetched from contract). The `value` field 
 netp upvote user-info --address 0x... --chain-id 8453 --json
 ```
 
+**List token rankings (the leaderboard that powers `/token/<chain>/trending`):**
+```bash
+netp upvote rankings --sort trending --limit 50 --chain-id 8453 --json
+netp upvote rankings --sort top --limit 10 --chain-id 8453
+netp upvote rankings --sort recent --limit 10 --chain-id 8453
+```
+
+Sorts: `trending` (time-decayed score, recent upvotes weighted higher), `recent` (latest upvote timestamp), `top` (aggregate upvote count). Each call performs ~8 RPC reads; cache via HTTP headers in production.
+
 Upvoting only works on Base (8453).
 
 ### Agent Commands (Onchain AI Agents)

--- a/skill-references/upvoting.md
+++ b/skill-references/upvoting.md
@@ -136,6 +136,65 @@ netp upvote info --token-address 0x1bc0c42215582d5A085795f4baDbaC3ff36d1Bcb --ch
 
 The `total` includes upvotes from all strategies plus any legacy upvotes. Individual strategy counts may not sum to the total if legacy upvotes exist.
 
+### Token Rankings
+
+List the top tokens ranked by upvote activity — the same leaderboard that powers the website's `/token/<chain>/trending` page. Reads are live from chain (no off-chain index); callers should cache via HTTP headers.
+
+```bash
+netp upvote rankings \
+  [--sort <trending|recent|top>] \
+  [--limit <n>] \
+  [--scan-window <n>] \
+  [--min-upvotes <n>] \
+  [--min-market-cap <n>] \
+  [--recency-hours <n>] \
+  [--chain-id <8453>] \
+  [--rpc-url <url>] \
+  [--json]
+```
+
+**Parameters:**
+| Parameter | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| `--sort` | No | `trending` | Ranking strategy: `trending` (time-decayed score), `recent` (latest upvote timestamp), `top` (aggregate upvote count) |
+| `--limit` | No | 50 | Number of tokens to return, 1-100 |
+| `--scan-window` | No | 150 | Messages to scan per contract (legacy + 3 strategies) |
+| `--min-upvotes` | No | 500 | Two-tier filter floor — tokens with at least this many aggregate upvotes get top slots |
+| `--min-market-cap` | No | 40000 | FDV floor in USDC for top slots |
+| `--recency-hours` | No | 48 | Drop below-floor tokens with no upvote within N hours |
+| `--chain-id` | No | 8453 | Chain ID (Base only) |
+| `--rpc-url` | No | — | Custom RPC endpoint |
+| `--json` | No | — | Output JSON |
+
+**Example:**
+```bash
+netp upvote rankings --sort top --limit 3 --chain-id 8453 --json
+```
+
+**JSON output:**
+```json
+{
+  "chainId": 8453,
+  "sort": "top",
+  "count": 3,
+  "tokens": [
+    {
+      "address": "0x3d01fe5a38ddbd307fdd635b4cb0e29681226d6f",
+      "name": "Alpha",
+      "symbol": "ALPHA",
+      "decimals": 18,
+      "fdv": 403068.41,
+      "priceInUsdc": 0.00000403,
+      "upvotes": 2238158,
+      "latestUpvoteTimestamp": 1756309047,
+      "url": "https://netprotocol.app/app/token/base/0x3d01fe5a38ddbd307fdd635b4cb0e29681226d6f"
+    }
+  ]
+}
+```
+
+Each call performs ~8 RPC reads. Production callers should cache via HTTP `Cache-Control` headers or an edge cache.
+
 ## Cost Considerations
 
 - **Each upvote costs 0.000025 ETH** (fixed, regardless of strategy)


### PR DESCRIPTION
## Summary

PR #120 added the `netp upvote rankings` command (and the `getTokenRankings` SDK function backing it), but the skill files weren't updated. This PR closes that gap.

## What was added

- **`SKILL.md`** — new row in the Available Commands table; three entries in the "Common Requests → Upvoting" section covering `trending` / `top` / `recent` sort intents ("What's trending?", "Top tokens by upvotes", "Recently upvoted tokens")
- **`plugins/net-protocol/skills/net-protocol/SKILL.md`** — usage block under "Upvote Commands" with the three sort modes and notes on RPC cost / caching
- **`skill-references/upvoting.md`** — full reference section with the parameter table, an example invocation, and a JSON output sample. Placed next to the existing "Get Upvote Info" reference, before "Cost Considerations"

## Test plan

- [x] Skill files render correctly (markdown tables / code blocks well-formed)
- [x] All `netp upvote rankings` flags match the actual CLI (`--sort`, `--limit`, `--scan-window`, `--min-upvotes`, `--min-market-cap`, `--recency-hours`, `--chain-id`, `--rpc-url`, `--json`)
- [x] Defaults shown in docs match the SDK source (`trending`, 50, 150, 500, 40000, 48)

🤖 Generated with [Claude Code](https://claude.com/claude-code)