### PR TITLE
docs: clarify bazaar offer/listing parameters and flows

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -673,10 +673,14 @@ When transactions are submitted externally (e.g., via Bankr after using `--encod
 - "Check profile upvotes for a user" → `netp upvote user-info --address 0x... --chain-id 8453 --json`
 
 ### Bazaar — NFTs and ERC-20s (use netp)
-- "List NFTs for sale" → `netp bazaar list-listings --nft-address 0x... --chain-id 8453 --json`
+- "Browse NFT listings for a collection" → `netp bazaar list-listings --nft-address 0x... --chain-id 8453 --json`
+- "List my NFT for sale" / "Create an NFT listing" → `netp bazaar create-listing --nft-address 0x... --token-id 42 --price 0.1 --offerer 0xMyAddr --chain-id 8453` (keyless; sign the returned EIP-712 then `submit-listing`)
+- "Make an offer on an NFT collection" → `netp bazaar create-offer --nft-address 0x... --price 0.1 --offerer 0xMyAddr --chain-id 8453` (bid is paid in WETH; keyless; sign then `submit-offer`)
 - "Buy an NFT" → `netp bazaar buy-listing --order-hash 0x... --nft-address 0x... --buyer 0xMyAddr --chain-id 8453 --encode-only`
 - "What NFTs do I own?" → `netp bazaar owned-nfts --nft-address 0x... --owner 0xMyAddr --chain-id 8453 --json`
-- "List ERC-20 tokens for sale" → `netp bazaar list-erc20-listings --token-address 0x... --chain-id 8453 --json`
+- "Browse ERC-20 listings for a token" → `netp bazaar list-erc20-listings --token-address 0x... --chain-id 8453 --json`
+- "Sell my ERC-20 tokens" / "Create an ERC-20 listing" → `netp bazaar create-erc20-listing --token-address 0x... --token-amount 1000000000000000000 --price 0.05 --offerer 0xMyAddr --chain-id 8453` (keyless; sign then `submit-erc20-listing`)
+- "Make an offer on an ERC-20 token" → `netp bazaar create-erc20-offer --token-address 0x... --token-amount 1000000000000000000 --price 0.05 --offerer 0xMyAddr --chain-id 8453` (bid is paid in wrapped native currency; keyless; sign then `submit-erc20-offer`)
 - "Check ERC-20 offers for a token" → `netp bazaar list-erc20-offers --token-address 0x... --chain-id 8453 --json`
 - "Buy ERC-20 tokens from a listing" → `netp bazaar buy-erc20-listing --order-hash 0x... --token-address 0x... --buyer 0xMyAddr --chain-id 8453 --encode-only`
 - "Accept an ERC-20 offer (sell tokens for wrapped native currency)" → `netp bazaar accept-erc20-offer --order-hash 0x... --token-address 0x... --seller 0xMyAddr --chain-id 8453 --encode-only`

--- a/skill-references/bazaar.md
+++ b/skill-references/bazaar.md
@@ -196,7 +196,7 @@ The agent should:
 
 Create a collection offer (bid on any token in a collection). Same dual mode as create-listing:
 
-**With private key:**
+**With private key (full flow):**
 ```bash
 netp bazaar create-offer \
   --nft-address <address> \
@@ -205,7 +205,9 @@ netp bazaar create-offer \
   --private-key 0x...
 ```
 
-**Without private key:**
+Steps executed: wrap native currency if needed, approve Seaport (directly — no conduit) to spend the wrapped native currency -> sign EIP-712 order -> submit offer on-chain.
+
+**Without private key (output EIP-712 data):**
 ```bash
 netp bazaar create-offer \
   --nft-address <address> \
@@ -214,7 +216,16 @@ netp bazaar create-offer \
   --chain-id 8453
 ```
 
-Output format is the same as create-listing. Use `submit-offer` for the follow-up.
+**Parameters:**
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `--nft-address` | Yes | NFT contract address. Offer applies to any token in this collection. |
+| `--price` | Yes | Bid amount in the chain's native currency unit (e.g. `0.1`). The actual currency moved on-chain is the **wrapped** native currency (WETH on Base/Ethereum) — the offerer pre-approves WETH to Seaport, and the fulfiller pulls it on accept. The offerer must hold enough WETH (or enough native currency for the CLI to wrap). |
+| `--offerer` | No | Required without `--private-key`. |
+
+`--price` is the **total** WETH the offerer is bidding, expressed as a decimal. The approval emitted in `approvals` (keyless mode) is a WETH `approve` to **Seaport directly** (not a conduit — see "Approval Spender" above).
+
+Output format is the same as `create-listing` (EIP-712 data + approvals). Use `submit-offer` for the follow-up.
 
 ## Submit Listing
 
@@ -453,7 +464,15 @@ netp bazaar create-erc20-offer \
   --chain-id 8453
 ```
 
-`--price` is the **total** amount of the wrapped native currency (WETH on Base, wrapped HYPE on HyperEVM) the offerer is bidding for the whole `token-amount`, expressed as a decimal. The approval emitted is a wrapped-native `approve` to **Seaport directly** (not a conduit — see "Approval Spender" above). Use `submit-erc20-offer` for the follow-up.
+**Parameters:**
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `--token-address` | Yes | ERC-20 token contract address (the token being bid on). |
+| `--token-amount` | Yes | Amount to buy in **raw units** (bigint string, e.g. `1000000000000000000` for 1.0 of an 18-decimal token). |
+| `--price` | Yes | **Total** amount of the wrapped native currency (WETH on Base, wrapped HYPE on HyperEVM) bid for the whole `token-amount`, expressed as a decimal (e.g. `0.05`). |
+| `--offerer` | No | Required without `--private-key`. |
+
+The approval emitted in `approvals` (keyless mode) is a wrapped-native `approve` to **Seaport directly** (not a conduit — see "Approval Spender" above). Use `submit-erc20-offer` for the follow-up.
 
 ## Submit ERC-20 Listing
 


### PR DESCRIPTION
## Summary
Enhanced documentation for NFT Bazaar marketplace commands to clarify parameter requirements, execution flows, and approval mechanics. Updated skill references to better guide users on when to use each command.

## Key Changes

- **create-offer command**: 
  - Renamed section headers to distinguish "full flow" (with private key) vs "output EIP-712 data" (keyless mode)
  - Added detailed parameter table documenting `--nft-address`, `--price`, and `--offerer`
  - Clarified that `--price` is the total WETH bid amount and that approvals go directly to Seaport (not a conduit)
  - Added explanation of execution steps for full flow

- **create-erc20-offer command**:
  - Added comprehensive parameter table for `--token-address`, `--token-amount`, `--price`, and `--offerer`
  - Clarified that `--price` is the total wrapped native currency amount for the entire `token-amount`
  - Moved approval details to a separate note for clarity

- **SKILL.md examples**:
  - Updated NFT/ERC-20 marketplace examples to be more user-intent focused ("Browse NFT listings" vs "List NFTs for sale")
  - Added examples for `create-listing`, `create-offer`, `create-erc20-listing`, and `create-erc20-offer` with keyless mode syntax
  - Clarified that offers are paid in wrapped native currency (WETH/wrapped HYPE)
  - Added notes about signing EIP-712 and using follow-up submit commands

## Notable Details

- Emphasized that wrapped native currency (WETH on Base/Ethereum) is used for offers, not native currency
- Clarified the distinction between keyless mode (outputs EIP-712 data for external signing) and full flow (with private key)
- Documented that approvals in keyless mode are to Seaport directly, not through a conduit
- Provided consistent parameter documentation across similar commands

https://claude.ai/code/session_01DDCbRrCPT7G7qVomWtmzYY