### PR TITLE
Add ERC20 quote token support for Base chain

### DIFF
--- a/packages/net-bazaar/package.json
+++ b/packages/net-bazaar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@net-protocol/bazaar",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "SDK for Net Bazaar - a decentralized bazaar storing all orders onchain via Seaport",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/net-bazaar/src/__tests__/chainConfig.test.ts
+++ b/packages/net-bazaar/src/__tests__/chainConfig.test.ts
@@ -7,6 +7,7 @@ import {
   getCollectionOffersAddress,
   getSeaportAddress,
   getWrappedNativeCurrency,
+  getErc20QuoteToken,
   getCurrencySymbol,
   getNftFeeBps,
   getErc20FeeBps,
@@ -101,6 +102,21 @@ describe("chainConfig", () => {
     it("returns WHYPE for HyperEVM", () => {
       const whype = getWrappedNativeCurrency(999);
       expect(whype?.symbol).toBe("WHYPE");
+    });
+  });
+
+  describe("getErc20QuoteToken", () => {
+    it("returns USDC for Base", () => {
+      const usdc = getErc20QuoteToken(8453);
+      expect(usdc?.symbol).toBe("USDC");
+      expect(usdc?.address).toBe("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913");
+      expect(usdc?.decimals).toBe(6);
+    });
+
+    it("returns undefined for chains without a configured quote token", () => {
+      expect(getErc20QuoteToken(1)).toBeUndefined();
+      expect(getErc20QuoteToken(84532)).toBeUndefined();
+      expect(getErc20QuoteToken(999)).toBeUndefined();
     });
   });
 

--- a/packages/net-bazaar/src/__tests__/orderCreation.test.ts
+++ b/packages/net-bazaar/src/__tests__/orderCreation.test.ts
@@ -182,7 +182,9 @@ describe("buildCollectionOfferOrderComponents", () => {
 });
 
 describe("buildErc20OfferOrderComponents", () => {
-  it("builds an ERC20 offer (chain 8453, 0% fee)", () => {
+  const BASE_USDC = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913" as `0x${string}`;
+
+  it("builds an ERC20 offer (chain 8453, 0% fee) using USDC as the quote token", () => {
     const { orderParameters } = buildErc20OfferOrderComponents(
       {
         tokenAddress: TOKEN_ADDRESS,
@@ -194,8 +196,9 @@ describe("buildErc20OfferOrderComponents", () => {
       BigInt(0)
     );
 
-    // Offer: WETH
+    // Offer: USDC payment from the buyer
     expect(orderParameters.offer[0].itemType).toBe(ItemType.ERC20);
+    expect(orderParameters.offer[0].token.toLowerCase()).toBe(BASE_USDC.toLowerCase());
 
     // Consideration: ERC20 tokens (no fee item on a 0% chain)
     expect(orderParameters.consideration).toHaveLength(1);
@@ -212,20 +215,39 @@ describe("buildErc20OfferOrderComponents", () => {
         priceWei: BigInt("1000000000000000000"),
         offerer: OFFERER,
       },
-      84532, // baseSepolia: default fees (5% NFT, 1% ERC20)
+      84532, // baseSepolia: default fees (5% NFT, 1% ERC20), no USDC quote token
       BigInt(0)
     );
 
-    // Consideration[1] is the fee item (WETH to feeCollector)
+    // Consideration[1] is the fee item (WETH to feeCollector on this chain)
     expect(orderParameters.consideration).toHaveLength(2);
     const feeAmount = orderParameters.consideration[1].startAmount;
     // Fee = ceiling(1e18 * 100 / 10000) = 10000000000000000 (1%)
     expect(feeAmount).toBe(BigInt("10000000000000000"));
   });
+
+  it("uses WETH (not USDC) on chains without an erc20QuoteToken", () => {
+    const { orderParameters } = buildErc20OfferOrderComponents(
+      {
+        tokenAddress: TOKEN_ADDRESS,
+        tokenAmount: BigInt("1000000"),
+        priceWei: BigInt("1000000000000000000"),
+        offerer: OFFERER,
+      },
+      84532, // baseSepolia: no erc20QuoteToken configured
+      BigInt(0)
+    );
+
+    // Offer should be WETH on chains without a quote token override
+    const wethAddress = "0x4200000000000000000000000000000000000006";
+    expect(orderParameters.offer[0].token.toLowerCase()).toBe(wethAddress);
+  });
 });
 
 describe("buildErc20ListingOrderComponents", () => {
-  it("applies 1% ERC20 fee on default-fee chains (not 5% NFT fee)", () => {
+  const BASE_USDC = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913" as `0x${string}`;
+
+  it("uses native consideration and applies 1% fee on chains without a quote token", () => {
     const { orderParameters } = buildErc20ListingOrderComponents(
       {
         tokenAddress: TOKEN_ADDRESS,
@@ -233,7 +255,7 @@ describe("buildErc20ListingOrderComponents", () => {
         priceWei: BigInt("1000000000000000000"),
         offerer: OFFERER,
       },
-      84532,
+      84532, // baseSepolia: no quote token configured
       BigInt(0)
     );
 
@@ -244,12 +266,37 @@ describe("buildErc20ListingOrderComponents", () => {
     // Consideration: native payment + fee (ceiling division for ERC20s)
     expect(orderParameters.consideration).toHaveLength(2);
     expect(orderParameters.consideration[0].itemType).toBe(ItemType.NATIVE);
+    expect(orderParameters.consideration[1].itemType).toBe(ItemType.NATIVE);
 
     const sellerAmount = orderParameters.consideration[0].startAmount;
     const feeAmount = orderParameters.consideration[1].startAmount;
     // Fee = ceiling(1e18 * 100 / 10000) = 10000000000000000 (1%)
     expect(feeAmount).toBe(BigInt("10000000000000000"));
     expect(sellerAmount + feeAmount).toBe(BigInt("1000000000000000000"));
+  });
+
+  it("uses USDC consideration on Base (chain 8453) instead of native ETH", () => {
+    const { orderParameters } = buildErc20ListingOrderComponents(
+      {
+        tokenAddress: TOKEN_ADDRESS,
+        tokenAmount: BigInt("1000000000000000000"), // 1 token, 18 decimals
+        priceWei: BigInt("5000000"), // 5 USDC (6 decimals)
+        offerer: OFFERER,
+      },
+      8453,
+      BigInt(0)
+    );
+
+    // Offer: ERC20 tokens being sold
+    expect(orderParameters.offer[0].itemType).toBe(ItemType.ERC20);
+    expect(orderParameters.offer[0].token).toBe(TOKEN_ADDRESS);
+
+    // Consideration must be ERC20 USDC (0% fee on Base means a single item)
+    expect(orderParameters.consideration).toHaveLength(1);
+    expect(orderParameters.consideration[0].itemType).toBe(ItemType.ERC20);
+    expect(orderParameters.consideration[0].token.toLowerCase()).toBe(BASE_USDC.toLowerCase());
+    expect(orderParameters.consideration[0].startAmount).toBe(BigInt("5000000"));
+    expect(orderParameters.consideration[0].recipient).toBe(OFFERER);
   });
 
   it("supports private orders", () => {

--- a/packages/net-bazaar/src/__tests__/parsing.test.ts
+++ b/packages/net-bazaar/src/__tests__/parsing.test.ts
@@ -1,8 +1,12 @@
 import { describe, it, expect } from "vitest";
 import { encodeAbiParameters } from "viem";
-import { parseListingFromMessage, parseErc20ListingFromMessage } from "../utils/parsing";
+import { parseListingFromMessage, parseErc20ListingFromMessage, parseErc20OfferFromMessage } from "../utils/parsing";
 import { BAZAAR_SUBMISSION_ABI } from "../abis";
-import { NET_SEAPORT_PRIVATE_ORDER_ZONE_ADDRESS, NET_SEAPORT_ZONE_ADDRESS } from "../chainConfig";
+import {
+  NET_SEAPORT_COLLECTION_OFFER_ZONE_ADDRESS,
+  NET_SEAPORT_PRIVATE_ORDER_ZONE_ADDRESS,
+  NET_SEAPORT_ZONE_ADDRESS,
+} from "../chainConfig";
 import { ItemType, OrderType } from "../types";
 
 // Helper to create a mock NetMessage with encoded Seaport submission data
@@ -231,7 +235,7 @@ function createMockErc20ListingMessage({
 describe("parseErc20ListingFromMessage", () => {
   it("parses a basic public ERC20 listing", () => {
     const message = createMockErc20ListingMessage();
-    const listing = parseErc20ListingFromMessage(message as any, 8453, 18);
+    const listing = parseErc20ListingFromMessage(message as any, 84532, 18);
 
     expect(listing).not.toBeNull();
     expect(listing!.maker).toBe("0x1234567890123456789012345678901234567890");
@@ -249,7 +253,7 @@ describe("parseErc20ListingFromMessage", () => {
       zoneHash: privateZoneHash,
     });
 
-    const listing = parseErc20ListingFromMessage(message as any, 8453, 18);
+    const listing = parseErc20ListingFromMessage(message as any, 84532, 18);
 
     expect(listing).not.toBeNull();
     expect(listing!.targetFulfiller).toBe(privateZoneHash);
@@ -261,7 +265,7 @@ describe("parseErc20ListingFromMessage", () => {
       zoneHash: "0x0000000000000000000000000000000000000000000000000000000000000000",
     });
 
-    const listing = parseErc20ListingFromMessage(message as any, 8453, 18);
+    const listing = parseErc20ListingFromMessage(message as any, 84532, 18);
 
     expect(listing).not.toBeNull();
     expect(listing!.targetFulfiller).toBeUndefined();
@@ -273,9 +277,180 @@ describe("parseErc20ListingFromMessage", () => {
       zoneHash: "0x00000000000000000000000000000000000000000000000000000000deadbeef",
     });
 
-    const listing = parseErc20ListingFromMessage(message as any, 8453, 18);
+    const listing = parseErc20ListingFromMessage(message as any, 84532, 18);
 
     expect(listing).not.toBeNull();
     expect(listing!.targetFulfiller).toBeUndefined();
+  });
+
+  it("rejects legacy native-payment listings on chains with a configured USDC quote token", () => {
+    // Base (8453) is configured with USDC as quote token, so a native-payment
+    // listing must be filtered out — legacy WETH/ETH orders no longer appear.
+    const message = createMockErc20ListingMessage();
+    const listing = parseErc20ListingFromMessage(message as any, 8453, 18);
+    expect(listing).toBeNull();
+  });
+});
+
+// Helper to create a mock USDC-denominated ERC20 listing (consideration = ERC20 USDC)
+const BASE_USDC_ADDRESS =
+  "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913" as `0x${string}`;
+
+function createMockErc20UsdcListingMessage({
+  offerer = "0x1234567890123456789012345678901234567890" as `0x${string}`,
+  tokenAddress = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" as `0x${string}`,
+  tokenAmount = BigInt("1000000000000000000"),
+  price = BigInt("5000000"), // 5 USDC (6 decimals)
+  quoteToken = BASE_USDC_ADDRESS,
+}: {
+  offerer?: `0x${string}`;
+  tokenAddress?: `0x${string}`;
+  tokenAmount?: bigint;
+  price?: bigint;
+  quoteToken?: `0x${string}`;
+} = {}) {
+  const submission = {
+    parameters: {
+      offerer,
+      zone: NET_SEAPORT_ZONE_ADDRESS,
+      offer: [
+        {
+          itemType: ItemType.ERC20,
+          token: tokenAddress,
+          identifierOrCriteria: BigInt(0),
+          startAmount: tokenAmount,
+          endAmount: tokenAmount,
+        },
+      ],
+      consideration: [
+        {
+          itemType: ItemType.ERC20,
+          token: quoteToken,
+          identifierOrCriteria: BigInt(0),
+          startAmount: price,
+          endAmount: price,
+          recipient: offerer,
+        },
+      ],
+      orderType: OrderType.FULL_RESTRICTED,
+      startTime: BigInt(0),
+      endTime: BigInt(Math.floor(Date.now() / 1000) + 86400),
+      zoneHash: "0x0000000000000000000000000000000000000000000000000000000000000000" as `0x${string}`,
+      salt: BigInt(12345),
+      conduitKey: "0x0000000000000000000000000000000000000000000000000000000000000000" as `0x${string}`,
+      totalOriginalConsiderationItems: BigInt(1),
+    },
+    counter: BigInt(0),
+    signature: "0x1234" as `0x${string}`,
+  };
+
+  const data = encodeAbiParameters(BAZAAR_SUBMISSION_ABI, [submission]);
+  return {
+    sender: offerer,
+    text: "",
+    data,
+    timestamp: BigInt(Math.floor(Date.now() / 1000)),
+  };
+}
+
+describe("parseErc20ListingFromMessage with USDC quote token (Base)", () => {
+  it("parses a USDC-denominated ERC20 listing on Base", () => {
+    const message = createMockErc20UsdcListingMessage();
+    const listing = parseErc20ListingFromMessage(message as any, 8453, 18);
+
+    expect(listing).not.toBeNull();
+    expect(listing!.tokenAddress.toLowerCase()).toBe("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+    expect(listing!.tokenAmount).toBe(BigInt("1000000000000000000"));
+    expect(listing!.priceWei).toBe(BigInt("5000000"));
+  });
+
+  it("rejects a USDC listing whose consideration is a different ERC20 token", () => {
+    const wrongToken = "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef" as `0x${string}`;
+    const message = createMockErc20UsdcListingMessage({ quoteToken: wrongToken });
+    const listing = parseErc20ListingFromMessage(message as any, 8453, 18);
+    expect(listing).toBeNull();
+  });
+});
+
+// Helper to create a mock ERC20 offer message (buyer offers `quoteToken` for `tokenAddress`)
+function createMockErc20OfferMessage({
+  offerer = "0x1234567890123456789012345678901234567890" as `0x${string}`,
+  tokenAddress = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" as `0x${string}`,
+  tokenAmount = BigInt("1000000000000000000"),
+  price = BigInt("5000000"),
+  quoteToken = BASE_USDC_ADDRESS,
+}: {
+  offerer?: `0x${string}`;
+  tokenAddress?: `0x${string}`;
+  tokenAmount?: bigint;
+  price?: bigint;
+  quoteToken?: `0x${string}`;
+} = {}) {
+  const submission = {
+    parameters: {
+      offerer,
+      zone: NET_SEAPORT_COLLECTION_OFFER_ZONE_ADDRESS,
+      offer: [
+        {
+          itemType: ItemType.ERC20,
+          token: quoteToken,
+          identifierOrCriteria: BigInt(0),
+          startAmount: price,
+          endAmount: price,
+        },
+      ],
+      consideration: [
+        {
+          itemType: ItemType.ERC20,
+          token: tokenAddress,
+          identifierOrCriteria: BigInt(0),
+          startAmount: tokenAmount,
+          endAmount: tokenAmount,
+          recipient: offerer,
+        },
+      ],
+      orderType: OrderType.FULL_RESTRICTED,
+      startTime: BigInt(0),
+      endTime: BigInt(Math.floor(Date.now() / 1000) + 86400),
+      zoneHash: "0x0000000000000000000000000000000000000000000000000000000000000000" as `0x${string}`,
+      salt: BigInt(12345),
+      conduitKey: "0x0000000000000000000000000000000000000000000000000000000000000000" as `0x${string}`,
+      totalOriginalConsiderationItems: BigInt(1),
+    },
+    counter: BigInt(0),
+    signature: "0x1234" as `0x${string}`,
+  };
+
+  const data = encodeAbiParameters(BAZAAR_SUBMISSION_ABI, [submission]);
+  return {
+    sender: offerer,
+    text: "",
+    data,
+    timestamp: BigInt(Math.floor(Date.now() / 1000)),
+  };
+}
+
+describe("parseErc20OfferFromMessage with USDC quote token (Base)", () => {
+  it("parses a USDC-denominated ERC20 offer on Base", () => {
+    const message = createMockErc20OfferMessage();
+    const offer = parseErc20OfferFromMessage(message as any, 8453, 18);
+
+    expect(offer).not.toBeNull();
+    expect(offer!.tokenAddress.toLowerCase()).toBe("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+    expect(offer!.priceWei).toBe(BigInt("5000000"));
+  });
+
+  it("rejects a legacy WETH-denominated offer on Base", () => {
+    const wethAddress = "0x4200000000000000000000000000000000000006" as `0x${string}`;
+    const message = createMockErc20OfferMessage({ quoteToken: wethAddress });
+    const offer = parseErc20OfferFromMessage(message as any, 8453, 18);
+    expect(offer).toBeNull();
+  });
+
+  it("accepts WETH-denominated offers on chains without a USDC quote token", () => {
+    const wethAddress = "0x4200000000000000000000000000000000000006" as `0x${string}`;
+    const message = createMockErc20OfferMessage({ quoteToken: wethAddress });
+    const offer = parseErc20OfferFromMessage(message as any, 84532, 18);
+    expect(offer).not.toBeNull();
   });
 });

--- a/packages/net-bazaar/src/chainConfig.ts
+++ b/packages/net-bazaar/src/chainConfig.ts
@@ -348,6 +348,26 @@ export function getErc20QuoteToken(chainId: number): QuoteToken | undefined {
 }
 
 /**
+ * Resolve the ERC20 token used to pay for offers (and to receive payment in
+ * listings) on a chain.
+ *
+ * Returns the configured `erc20QuoteToken` if set (e.g. USDC on Base),
+ * otherwise the wrapped native currency synthesized as a 18-decimal quote
+ * token. Returns undefined when neither is configured.
+ *
+ * This is the single source of truth for "what token denominates ERC20
+ * bazaar trades?" — call sites that previously combined `getErc20QuoteToken`
+ * and `getWrappedNativeCurrency` should use this instead.
+ */
+export function getErc20PaymentToken(chainId: number): QuoteToken | undefined {
+  const quote = BAZAAR_CHAIN_CONFIGS[chainId]?.erc20QuoteToken;
+  if (quote) return quote;
+  const weth = BAZAAR_CHAIN_CONFIGS[chainId]?.wrappedNativeCurrency;
+  if (!weth) return undefined;
+  return { address: weth.address, symbol: weth.symbol, decimals: 18 };
+}
+
+/**
  * Get currency symbol for a chain (lowercase)
  */
 export function getCurrencySymbol(chainId: number): string {

--- a/packages/net-bazaar/src/chainConfig.ts
+++ b/packages/net-bazaar/src/chainConfig.ts
@@ -10,6 +10,20 @@ export interface WrappedNativeCurrency {
   symbol: string;
 }
 
+/**
+ * Quote token for ERC20 bazaar trades.
+ *
+ * When set, ERC20 offers and listings on this chain use this token as the
+ * payment currency instead of the wrapped native currency / native currency.
+ * Offers pay in this token; listings receive payment in this token (ERC20
+ * consideration instead of NATIVE).
+ */
+export interface QuoteToken {
+  address: `0x${string}`;
+  symbol: string;
+  decimals: number;
+}
+
 export interface BazaarChainConfig {
   /** Main NFT listing contract */
   bazaarAddress: `0x${string}`;
@@ -29,6 +43,14 @@ export interface BazaarChainConfig {
   erc20FeeBps?: number;
   /** Wrapped native currency (WETH, etc.) */
   wrappedNativeCurrency: WrappedNativeCurrency;
+  /**
+   * Optional quote token for ERC20 bazaar trades.
+   *
+   * If set, ERC20 offers/listings on this chain use this token (e.g. USDC)
+   * for pricing instead of the wrapped native currency / native currency.
+   * If unset, offers use wrappedNativeCurrency and listings use NATIVE.
+   */
+  erc20QuoteToken?: QuoteToken;
   /** Address with high ETH balance for Seaport checks */
   highEthAddress?: `0x${string}`;
   /** Native currency symbol (lowercase) */
@@ -90,6 +112,12 @@ const BAZAAR_CHAIN_CONFIGS: Record<number, BazaarChainConfig> = {
       address: "0x4200000000000000000000000000000000000006",
       name: "Wrapped Ether",
       symbol: "WETH",
+    },
+    // ERC20 bazaar trades on Base are priced in USDC, not WETH/ETH.
+    erc20QuoteToken: {
+      address: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+      symbol: "USDC",
+      decimals: 6,
     },
     currencySymbol: "eth",
   },
@@ -306,6 +334,17 @@ export function getErc20FeeBps(chainId: number): number {
  */
 export function getWrappedNativeCurrency(chainId: number): WrappedNativeCurrency | undefined {
   return BAZAAR_CHAIN_CONFIGS[chainId]?.wrappedNativeCurrency;
+}
+
+/**
+ * Get the ERC20 bazaar quote token for a chain, if one is configured.
+ *
+ * When set, ERC20 offers and listings on this chain price/settle in this
+ * token (e.g. USDC on Base) instead of WETH/native ETH. When undefined,
+ * the chain uses the legacy WETH-for-offers / native-for-listings flow.
+ */
+export function getErc20QuoteToken(chainId: number): QuoteToken | undefined {
+  return BAZAAR_CHAIN_CONFIGS[chainId]?.erc20QuoteToken;
 }
 
 /**

--- a/packages/net-bazaar/src/client/BazaarClient.ts
+++ b/packages/net-bazaar/src/client/BazaarClient.ts
@@ -46,7 +46,7 @@ import {
   getErc20BazaarAddress,
   getSeaportAddress,
   getWrappedNativeCurrency,
-  getErc20QuoteToken,
+  getErc20PaymentToken,
   isBazaarSupportedOnChain,
   NET_SEAPORT_ZONE_ADDRESS,
 } from "../chainConfig";
@@ -646,17 +646,13 @@ export class BazaarClient {
   ): Promise<Erc20Offer[]> {
     const { tokenAddress, excludeMaker } = options;
     const tag = `[BazaarClient.processErc20Offers chain=${this.chainId}]`;
-    // The offer side of an ERC20 offer is the chain's quote token (USDC on
-    // Base, WETH elsewhere). Balances and validation use the same address.
-    const quoteToken = getErc20QuoteToken(this.chainId);
-    const wrappedNative = getWrappedNativeCurrency(this.chainId);
-    const offerPaymentToken = quoteToken
-      ? { address: quoteToken.address }
-      : wrappedNative;
-
-    if (!offerPaymentToken) {
+    // The offer side of an ERC20 offer is the chain's payment token
+    // (USDC on Base, WETH elsewhere). Balances and validation use the same address.
+    const paymentToken = getErc20PaymentToken(this.chainId);
+    if (!paymentToken) {
       return [];
     }
+    const paymentTokenAddressLower = paymentToken.address.toLowerCase();
 
     // Resolve decimals: one shot for single-token queries, otherwise warm the
     // cache for every distinct consideration token in parallel before parsing.
@@ -679,13 +675,13 @@ export class BazaarClient {
       const offer = parseErc20OfferFromMessage(message, this.chainId, decimals);
       if (!offer) continue;
 
-      // Validate the offer's payment token matches the chain's quote token
+      // Validate the offer's payment token matches the chain's payment token
       // (USDC on Base, WETH elsewhere). parseErc20OfferFromMessage already
       // enforces this on chains with a configured quote token, but this guard
       // also keeps legacy non-WETH offers out on chains without one.
       const order = getSeaportOrderFromMessageData(offer.messageData);
       const offerToken = order.parameters.offer?.[0]?.token?.toLowerCase();
-      if (offerToken !== offerPaymentToken.address.toLowerCase()) {
+      if (offerToken !== paymentTokenAddressLower) {
         continue;
       }
 
@@ -739,9 +735,9 @@ export class BazaarClient {
       return [];
     }
 
-    // Validate buyer's balance in the chain's quote token
+    // Validate buyer's balance in the chain's payment token
     const uniqueMakers = [...new Set(offers.map((o) => o.maker))];
-    const balances = await bulkFetchErc20Balances(this.client, offerPaymentToken.address, uniqueMakers);
+    const balances = await bulkFetchErc20Balances(this.client, paymentToken.address, uniqueMakers);
 
     const balanceMap = new Map<string, bigint>();
     uniqueMakers.forEach((maker, index) => {
@@ -1420,13 +1416,9 @@ export class BazaarClient {
     params: CreateErc20OfferParams & { offerer: `0x${string}` }
   ): Promise<PreparedOrder> {
     const seaportAddress = getSeaportAddress(this.chainId);
-    const quoteToken = getErc20QuoteToken(this.chainId);
-    const wrappedNative = getWrappedNativeCurrency(this.chainId);
-    const paymentTokenAddress = quoteToken
-      ? quoteToken.address
-      : wrappedNative?.address;
-    if (!paymentTokenAddress) {
-      throw new Error(`No ERC20 quote token configured for chain ${this.chainId}`);
+    const paymentToken = getErc20PaymentToken(this.chainId);
+    if (!paymentToken) {
+      throw new Error(`No ERC20 payment token configured for chain ${this.chainId}`);
     }
 
     const counter = await this.getSeaportCounter(params.offerer);
@@ -1434,11 +1426,11 @@ export class BazaarClient {
     const { orderParameters } = buildErc20OfferOrderComponents(params, this.chainId, counter);
     const eip712 = buildEIP712OrderData(orderParameters, counter, this.chainId, seaportAddress);
 
-    // Check quote-token approval for the offerer
+    // Check payment-token approval for the offerer
     const approvals: WriteTransactionConfig[] = [];
     const approval = await checkErc20Approval(
       this.client,
-      paymentTokenAddress,
+      paymentToken.address,
       params.offerer,
       seaportAddress,
       params.priceWei

--- a/packages/net-bazaar/src/client/BazaarClient.ts
+++ b/packages/net-bazaar/src/client/BazaarClient.ts
@@ -46,6 +46,7 @@ import {
   getErc20BazaarAddress,
   getSeaportAddress,
   getWrappedNativeCurrency,
+  getErc20QuoteToken,
   isBazaarSupportedOnChain,
   NET_SEAPORT_ZONE_ADDRESS,
 } from "../chainConfig";
@@ -645,9 +646,15 @@ export class BazaarClient {
   ): Promise<Erc20Offer[]> {
     const { tokenAddress, excludeMaker } = options;
     const tag = `[BazaarClient.processErc20Offers chain=${this.chainId}]`;
-    const weth = getWrappedNativeCurrency(this.chainId);
+    // The offer side of an ERC20 offer is the chain's quote token (USDC on
+    // Base, WETH elsewhere). Balances and validation use the same address.
+    const quoteToken = getErc20QuoteToken(this.chainId);
+    const wrappedNative = getWrappedNativeCurrency(this.chainId);
+    const offerPaymentToken = quoteToken
+      ? { address: quoteToken.address }
+      : wrappedNative;
 
-    if (!weth) {
+    if (!offerPaymentToken) {
       return [];
     }
 
@@ -672,10 +679,13 @@ export class BazaarClient {
       const offer = parseErc20OfferFromMessage(message, this.chainId, decimals);
       if (!offer) continue;
 
-      // Validate WETH token matches
+      // Validate the offer's payment token matches the chain's quote token
+      // (USDC on Base, WETH elsewhere). parseErc20OfferFromMessage already
+      // enforces this on chains with a configured quote token, but this guard
+      // also keeps legacy non-WETH offers out on chains without one.
       const order = getSeaportOrderFromMessageData(offer.messageData);
       const offerToken = order.parameters.offer?.[0]?.token?.toLowerCase();
-      if (offerToken !== weth.address.toLowerCase()) {
+      if (offerToken !== offerPaymentToken.address.toLowerCase()) {
         continue;
       }
 
@@ -729,9 +739,9 @@ export class BazaarClient {
       return [];
     }
 
-    // Validate WETH balances
+    // Validate buyer's balance in the chain's quote token
     const uniqueMakers = [...new Set(offers.map((o) => o.maker))];
-    const balances = await bulkFetchErc20Balances(this.client, weth.address, uniqueMakers);
+    const balances = await bulkFetchErc20Balances(this.client, offerPaymentToken.address, uniqueMakers);
 
     const balanceMap = new Map<string, bigint>();
     uniqueMakers.forEach((maker, index) => {
@@ -1403,16 +1413,20 @@ export class BazaarClient {
   /**
    * Prepare an ERC20 offer order for signing.
    *
-   * Returns EIP-712 typed data for the caller to sign, plus any maker approvals needed
-   * (WETH `approve` for Seaport).
+   * Returns EIP-712 typed data for the caller to sign, plus any maker approvals
+   * needed (quote-token `approve` for Seaport — USDC on Base, WETH elsewhere).
    */
   async prepareCreateErc20Offer(
     params: CreateErc20OfferParams & { offerer: `0x${string}` }
   ): Promise<PreparedOrder> {
     const seaportAddress = getSeaportAddress(this.chainId);
-    const weth = getWrappedNativeCurrency(this.chainId);
-    if (!weth) {
-      throw new Error(`No wrapped native currency configured for chain ${this.chainId}`);
+    const quoteToken = getErc20QuoteToken(this.chainId);
+    const wrappedNative = getWrappedNativeCurrency(this.chainId);
+    const paymentTokenAddress = quoteToken
+      ? quoteToken.address
+      : wrappedNative?.address;
+    if (!paymentTokenAddress) {
+      throw new Error(`No ERC20 quote token configured for chain ${this.chainId}`);
     }
 
     const counter = await this.getSeaportCounter(params.offerer);
@@ -1420,17 +1434,17 @@ export class BazaarClient {
     const { orderParameters } = buildErc20OfferOrderComponents(params, this.chainId, counter);
     const eip712 = buildEIP712OrderData(orderParameters, counter, this.chainId, seaportAddress);
 
-    // Check WETH approval
+    // Check quote-token approval for the offerer
     const approvals: WriteTransactionConfig[] = [];
-    const wethApproval = await checkErc20Approval(
+    const approval = await checkErc20Approval(
       this.client,
-      weth.address,
+      paymentTokenAddress,
       params.offerer,
       seaportAddress,
       params.priceWei
     );
-    if (wethApproval) {
-      approvals.push(wethApproval);
+    if (approval) {
+      approvals.push(approval);
     }
 
     return { eip712, approvals };

--- a/packages/net-bazaar/src/utils/orderCreation.ts
+++ b/packages/net-bazaar/src/utils/orderCreation.ts
@@ -26,6 +26,7 @@ import {
   getErc20FeeBps,
   getWrappedNativeCurrency,
   getErc20QuoteToken,
+  getErc20PaymentToken,
   NET_SEAPORT_ZONE_ADDRESS,
   NET_SEAPORT_COLLECTION_OFFER_ZONE_ADDRESS,
   NET_SEAPORT_PRIVATE_ORDER_ZONE_ADDRESS,
@@ -268,22 +269,6 @@ export function buildCollectionOfferOrderComponents(
 }
 
 /**
- * Resolve the ERC20 quote token for offers/listings on a chain.
- *
- * Returns the configured `erc20QuoteToken` if set (e.g. USDC on Base), otherwise
- * falls back to the wrapped native currency (e.g. WETH).
- */
-function getOfferQuoteTokenAddress(chainId: number): `0x${string}` {
-  const quote = getErc20QuoteToken(chainId);
-  if (quote) return quote.address;
-  const weth = getWrappedNativeCurrency(chainId);
-  if (!weth) {
-    throw new Error(`No ERC20 quote token configured for chain ${chainId}`);
-  }
-  return weth.address;
-}
-
-/**
  * Build order components for an ERC20 offer (buying ERC20 tokens with the quote token).
  *
  * Offer: quote token payment (USDC on Base, WETH elsewhere)
@@ -294,7 +279,11 @@ export function buildErc20OfferOrderComponents(
   chainId: number,
   counter: bigint
 ): { orderParameters: SeaportOrderParameters; counter: bigint } {
-  const quoteTokenAddress = getOfferQuoteTokenAddress(chainId);
+  const paymentToken = getErc20PaymentToken(chainId);
+  if (!paymentToken) {
+    throw new Error(`No ERC20 payment token configured for chain ${chainId}`);
+  }
+  const quoteTokenAddress = paymentToken.address;
 
   const feeBps = getErc20FeeBps(chainId);
   const feeAmount = calculateFee(params.priceWei, feeBps, true); // Ceiling division for ERC20s

--- a/packages/net-bazaar/src/utils/orderCreation.ts
+++ b/packages/net-bazaar/src/utils/orderCreation.ts
@@ -25,6 +25,7 @@ import {
   getNftFeeBps,
   getErc20FeeBps,
   getWrappedNativeCurrency,
+  getErc20QuoteToken,
   NET_SEAPORT_ZONE_ADDRESS,
   NET_SEAPORT_COLLECTION_OFFER_ZONE_ADDRESS,
   NET_SEAPORT_PRIVATE_ORDER_ZONE_ADDRESS,
@@ -267,20 +268,33 @@ export function buildCollectionOfferOrderComponents(
 }
 
 /**
- * Build order components for an ERC20 offer (buying ERC20 tokens with WETH).
+ * Resolve the ERC20 quote token for offers/listings on a chain.
  *
- * Offer: WETH payment
- * Consideration: ERC20 tokens to offerer + optional WETH fee to feeCollector
+ * Returns the configured `erc20QuoteToken` if set (e.g. USDC on Base), otherwise
+ * falls back to the wrapped native currency (e.g. WETH).
+ */
+function getOfferQuoteTokenAddress(chainId: number): `0x${string}` {
+  const quote = getErc20QuoteToken(chainId);
+  if (quote) return quote.address;
+  const weth = getWrappedNativeCurrency(chainId);
+  if (!weth) {
+    throw new Error(`No ERC20 quote token configured for chain ${chainId}`);
+  }
+  return weth.address;
+}
+
+/**
+ * Build order components for an ERC20 offer (buying ERC20 tokens with the quote token).
+ *
+ * Offer: quote token payment (USDC on Base, WETH elsewhere)
+ * Consideration: ERC20 tokens to offerer + optional quote-token fee to feeCollector
  */
 export function buildErc20OfferOrderComponents(
   params: CreateErc20OfferParams & { offerer: `0x${string}` },
   chainId: number,
   counter: bigint
 ): { orderParameters: SeaportOrderParameters; counter: bigint } {
-  const weth = getWrappedNativeCurrency(chainId);
-  if (!weth) {
-    throw new Error(`No wrapped native currency configured for chain ${chainId}`);
-  }
+  const quoteTokenAddress = getOfferQuoteTokenAddress(chainId);
 
   const feeBps = getErc20FeeBps(chainId);
   const feeAmount = calculateFee(params.priceWei, feeBps, true); // Ceiling division for ERC20s
@@ -301,7 +315,7 @@ export function buildErc20OfferOrderComponents(
   if (feeAmount > BigInt(0)) {
     consideration.push({
       itemType: ItemType.ERC20,
-      token: weth.address,
+      token: quoteTokenAddress,
       identifierOrCriteria: BigInt(0),
       startAmount: feeAmount,
       endAmount: feeAmount,
@@ -315,7 +329,7 @@ export function buildErc20OfferOrderComponents(
     offer: [
       {
         itemType: ItemType.ERC20,
-        token: weth.address,
+        token: quoteTokenAddress,
         identifierOrCriteria: BigInt(0),
         startAmount: params.priceWei,
         endAmount: params.priceWei,
@@ -335,10 +349,14 @@ export function buildErc20OfferOrderComponents(
 }
 
 /**
- * Build order components for an ERC20 listing (selling ERC20 tokens for native currency).
+ * Build order components for an ERC20 listing (selling ERC20 tokens for the quote token).
  *
- * Offer: ERC20 tokens
- * Consideration: native currency payment to offerer + optional fee to feeCollector
+ * Offer: ERC20 tokens being sold.
+ * Consideration:
+ *   - If the chain has an `erc20QuoteToken` configured (e.g. USDC on Base),
+ *     payment is in that ERC20 token. Buyers must approve the quote token
+ *     before fulfilling.
+ *   - Otherwise, payment is in native currency (legacy behavior).
  */
 export function buildErc20ListingOrderComponents(
   params: CreateErc20ListingParams & { offerer: `0x${string}`; targetFulfiller?: `0x${string}` },
@@ -351,10 +369,16 @@ export function buildErc20ListingOrderComponents(
   const endTime = BigInt(params.expirationDate ?? getDefaultExpiration());
   const feeCollector = getFeeCollectorAddress(chainId);
 
+  const quoteToken = getErc20QuoteToken(chainId);
+  const paymentItemType = quoteToken ? ItemType.ERC20 : ItemType.NATIVE;
+  const paymentTokenAddress = quoteToken
+    ? quoteToken.address
+    : (ZERO_ADDRESS as `0x${string}`);
+
   const consideration = [
     {
-      itemType: ItemType.NATIVE,
-      token: ZERO_ADDRESS as `0x${string}`,
+      itemType: paymentItemType,
+      token: paymentTokenAddress,
       identifierOrCriteria: BigInt(0),
       startAmount: sellerAmount,
       endAmount: sellerAmount,
@@ -364,8 +388,8 @@ export function buildErc20ListingOrderComponents(
 
   if (feeAmount > BigInt(0)) {
     consideration.push({
-      itemType: ItemType.NATIVE,
-      token: ZERO_ADDRESS as `0x${string}`,
+      itemType: paymentItemType,
+      token: paymentTokenAddress,
       identifierOrCriteria: BigInt(0),
       startAmount: feeAmount,
       endAmount: feeAmount,

--- a/packages/net-bazaar/src/utils/parsing.ts
+++ b/packages/net-bazaar/src/utils/parsing.ts
@@ -12,7 +12,12 @@ import {
   formatPrice,
   formatPricePerToken,
 } from "./seaport";
-import { getCurrencySymbol, NET_SEAPORT_COLLECTION_OFFER_ZONE_ADDRESS, NET_SEAPORT_PRIVATE_ORDER_ZONE_ADDRESS } from "../chainConfig";
+import {
+  getCurrencySymbol,
+  getErc20QuoteToken,
+  NET_SEAPORT_COLLECTION_OFFER_ZONE_ADDRESS,
+  NET_SEAPORT_PRIVATE_ORDER_ZONE_ADDRESS,
+} from "../chainConfig";
 
 /**
  * Parse a Net message into an NFT listing
@@ -205,15 +210,30 @@ export function parseErc20OfferFromMessage(
       return null;
     }
 
-    // ERC20 offers have WETH in the offer array
+    // ERC20 offers have the quote token (WETH or USDC) in the offer array
     const offerItem = parameters.offer[0];
     if (!offerItem || offerItem.itemType !== ItemType.ERC20) {
       return null;
     }
 
-    // The ERC20 token being purchased is in the consideration array
+    // On chains with a configured ERC20 quote token, strictly require the
+    // offer item to be that token. This naturally hides legacy WETH orders
+    // on chains that have migrated to USDC.
+    const quoteToken = getErc20QuoteToken(chainId);
+    if (
+      quoteToken &&
+      offerItem.token.toLowerCase() !== quoteToken.address.toLowerCase()
+    ) {
+      return null;
+    }
+
+    // The ERC20 token being purchased is in the consideration array.
+    // It must be different from the quote token (otherwise the fee/payment
+    // items would shadow the actual traded token).
     const erc20Consideration = parameters.consideration.find(
-      (item) => item.itemType === ItemType.ERC20
+      (item) =>
+        item.itemType === ItemType.ERC20 &&
+        item.token.toLowerCase() !== offerItem.token.toLowerCase()
     );
 
     if (!erc20Consideration) {
@@ -297,6 +317,21 @@ export function parseErc20ListingFromMessage(
     const tokenAmount = offerItem.startAmount;
     if (tokenAmount === BigInt(0)) {
       return null;
+    }
+
+    // On chains with a configured ERC20 quote token, strictly require every
+    // consideration item to be that quote token. This hides legacy
+    // native-payment listings on chains that have migrated to USDC.
+    const quoteToken = getErc20QuoteToken(chainId);
+    if (quoteToken) {
+      const allMatch = parameters.consideration.every(
+        (item) =>
+          item.itemType === ItemType.ERC20 &&
+          item.token.toLowerCase() === quoteToken.address.toLowerCase()
+      );
+      if (!allMatch) {
+        return null;
+      }
     }
 
     const priceWei = getTotalConsiderationAmount(parameters);

--- a/packages/net-bazaar/src/utils/parsing.ts
+++ b/packages/net-bazaar/src/utils/parsing.ts
@@ -219,11 +219,9 @@ export function parseErc20OfferFromMessage(
     // On chains with a configured ERC20 quote token, strictly require the
     // offer item to be that token. This naturally hides legacy WETH orders
     // on chains that have migrated to USDC.
+    const offerTokenLower = offerItem.token.toLowerCase();
     const quoteToken = getErc20QuoteToken(chainId);
-    if (
-      quoteToken &&
-      offerItem.token.toLowerCase() !== quoteToken.address.toLowerCase()
-    ) {
+    if (quoteToken && offerTokenLower !== quoteToken.address.toLowerCase()) {
       return null;
     }
 
@@ -233,7 +231,7 @@ export function parseErc20OfferFromMessage(
     const erc20Consideration = parameters.consideration.find(
       (item) =>
         item.itemType === ItemType.ERC20 &&
-        item.token.toLowerCase() !== offerItem.token.toLowerCase()
+        item.token.toLowerCase() !== offerTokenLower
     );
 
     if (!erc20Consideration) {
@@ -324,10 +322,11 @@ export function parseErc20ListingFromMessage(
     // native-payment listings on chains that have migrated to USDC.
     const quoteToken = getErc20QuoteToken(chainId);
     if (quoteToken) {
+      const quoteAddrLower = quoteToken.address.toLowerCase();
       const allMatch = parameters.consideration.every(
         (item) =>
           item.itemType === ItemType.ERC20 &&
-          item.token.toLowerCase() === quoteToken.address.toLowerCase()
+          item.token.toLowerCase() === quoteAddrLower
       );
       if (!allMatch) {
         return null;

--- a/packages/net-cli/package.json
+++ b/packages/net-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@net-protocol/cli",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "CLI tool for Net Protocol",
   "type": "module",
   "bin": {
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@net-protocol/agents": "^0.1.0",
-    "@net-protocol/bazaar": "^0.2.0",
+    "@net-protocol/bazaar": "^0.2.1",
     "@net-protocol/chats": "^0.1.0",
     "@net-protocol/core": "^0.1.9",
     "@net-protocol/feeds": "^0.1.14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1263,7 +1263,7 @@ __metadata:
 
 "@net-protocol/chats@file:../net-chats::locator=botchan%40workspace%3Apackages%2Fbotchan":
   version: 0.1.1
-  resolution: "@net-protocol/chats@file:../net-chats#../net-chats::hash=a0da87&locator=botchan%40workspace%3Apackages%2Fbotchan"
+  resolution: "@net-protocol/chats@file:../net-chats#../net-chats::hash=230c7f&locator=botchan%40workspace%3Apackages%2Fbotchan"
   dependencies:
     "@net-protocol/core": "file:../net-core"
   peerDependencies:
@@ -1275,7 +1275,7 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: 9caa7d44c78ea9be9ff5bc71f0f71898b964d3cd23f8cec688c07b6aabfb5e12c8cb8e9e7fd39e65cbbb59243cdbd0b41a1336842cfb0765614763a2f6c0102c
+  checksum: eadd4a4c800204b9bfa8b7e24b4dd52c7cf358bb60d978cab54feef3c683957b078e6d8e966c40c6856dd5c6d3fa855e46f7e2c21276d4f4e96e66e7fac24c96
   languageName: node
   linkType: hard
 
@@ -1303,7 +1303,7 @@ __metadata:
 
 "@net-protocol/cli@file:../net-cli::locator=botchan%40workspace%3Apackages%2Fbotchan":
   version: 0.2.1
-  resolution: "@net-protocol/cli@file:../net-cli#../net-cli::hash=3e1249&locator=botchan%40workspace%3Apackages%2Fbotchan"
+  resolution: "@net-protocol/cli@file:../net-cli#../net-cli::hash=339ade&locator=botchan%40workspace%3Apackages%2Fbotchan"
   dependencies:
     "@net-protocol/agents": "npm:^0.1.0"
     "@net-protocol/bazaar": "npm:^0.2.0"
@@ -1324,7 +1324,7 @@ __metadata:
     viem: "npm:^2.45.0"
   bin:
     netp: ./dist/cli/index.mjs
-  checksum: 3f825786e5186c17432cc3a78e7a6bf7d04e2358fb3d8c9a68b52e7417071c5ef9b66c9ba28c93a7f43e5c4cdb075b909c342a7eed5db8f38ba2c3f4dcbedf2d
+  checksum: 6b728c67f8e3bc9f07f8efe5afb06abb96a0837cb3e2e426975efa4e49f95535c20815b9644477a4da7b4ebffd445e76228799edac95df22a8d59c3b7aaead61
   languageName: node
   linkType: hard
 
@@ -1362,7 +1362,7 @@ __metadata:
 
 "@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fagents%40workspace%3Apackages%2Fnet-agents":
   version: 0.1.12
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=4cc214&locator=%40net-protocol%2Fagents%40workspace%3Apackages%2Fnet-agents"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=f60c82&locator=%40net-protocol%2Fagents%40workspace%3Apackages%2Fnet-agents"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1374,13 +1374,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: 1ac9e0ad07be6eec0a22ebd79c6db07dbdf7c3802a6185a926c665a5a238f406bb3d0057316e33371d2c288b126a0a67fddf3f9f72515d109e8e07e4d593cb26
+  checksum: 4e78c8742170342822886733f098af70d1a821908c86ee60b8f9f4c990f28c1a7953e66a16ee0cebbc61db484f81165c94f69e042fe592b48d094a04702039fb
   languageName: node
   linkType: hard
 
-"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fchats%40file%3A..%2Fnet-chats%23..%2Fnet-chats%3A%3Ahash%3Da0da87%26locator%3Dbotchan%2540workspace%253Apackages%252Fbotchan":
+"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fchats%40file%3A..%2Fnet-chats%23..%2Fnet-chats%3A%3Ahash%3D230c7f%26locator%3Dbotchan%2540workspace%253Apackages%252Fbotchan":
   version: 0.1.12
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=4cc214&locator=%40net-protocol%2Fchats%40file%3A..%2Fnet-chats%23..%2Fnet-chats%3A%3Ahash%3Da0da87%26locator%3Dbotchan%2540workspace%253Apackages%252Fbotchan"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=f60c82&locator=%40net-protocol%2Fchats%40file%3A..%2Fnet-chats%23..%2Fnet-chats%3A%3Ahash%3D230c7f%26locator%3Dbotchan%2540workspace%253Apackages%252Fbotchan"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1392,13 +1392,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: 1ac9e0ad07be6eec0a22ebd79c6db07dbdf7c3802a6185a926c665a5a238f406bb3d0057316e33371d2c288b126a0a67fddf3f9f72515d109e8e07e4d593cb26
+  checksum: 4e78c8742170342822886733f098af70d1a821908c86ee60b8f9f4c990f28c1a7953e66a16ee0cebbc61db484f81165c94f69e042fe592b48d094a04702039fb
   languageName: node
   linkType: hard
 
 "@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fchats%40workspace%3Apackages%2Fnet-chats":
   version: 0.1.12
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=4cc214&locator=%40net-protocol%2Fchats%40workspace%3Apackages%2Fnet-chats"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=f60c82&locator=%40net-protocol%2Fchats%40workspace%3Apackages%2Fnet-chats"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1410,13 +1410,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: 1ac9e0ad07be6eec0a22ebd79c6db07dbdf7c3802a6185a926c665a5a238f406bb3d0057316e33371d2c288b126a0a67fddf3f9f72515d109e8e07e4d593cb26
+  checksum: 4e78c8742170342822886733f098af70d1a821908c86ee60b8f9f4c990f28c1a7953e66a16ee0cebbc61db484f81165c94f69e042fe592b48d094a04702039fb
   languageName: node
   linkType: hard
 
-"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Ffeeds%40file%3A..%2Fnet-feeds%23..%2Fnet-feeds%3A%3Ahash%3D32106a%26locator%3Dbotchan%2540workspace%253Apackages%252Fbotchan":
+"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Ffeeds%40file%3A..%2Fnet-feeds%23..%2Fnet-feeds%3A%3Ahash%3Da4eb9c%26locator%3Dbotchan%2540workspace%253Apackages%252Fbotchan":
   version: 0.1.12
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=4cc214&locator=%40net-protocol%2Ffeeds%40file%3A..%2Fnet-feeds%23..%2Fnet-feeds%3A%3Ahash%3D32106a%26locator%3Dbotchan%2540workspace%253Apackages%252Fbotchan"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=f60c82&locator=%40net-protocol%2Ffeeds%40file%3A..%2Fnet-feeds%23..%2Fnet-feeds%3A%3Ahash%3Da4eb9c%26locator%3Dbotchan%2540workspace%253Apackages%252Fbotchan"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1428,13 +1428,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: 1ac9e0ad07be6eec0a22ebd79c6db07dbdf7c3802a6185a926c665a5a238f406bb3d0057316e33371d2c288b126a0a67fddf3f9f72515d109e8e07e4d593cb26
+  checksum: 4e78c8742170342822886733f098af70d1a821908c86ee60b8f9f4c990f28c1a7953e66a16ee0cebbc61db484f81165c94f69e042fe592b48d094a04702039fb
   languageName: node
   linkType: hard
 
 "@net-protocol/core@file:../net-core::locator=%40net-protocol%2Ffeeds%40workspace%3Apackages%2Fnet-feeds":
   version: 0.1.12
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=4cc214&locator=%40net-protocol%2Ffeeds%40workspace%3Apackages%2Fnet-feeds"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=f60c82&locator=%40net-protocol%2Ffeeds%40workspace%3Apackages%2Fnet-feeds"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1446,13 +1446,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: 1ac9e0ad07be6eec0a22ebd79c6db07dbdf7c3802a6185a926c665a5a238f406bb3d0057316e33371d2c288b126a0a67fddf3f9f72515d109e8e07e4d593cb26
+  checksum: 4e78c8742170342822886733f098af70d1a821908c86ee60b8f9f4c990f28c1a7953e66a16ee0cebbc61db484f81165c94f69e042fe592b48d094a04702039fb
   languageName: node
   linkType: hard
 
 "@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fnetr%40workspace%3Apackages%2Fnet-netr":
   version: 0.1.12
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=4cc214&locator=%40net-protocol%2Fnetr%40workspace%3Apackages%2Fnet-netr"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=f60c82&locator=%40net-protocol%2Fnetr%40workspace%3Apackages%2Fnet-netr"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1464,13 +1464,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: 1ac9e0ad07be6eec0a22ebd79c6db07dbdf7c3802a6185a926c665a5a238f406bb3d0057316e33371d2c288b126a0a67fddf3f9f72515d109e8e07e4d593cb26
+  checksum: 4e78c8742170342822886733f098af70d1a821908c86ee60b8f9f4c990f28c1a7953e66a16ee0cebbc61db484f81165c94f69e042fe592b48d094a04702039fb
   languageName: node
   linkType: hard
 
 "@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fprofiles%40workspace%3Apackages%2Fnet-profiles":
   version: 0.1.12
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=4cc214&locator=%40net-protocol%2Fprofiles%40workspace%3Apackages%2Fnet-profiles"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=f60c82&locator=%40net-protocol%2Fprofiles%40workspace%3Apackages%2Fnet-profiles"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1482,13 +1482,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: 1ac9e0ad07be6eec0a22ebd79c6db07dbdf7c3802a6185a926c665a5a238f406bb3d0057316e33371d2c288b126a0a67fddf3f9f72515d109e8e07e4d593cb26
+  checksum: 4e78c8742170342822886733f098af70d1a821908c86ee60b8f9f4c990f28c1a7953e66a16ee0cebbc61db484f81165c94f69e042fe592b48d094a04702039fb
   languageName: node
   linkType: hard
 
-"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Frelay%40file%3A..%2Fnet-relay%23..%2Fnet-relay%3A%3Ahash%3D69b2fc%26locator%3D%2540net-protocol%252Fagents%2540workspace%253Apackages%252Fnet-agents":
+"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Frelay%40file%3A..%2Fnet-relay%23..%2Fnet-relay%3A%3Ahash%3D991f0e%26locator%3D%2540net-protocol%252Fagents%2540workspace%253Apackages%252Fnet-agents":
   version: 0.1.12
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=4cc214&locator=%40net-protocol%2Frelay%40file%3A..%2Fnet-relay%23..%2Fnet-relay%3A%3Ahash%3D69b2fc%26locator%3D%2540net-protocol%252Fagents%2540workspace%253Apackages%252Fnet-agents"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=f60c82&locator=%40net-protocol%2Frelay%40file%3A..%2Fnet-relay%23..%2Fnet-relay%3A%3Ahash%3D991f0e%26locator%3D%2540net-protocol%252Fagents%2540workspace%253Apackages%252Fnet-agents"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1500,13 +1500,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: 1ac9e0ad07be6eec0a22ebd79c6db07dbdf7c3802a6185a926c665a5a238f406bb3d0057316e33371d2c288b126a0a67fddf3f9f72515d109e8e07e4d593cb26
+  checksum: 4e78c8742170342822886733f098af70d1a821908c86ee60b8f9f4c990f28c1a7953e66a16ee0cebbc61db484f81165c94f69e042fe592b48d094a04702039fb
   languageName: node
   linkType: hard
 
 "@net-protocol/core@file:../net-core::locator=%40net-protocol%2Frelay%40workspace%3Apackages%2Fnet-relay":
   version: 0.1.12
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=4cc214&locator=%40net-protocol%2Frelay%40workspace%3Apackages%2Fnet-relay"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=f60c82&locator=%40net-protocol%2Frelay%40workspace%3Apackages%2Fnet-relay"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1518,13 +1518,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: 1ac9e0ad07be6eec0a22ebd79c6db07dbdf7c3802a6185a926c665a5a238f406bb3d0057316e33371d2c288b126a0a67fddf3f9f72515d109e8e07e4d593cb26
+  checksum: 4e78c8742170342822886733f098af70d1a821908c86ee60b8f9f4c990f28c1a7953e66a16ee0cebbc61db484f81165c94f69e042fe592b48d094a04702039fb
   languageName: node
   linkType: hard
 
 "@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fscore%40workspace%3Apackages%2Fnet-score":
   version: 0.1.12
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=4cc214&locator=%40net-protocol%2Fscore%40workspace%3Apackages%2Fnet-score"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=f60c82&locator=%40net-protocol%2Fscore%40workspace%3Apackages%2Fnet-score"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1536,13 +1536,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: 1ac9e0ad07be6eec0a22ebd79c6db07dbdf7c3802a6185a926c665a5a238f406bb3d0057316e33371d2c288b126a0a67fddf3f9f72515d109e8e07e4d593cb26
+  checksum: 4e78c8742170342822886733f098af70d1a821908c86ee60b8f9f4c990f28c1a7953e66a16ee0cebbc61db484f81165c94f69e042fe592b48d094a04702039fb
   languageName: node
   linkType: hard
 
-"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3D68a29c%26locator%3D%2540net-protocol%252Fnetr%2540workspace%253Apackages%252Fnet-netr":
+"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3D1ff51c%26locator%3D%2540net-protocol%252Fnetr%2540workspace%253Apackages%252Fnet-netr":
   version: 0.1.12
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=4cc214&locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3D68a29c%26locator%3D%2540net-protocol%252Fnetr%2540workspace%253Apackages%252Fnet-netr"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=f60c82&locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3D1ff51c%26locator%3D%2540net-protocol%252Fnetr%2540workspace%253Apackages%252Fnet-netr"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1554,13 +1554,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: 1ac9e0ad07be6eec0a22ebd79c6db07dbdf7c3802a6185a926c665a5a238f406bb3d0057316e33371d2c288b126a0a67fddf3f9f72515d109e8e07e4d593cb26
+  checksum: 4e78c8742170342822886733f098af70d1a821908c86ee60b8f9f4c990f28c1a7953e66a16ee0cebbc61db484f81165c94f69e042fe592b48d094a04702039fb
   languageName: node
   linkType: hard
 
-"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3D68a29c%26locator%3D%2540net-protocol%252Fprofiles%2540workspace%253Apackages%252Fnet-profiles":
+"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3D1ff51c%26locator%3D%2540net-protocol%252Fprofiles%2540workspace%253Apackages%252Fnet-profiles":
   version: 0.1.12
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=4cc214&locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3D68a29c%26locator%3D%2540net-protocol%252Fprofiles%2540workspace%253Apackages%252Fnet-profiles"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=f60c82&locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3D1ff51c%26locator%3D%2540net-protocol%252Fprofiles%2540workspace%253Apackages%252Fnet-profiles"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1572,13 +1572,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: 1ac9e0ad07be6eec0a22ebd79c6db07dbdf7c3802a6185a926c665a5a238f406bb3d0057316e33371d2c288b126a0a67fddf3f9f72515d109e8e07e4d593cb26
+  checksum: 4e78c8742170342822886733f098af70d1a821908c86ee60b8f9f4c990f28c1a7953e66a16ee0cebbc61db484f81165c94f69e042fe592b48d094a04702039fb
   languageName: node
   linkType: hard
 
-"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3D68a29c%26locator%3D%2540net-protocol%252Fscore%2540workspace%253Apackages%252Fnet-score":
+"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3D1ff51c%26locator%3D%2540net-protocol%252Fscore%2540workspace%253Apackages%252Fnet-score":
   version: 0.1.12
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=4cc214&locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3D68a29c%26locator%3D%2540net-protocol%252Fscore%2540workspace%253Apackages%252Fnet-score"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=f60c82&locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3D1ff51c%26locator%3D%2540net-protocol%252Fscore%2540workspace%253Apackages%252Fnet-score"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1590,13 +1590,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: 1ac9e0ad07be6eec0a22ebd79c6db07dbdf7c3802a6185a926c665a5a238f406bb3d0057316e33371d2c288b126a0a67fddf3f9f72515d109e8e07e4d593cb26
+  checksum: 4e78c8742170342822886733f098af70d1a821908c86ee60b8f9f4c990f28c1a7953e66a16ee0cebbc61db484f81165c94f69e042fe592b48d094a04702039fb
   languageName: node
   linkType: hard
 
 "@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fstorage%40workspace%3Apackages%2Fnet-storage":
   version: 0.1.12
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=4cc214&locator=%40net-protocol%2Fstorage%40workspace%3Apackages%2Fnet-storage"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=f60c82&locator=%40net-protocol%2Fstorage%40workspace%3Apackages%2Fnet-storage"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1608,13 +1608,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: 1ac9e0ad07be6eec0a22ebd79c6db07dbdf7c3802a6185a926c665a5a238f406bb3d0057316e33371d2c288b126a0a67fddf3f9f72515d109e8e07e4d593cb26
+  checksum: 4e78c8742170342822886733f098af70d1a821908c86ee60b8f9f4c990f28c1a7953e66a16ee0cebbc61db484f81165c94f69e042fe592b48d094a04702039fb
   languageName: node
   linkType: hard
 
 "@net-protocol/core@file:../net-core::locator=botchan%40workspace%3Apackages%2Fbotchan":
   version: 0.1.12
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=4cc214&locator=botchan%40workspace%3Apackages%2Fbotchan"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=f60c82&locator=botchan%40workspace%3Apackages%2Fbotchan"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1626,7 +1626,7 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: 1ac9e0ad07be6eec0a22ebd79c6db07dbdf7c3802a6185a926c665a5a238f406bb3d0057316e33371d2c288b126a0a67fddf3f9f72515d109e8e07e4d593cb26
+  checksum: 4e78c8742170342822886733f098af70d1a821908c86ee60b8f9f4c990f28c1a7953e66a16ee0cebbc61db484f81165c94f69e042fe592b48d094a04702039fb
   languageName: node
   linkType: hard
 
@@ -1656,7 +1656,7 @@ __metadata:
 
 "@net-protocol/feeds@file:../net-feeds::locator=botchan%40workspace%3Apackages%2Fbotchan":
   version: 0.1.17
-  resolution: "@net-protocol/feeds@file:../net-feeds#../net-feeds::hash=32106a&locator=botchan%40workspace%3Apackages%2Fbotchan"
+  resolution: "@net-protocol/feeds@file:../net-feeds#../net-feeds::hash=a4eb9c&locator=botchan%40workspace%3Apackages%2Fbotchan"
   dependencies:
     "@net-protocol/core": "file:../net-core"
   peerDependencies:
@@ -1668,7 +1668,7 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: 5a4bb257f905903387f7b3d3b6d6d71d4000a55cd833b631d894ebf05c5274d65a4d6a0a2a5fba683cf2538ddf92d4a4f5fa3c8f4fada11642b5196298aec625
+  checksum: 8b6997288350bbb74d907d59a082b9e45e8268d9288eabcf4a0cf9fea6e94c7bf72f9dc9f59c8130eb7fd832cc7eeb3b2e309539f8d0a8fdd4c9f81605d63296
   languageName: node
   linkType: hard
 
@@ -1758,14 +1758,14 @@ __metadata:
 
 "@net-protocol/relay@file:../net-relay::locator=%40net-protocol%2Fagents%40workspace%3Apackages%2Fnet-agents":
   version: 0.1.5
-  resolution: "@net-protocol/relay@file:../net-relay#../net-relay::hash=69b2fc&locator=%40net-protocol%2Fagents%40workspace%3Apackages%2Fnet-agents"
+  resolution: "@net-protocol/relay@file:../net-relay#../net-relay::hash=991f0e&locator=%40net-protocol%2Fagents%40workspace%3Apackages%2Fnet-agents"
   dependencies:
     "@net-protocol/core": "file:../net-core"
     "@x402/evm": "npm:^2.1.0"
     "@x402/fetch": "npm:^2.1.0"
   peerDependencies:
     viem: ^2.31.4
-  checksum: 1f56f27b2b8c19be74ac62b41db36f386ed1ea988a87469975c53f6c95de9f8e46a73c06cad674e37903e9e079365f73cfc5e0a49f72019f170f20c00a7693a6
+  checksum: 0952ff6d1d2dcdc2e2445064a5ce92e1627cda93738092c9dd9618f8d0d124654da00fb8a9a76adf18820580a28fdb29f5d397db99e079d08debdd76c155a184
   languageName: node
   linkType: hard
 
@@ -1822,7 +1822,7 @@ __metadata:
 
 "@net-protocol/storage@file:../net-storage::locator=%40net-protocol%2Fnetr%40workspace%3Apackages%2Fnet-netr":
   version: 0.1.17
-  resolution: "@net-protocol/storage@file:../net-storage#../net-storage::hash=68a29c&locator=%40net-protocol%2Fnetr%40workspace%3Apackages%2Fnet-netr"
+  resolution: "@net-protocol/storage@file:../net-storage#../net-storage::hash=1ff51c&locator=%40net-protocol%2Fnetr%40workspace%3Apackages%2Fnet-netr"
   dependencies:
     "@net-protocol/core": "file:../net-core"
     pako: "npm:^2.1.0"
@@ -1836,13 +1836,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: 4cd0dc2fcc7c9732a8cc0b0d8862e34ad497b22902e23ed56368f19795f2704e6c5f82ebaaca367b986a383a5068f361b60de2f4256f9834799e366e483a09f1
+  checksum: e701fb9b727c13cffaf2da589ad743a34f2955e7affd1ad04697a896aac0ab90fec02142475a7eec72c5d7259c05f10074dc689b1ca9e171cb4a8c807fa8740d
   languageName: node
   linkType: hard
 
 "@net-protocol/storage@file:../net-storage::locator=%40net-protocol%2Fprofiles%40workspace%3Apackages%2Fnet-profiles":
   version: 0.1.17
-  resolution: "@net-protocol/storage@file:../net-storage#../net-storage::hash=68a29c&locator=%40net-protocol%2Fprofiles%40workspace%3Apackages%2Fnet-profiles"
+  resolution: "@net-protocol/storage@file:../net-storage#../net-storage::hash=1ff51c&locator=%40net-protocol%2Fprofiles%40workspace%3Apackages%2Fnet-profiles"
   dependencies:
     "@net-protocol/core": "file:../net-core"
     pako: "npm:^2.1.0"
@@ -1856,13 +1856,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: 4cd0dc2fcc7c9732a8cc0b0d8862e34ad497b22902e23ed56368f19795f2704e6c5f82ebaaca367b986a383a5068f361b60de2f4256f9834799e366e483a09f1
+  checksum: e701fb9b727c13cffaf2da589ad743a34f2955e7affd1ad04697a896aac0ab90fec02142475a7eec72c5d7259c05f10074dc689b1ca9e171cb4a8c807fa8740d
   languageName: node
   linkType: hard
 
 "@net-protocol/storage@file:../net-storage::locator=%40net-protocol%2Fscore%40workspace%3Apackages%2Fnet-score":
   version: 0.1.17
-  resolution: "@net-protocol/storage@file:../net-storage#../net-storage::hash=68a29c&locator=%40net-protocol%2Fscore%40workspace%3Apackages%2Fnet-score"
+  resolution: "@net-protocol/storage@file:../net-storage#../net-storage::hash=1ff51c&locator=%40net-protocol%2Fscore%40workspace%3Apackages%2Fnet-score"
   dependencies:
     "@net-protocol/core": "file:../net-core"
     pako: "npm:^2.1.0"
@@ -1876,7 +1876,7 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: 4cd0dc2fcc7c9732a8cc0b0d8862e34ad497b22902e23ed56368f19795f2704e6c5f82ebaaca367b986a383a5068f361b60de2f4256f9834799e366e483a09f1
+  checksum: e701fb9b727c13cffaf2da589ad743a34f2955e7affd1ad04697a896aac0ab90fec02142475a7eec72c5d7259c05f10074dc689b1ca9e171cb4a8c807fa8740d
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1228,7 +1228,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@net-protocol/bazaar@npm:^0.2.0, @net-protocol/bazaar@workspace:packages/net-bazaar":
+"@net-protocol/bazaar@npm:^0.2.1, @net-protocol/bazaar@workspace:packages/net-bazaar":
   version: 0.0.0-use.local
   resolution: "@net-protocol/bazaar@workspace:packages/net-bazaar"
   dependencies:
@@ -1263,7 +1263,7 @@ __metadata:
 
 "@net-protocol/chats@file:../net-chats::locator=botchan%40workspace%3Apackages%2Fbotchan":
   version: 0.1.1
-  resolution: "@net-protocol/chats@file:../net-chats#../net-chats::hash=230c7f&locator=botchan%40workspace%3Apackages%2Fbotchan"
+  resolution: "@net-protocol/chats@file:../net-chats#../net-chats::hash=3e9512&locator=botchan%40workspace%3Apackages%2Fbotchan"
   dependencies:
     "@net-protocol/core": "file:../net-core"
   peerDependencies:
@@ -1275,7 +1275,7 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: eadd4a4c800204b9bfa8b7e24b4dd52c7cf358bb60d978cab54feef3c683957b078e6d8e966c40c6856dd5c6d3fa855e46f7e2c21276d4f4e96e66e7fac24c96
+  checksum: d4c262ce1a9da47ea307618cbe85602db8afe6adbc45074d66a72beb3865d312faccef73b1a55ba746e3f4947e819be9186df2582614904a82f679b53a38aec6
   languageName: node
   linkType: hard
 
@@ -1302,11 +1302,11 @@ __metadata:
   linkType: soft
 
 "@net-protocol/cli@file:../net-cli::locator=botchan%40workspace%3Apackages%2Fbotchan":
-  version: 0.2.1
-  resolution: "@net-protocol/cli@file:../net-cli#../net-cli::hash=339ade&locator=botchan%40workspace%3Apackages%2Fbotchan"
+  version: 0.2.2
+  resolution: "@net-protocol/cli@file:../net-cli#../net-cli::hash=841bae&locator=botchan%40workspace%3Apackages%2Fbotchan"
   dependencies:
     "@net-protocol/agents": "npm:^0.1.0"
-    "@net-protocol/bazaar": "npm:^0.2.0"
+    "@net-protocol/bazaar": "npm:^0.2.1"
     "@net-protocol/chats": "npm:^0.1.0"
     "@net-protocol/core": "npm:^0.1.9"
     "@net-protocol/feeds": "npm:^0.1.14"
@@ -1324,7 +1324,7 @@ __metadata:
     viem: "npm:^2.45.0"
   bin:
     netp: ./dist/cli/index.mjs
-  checksum: 6b728c67f8e3bc9f07f8efe5afb06abb96a0837cb3e2e426975efa4e49f95535c20815b9644477a4da7b4ebffd445e76228799edac95df22a8d59c3b7aaead61
+  checksum: ebe9cc1b127731f46db26cfeba7cd055a36d31aa9074c58438a1145b8a63d12ae9648d9ccb21916a1eb0beee63161dc1702614a9f2f8a2e1d8342e505d9c61a5
   languageName: node
   linkType: hard
 
@@ -1333,7 +1333,7 @@ __metadata:
   resolution: "@net-protocol/cli@workspace:packages/net-cli"
   dependencies:
     "@net-protocol/agents": "npm:^0.1.0"
-    "@net-protocol/bazaar": "npm:^0.2.0"
+    "@net-protocol/bazaar": "npm:^0.2.1"
     "@net-protocol/chats": "npm:^0.1.0"
     "@net-protocol/core": "npm:^0.1.9"
     "@net-protocol/feeds": "npm:^0.1.14"
@@ -1362,7 +1362,7 @@ __metadata:
 
 "@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fagents%40workspace%3Apackages%2Fnet-agents":
   version: 0.1.12
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=f60c82&locator=%40net-protocol%2Fagents%40workspace%3Apackages%2Fnet-agents"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=cbe59b&locator=%40net-protocol%2Fagents%40workspace%3Apackages%2Fnet-agents"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1374,13 +1374,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: 4e78c8742170342822886733f098af70d1a821908c86ee60b8f9f4c990f28c1a7953e66a16ee0cebbc61db484f81165c94f69e042fe592b48d094a04702039fb
+  checksum: c5209f3f41890cf007690453eae6fd1bb4412d5482b220ab56a8a95e054b85989e0986ad14f054b6a575524f2021112041a402ceb736882267eeebcf2291cc5f
   languageName: node
   linkType: hard
 
-"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fchats%40file%3A..%2Fnet-chats%23..%2Fnet-chats%3A%3Ahash%3D230c7f%26locator%3Dbotchan%2540workspace%253Apackages%252Fbotchan":
+"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fchats%40file%3A..%2Fnet-chats%23..%2Fnet-chats%3A%3Ahash%3D3e9512%26locator%3Dbotchan%2540workspace%253Apackages%252Fbotchan":
   version: 0.1.12
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=f60c82&locator=%40net-protocol%2Fchats%40file%3A..%2Fnet-chats%23..%2Fnet-chats%3A%3Ahash%3D230c7f%26locator%3Dbotchan%2540workspace%253Apackages%252Fbotchan"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=cbe59b&locator=%40net-protocol%2Fchats%40file%3A..%2Fnet-chats%23..%2Fnet-chats%3A%3Ahash%3D3e9512%26locator%3Dbotchan%2540workspace%253Apackages%252Fbotchan"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1392,13 +1392,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: 4e78c8742170342822886733f098af70d1a821908c86ee60b8f9f4c990f28c1a7953e66a16ee0cebbc61db484f81165c94f69e042fe592b48d094a04702039fb
+  checksum: c5209f3f41890cf007690453eae6fd1bb4412d5482b220ab56a8a95e054b85989e0986ad14f054b6a575524f2021112041a402ceb736882267eeebcf2291cc5f
   languageName: node
   linkType: hard
 
 "@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fchats%40workspace%3Apackages%2Fnet-chats":
   version: 0.1.12
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=f60c82&locator=%40net-protocol%2Fchats%40workspace%3Apackages%2Fnet-chats"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=cbe59b&locator=%40net-protocol%2Fchats%40workspace%3Apackages%2Fnet-chats"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1410,13 +1410,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: 4e78c8742170342822886733f098af70d1a821908c86ee60b8f9f4c990f28c1a7953e66a16ee0cebbc61db484f81165c94f69e042fe592b48d094a04702039fb
+  checksum: c5209f3f41890cf007690453eae6fd1bb4412d5482b220ab56a8a95e054b85989e0986ad14f054b6a575524f2021112041a402ceb736882267eeebcf2291cc5f
   languageName: node
   linkType: hard
 
-"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Ffeeds%40file%3A..%2Fnet-feeds%23..%2Fnet-feeds%3A%3Ahash%3Da4eb9c%26locator%3Dbotchan%2540workspace%253Apackages%252Fbotchan":
+"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Ffeeds%40file%3A..%2Fnet-feeds%23..%2Fnet-feeds%3A%3Ahash%3D1ca43c%26locator%3Dbotchan%2540workspace%253Apackages%252Fbotchan":
   version: 0.1.12
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=f60c82&locator=%40net-protocol%2Ffeeds%40file%3A..%2Fnet-feeds%23..%2Fnet-feeds%3A%3Ahash%3Da4eb9c%26locator%3Dbotchan%2540workspace%253Apackages%252Fbotchan"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=cbe59b&locator=%40net-protocol%2Ffeeds%40file%3A..%2Fnet-feeds%23..%2Fnet-feeds%3A%3Ahash%3D1ca43c%26locator%3Dbotchan%2540workspace%253Apackages%252Fbotchan"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1428,13 +1428,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: 4e78c8742170342822886733f098af70d1a821908c86ee60b8f9f4c990f28c1a7953e66a16ee0cebbc61db484f81165c94f69e042fe592b48d094a04702039fb
+  checksum: c5209f3f41890cf007690453eae6fd1bb4412d5482b220ab56a8a95e054b85989e0986ad14f054b6a575524f2021112041a402ceb736882267eeebcf2291cc5f
   languageName: node
   linkType: hard
 
 "@net-protocol/core@file:../net-core::locator=%40net-protocol%2Ffeeds%40workspace%3Apackages%2Fnet-feeds":
   version: 0.1.12
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=f60c82&locator=%40net-protocol%2Ffeeds%40workspace%3Apackages%2Fnet-feeds"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=cbe59b&locator=%40net-protocol%2Ffeeds%40workspace%3Apackages%2Fnet-feeds"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1446,13 +1446,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: 4e78c8742170342822886733f098af70d1a821908c86ee60b8f9f4c990f28c1a7953e66a16ee0cebbc61db484f81165c94f69e042fe592b48d094a04702039fb
+  checksum: c5209f3f41890cf007690453eae6fd1bb4412d5482b220ab56a8a95e054b85989e0986ad14f054b6a575524f2021112041a402ceb736882267eeebcf2291cc5f
   languageName: node
   linkType: hard
 
 "@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fnetr%40workspace%3Apackages%2Fnet-netr":
   version: 0.1.12
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=f60c82&locator=%40net-protocol%2Fnetr%40workspace%3Apackages%2Fnet-netr"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=cbe59b&locator=%40net-protocol%2Fnetr%40workspace%3Apackages%2Fnet-netr"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1464,13 +1464,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: 4e78c8742170342822886733f098af70d1a821908c86ee60b8f9f4c990f28c1a7953e66a16ee0cebbc61db484f81165c94f69e042fe592b48d094a04702039fb
+  checksum: c5209f3f41890cf007690453eae6fd1bb4412d5482b220ab56a8a95e054b85989e0986ad14f054b6a575524f2021112041a402ceb736882267eeebcf2291cc5f
   languageName: node
   linkType: hard
 
 "@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fprofiles%40workspace%3Apackages%2Fnet-profiles":
   version: 0.1.12
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=f60c82&locator=%40net-protocol%2Fprofiles%40workspace%3Apackages%2Fnet-profiles"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=cbe59b&locator=%40net-protocol%2Fprofiles%40workspace%3Apackages%2Fnet-profiles"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1482,13 +1482,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: 4e78c8742170342822886733f098af70d1a821908c86ee60b8f9f4c990f28c1a7953e66a16ee0cebbc61db484f81165c94f69e042fe592b48d094a04702039fb
+  checksum: c5209f3f41890cf007690453eae6fd1bb4412d5482b220ab56a8a95e054b85989e0986ad14f054b6a575524f2021112041a402ceb736882267eeebcf2291cc5f
   languageName: node
   linkType: hard
 
-"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Frelay%40file%3A..%2Fnet-relay%23..%2Fnet-relay%3A%3Ahash%3D991f0e%26locator%3D%2540net-protocol%252Fagents%2540workspace%253Apackages%252Fnet-agents":
+"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Frelay%40file%3A..%2Fnet-relay%23..%2Fnet-relay%3A%3Ahash%3Db98d44%26locator%3D%2540net-protocol%252Fagents%2540workspace%253Apackages%252Fnet-agents":
   version: 0.1.12
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=f60c82&locator=%40net-protocol%2Frelay%40file%3A..%2Fnet-relay%23..%2Fnet-relay%3A%3Ahash%3D991f0e%26locator%3D%2540net-protocol%252Fagents%2540workspace%253Apackages%252Fnet-agents"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=cbe59b&locator=%40net-protocol%2Frelay%40file%3A..%2Fnet-relay%23..%2Fnet-relay%3A%3Ahash%3Db98d44%26locator%3D%2540net-protocol%252Fagents%2540workspace%253Apackages%252Fnet-agents"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1500,13 +1500,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: 4e78c8742170342822886733f098af70d1a821908c86ee60b8f9f4c990f28c1a7953e66a16ee0cebbc61db484f81165c94f69e042fe592b48d094a04702039fb
+  checksum: c5209f3f41890cf007690453eae6fd1bb4412d5482b220ab56a8a95e054b85989e0986ad14f054b6a575524f2021112041a402ceb736882267eeebcf2291cc5f
   languageName: node
   linkType: hard
 
 "@net-protocol/core@file:../net-core::locator=%40net-protocol%2Frelay%40workspace%3Apackages%2Fnet-relay":
   version: 0.1.12
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=f60c82&locator=%40net-protocol%2Frelay%40workspace%3Apackages%2Fnet-relay"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=cbe59b&locator=%40net-protocol%2Frelay%40workspace%3Apackages%2Fnet-relay"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1518,13 +1518,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: 4e78c8742170342822886733f098af70d1a821908c86ee60b8f9f4c990f28c1a7953e66a16ee0cebbc61db484f81165c94f69e042fe592b48d094a04702039fb
+  checksum: c5209f3f41890cf007690453eae6fd1bb4412d5482b220ab56a8a95e054b85989e0986ad14f054b6a575524f2021112041a402ceb736882267eeebcf2291cc5f
   languageName: node
   linkType: hard
 
 "@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fscore%40workspace%3Apackages%2Fnet-score":
   version: 0.1.12
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=f60c82&locator=%40net-protocol%2Fscore%40workspace%3Apackages%2Fnet-score"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=cbe59b&locator=%40net-protocol%2Fscore%40workspace%3Apackages%2Fnet-score"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1536,13 +1536,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: 4e78c8742170342822886733f098af70d1a821908c86ee60b8f9f4c990f28c1a7953e66a16ee0cebbc61db484f81165c94f69e042fe592b48d094a04702039fb
+  checksum: c5209f3f41890cf007690453eae6fd1bb4412d5482b220ab56a8a95e054b85989e0986ad14f054b6a575524f2021112041a402ceb736882267eeebcf2291cc5f
   languageName: node
   linkType: hard
 
-"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3D1ff51c%26locator%3D%2540net-protocol%252Fnetr%2540workspace%253Apackages%252Fnet-netr":
+"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3Dca8b19%26locator%3D%2540net-protocol%252Fnetr%2540workspace%253Apackages%252Fnet-netr":
   version: 0.1.12
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=f60c82&locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3D1ff51c%26locator%3D%2540net-protocol%252Fnetr%2540workspace%253Apackages%252Fnet-netr"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=cbe59b&locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3Dca8b19%26locator%3D%2540net-protocol%252Fnetr%2540workspace%253Apackages%252Fnet-netr"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1554,13 +1554,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: 4e78c8742170342822886733f098af70d1a821908c86ee60b8f9f4c990f28c1a7953e66a16ee0cebbc61db484f81165c94f69e042fe592b48d094a04702039fb
+  checksum: c5209f3f41890cf007690453eae6fd1bb4412d5482b220ab56a8a95e054b85989e0986ad14f054b6a575524f2021112041a402ceb736882267eeebcf2291cc5f
   languageName: node
   linkType: hard
 
-"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3D1ff51c%26locator%3D%2540net-protocol%252Fprofiles%2540workspace%253Apackages%252Fnet-profiles":
+"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3Dca8b19%26locator%3D%2540net-protocol%252Fprofiles%2540workspace%253Apackages%252Fnet-profiles":
   version: 0.1.12
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=f60c82&locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3D1ff51c%26locator%3D%2540net-protocol%252Fprofiles%2540workspace%253Apackages%252Fnet-profiles"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=cbe59b&locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3Dca8b19%26locator%3D%2540net-protocol%252Fprofiles%2540workspace%253Apackages%252Fnet-profiles"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1572,13 +1572,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: 4e78c8742170342822886733f098af70d1a821908c86ee60b8f9f4c990f28c1a7953e66a16ee0cebbc61db484f81165c94f69e042fe592b48d094a04702039fb
+  checksum: c5209f3f41890cf007690453eae6fd1bb4412d5482b220ab56a8a95e054b85989e0986ad14f054b6a575524f2021112041a402ceb736882267eeebcf2291cc5f
   languageName: node
   linkType: hard
 
-"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3D1ff51c%26locator%3D%2540net-protocol%252Fscore%2540workspace%253Apackages%252Fnet-score":
+"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3Dca8b19%26locator%3D%2540net-protocol%252Fscore%2540workspace%253Apackages%252Fnet-score":
   version: 0.1.12
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=f60c82&locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3D1ff51c%26locator%3D%2540net-protocol%252Fscore%2540workspace%253Apackages%252Fnet-score"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=cbe59b&locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3Dca8b19%26locator%3D%2540net-protocol%252Fscore%2540workspace%253Apackages%252Fnet-score"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1590,13 +1590,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: 4e78c8742170342822886733f098af70d1a821908c86ee60b8f9f4c990f28c1a7953e66a16ee0cebbc61db484f81165c94f69e042fe592b48d094a04702039fb
+  checksum: c5209f3f41890cf007690453eae6fd1bb4412d5482b220ab56a8a95e054b85989e0986ad14f054b6a575524f2021112041a402ceb736882267eeebcf2291cc5f
   languageName: node
   linkType: hard
 
 "@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fstorage%40workspace%3Apackages%2Fnet-storage":
   version: 0.1.12
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=f60c82&locator=%40net-protocol%2Fstorage%40workspace%3Apackages%2Fnet-storage"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=cbe59b&locator=%40net-protocol%2Fstorage%40workspace%3Apackages%2Fnet-storage"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1608,13 +1608,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: 4e78c8742170342822886733f098af70d1a821908c86ee60b8f9f4c990f28c1a7953e66a16ee0cebbc61db484f81165c94f69e042fe592b48d094a04702039fb
+  checksum: c5209f3f41890cf007690453eae6fd1bb4412d5482b220ab56a8a95e054b85989e0986ad14f054b6a575524f2021112041a402ceb736882267eeebcf2291cc5f
   languageName: node
   linkType: hard
 
 "@net-protocol/core@file:../net-core::locator=botchan%40workspace%3Apackages%2Fbotchan":
   version: 0.1.12
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=f60c82&locator=botchan%40workspace%3Apackages%2Fbotchan"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=cbe59b&locator=botchan%40workspace%3Apackages%2Fbotchan"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1626,7 +1626,7 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: 4e78c8742170342822886733f098af70d1a821908c86ee60b8f9f4c990f28c1a7953e66a16ee0cebbc61db484f81165c94f69e042fe592b48d094a04702039fb
+  checksum: c5209f3f41890cf007690453eae6fd1bb4412d5482b220ab56a8a95e054b85989e0986ad14f054b6a575524f2021112041a402ceb736882267eeebcf2291cc5f
   languageName: node
   linkType: hard
 
@@ -1656,7 +1656,7 @@ __metadata:
 
 "@net-protocol/feeds@file:../net-feeds::locator=botchan%40workspace%3Apackages%2Fbotchan":
   version: 0.1.17
-  resolution: "@net-protocol/feeds@file:../net-feeds#../net-feeds::hash=a4eb9c&locator=botchan%40workspace%3Apackages%2Fbotchan"
+  resolution: "@net-protocol/feeds@file:../net-feeds#../net-feeds::hash=1ca43c&locator=botchan%40workspace%3Apackages%2Fbotchan"
   dependencies:
     "@net-protocol/core": "file:../net-core"
   peerDependencies:
@@ -1668,7 +1668,7 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: 8b6997288350bbb74d907d59a082b9e45e8268d9288eabcf4a0cf9fea6e94c7bf72f9dc9f59c8130eb7fd832cc7eeb3b2e309539f8d0a8fdd4c9f81605d63296
+  checksum: 667ee127c0f6a65b85be7405c4107b070089d478aeab579640875f39eb5cb57d0e4c0a81825e574c5041a1216da66bba7457d9e95b10913840e0ee39912f5ab3
   languageName: node
   linkType: hard
 
@@ -1758,14 +1758,14 @@ __metadata:
 
 "@net-protocol/relay@file:../net-relay::locator=%40net-protocol%2Fagents%40workspace%3Apackages%2Fnet-agents":
   version: 0.1.5
-  resolution: "@net-protocol/relay@file:../net-relay#../net-relay::hash=991f0e&locator=%40net-protocol%2Fagents%40workspace%3Apackages%2Fnet-agents"
+  resolution: "@net-protocol/relay@file:../net-relay#../net-relay::hash=b98d44&locator=%40net-protocol%2Fagents%40workspace%3Apackages%2Fnet-agents"
   dependencies:
     "@net-protocol/core": "file:../net-core"
     "@x402/evm": "npm:^2.1.0"
     "@x402/fetch": "npm:^2.1.0"
   peerDependencies:
     viem: ^2.31.4
-  checksum: 0952ff6d1d2dcdc2e2445064a5ce92e1627cda93738092c9dd9618f8d0d124654da00fb8a9a76adf18820580a28fdb29f5d397db99e079d08debdd76c155a184
+  checksum: 89c8ddcdba885f00d03031b267ae75c9a84269ba55cb8e1088afc606bb05bde9b48623a4c3e62c5802ff3c1178717a2edd32cade475d3152e53417c90a8902cd
   languageName: node
   linkType: hard
 
@@ -1822,7 +1822,7 @@ __metadata:
 
 "@net-protocol/storage@file:../net-storage::locator=%40net-protocol%2Fnetr%40workspace%3Apackages%2Fnet-netr":
   version: 0.1.17
-  resolution: "@net-protocol/storage@file:../net-storage#../net-storage::hash=1ff51c&locator=%40net-protocol%2Fnetr%40workspace%3Apackages%2Fnet-netr"
+  resolution: "@net-protocol/storage@file:../net-storage#../net-storage::hash=ca8b19&locator=%40net-protocol%2Fnetr%40workspace%3Apackages%2Fnet-netr"
   dependencies:
     "@net-protocol/core": "file:../net-core"
     pako: "npm:^2.1.0"
@@ -1836,13 +1836,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: e701fb9b727c13cffaf2da589ad743a34f2955e7affd1ad04697a896aac0ab90fec02142475a7eec72c5d7259c05f10074dc689b1ca9e171cb4a8c807fa8740d
+  checksum: 95e798f69d3da762d1507749806fb516416ccfc4e98bfbf3993295e878b398b1c78b0e9b52d3f9ff9e686ddf99346f229534093ca25cadfa8aeb6dde73d38c89
   languageName: node
   linkType: hard
 
 "@net-protocol/storage@file:../net-storage::locator=%40net-protocol%2Fprofiles%40workspace%3Apackages%2Fnet-profiles":
   version: 0.1.17
-  resolution: "@net-protocol/storage@file:../net-storage#../net-storage::hash=1ff51c&locator=%40net-protocol%2Fprofiles%40workspace%3Apackages%2Fnet-profiles"
+  resolution: "@net-protocol/storage@file:../net-storage#../net-storage::hash=ca8b19&locator=%40net-protocol%2Fprofiles%40workspace%3Apackages%2Fnet-profiles"
   dependencies:
     "@net-protocol/core": "file:../net-core"
     pako: "npm:^2.1.0"
@@ -1856,13 +1856,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: e701fb9b727c13cffaf2da589ad743a34f2955e7affd1ad04697a896aac0ab90fec02142475a7eec72c5d7259c05f10074dc689b1ca9e171cb4a8c807fa8740d
+  checksum: 95e798f69d3da762d1507749806fb516416ccfc4e98bfbf3993295e878b398b1c78b0e9b52d3f9ff9e686ddf99346f229534093ca25cadfa8aeb6dde73d38c89
   languageName: node
   linkType: hard
 
 "@net-protocol/storage@file:../net-storage::locator=%40net-protocol%2Fscore%40workspace%3Apackages%2Fnet-score":
   version: 0.1.17
-  resolution: "@net-protocol/storage@file:../net-storage#../net-storage::hash=1ff51c&locator=%40net-protocol%2Fscore%40workspace%3Apackages%2Fnet-score"
+  resolution: "@net-protocol/storage@file:../net-storage#../net-storage::hash=ca8b19&locator=%40net-protocol%2Fscore%40workspace%3Apackages%2Fnet-score"
   dependencies:
     "@net-protocol/core": "file:../net-core"
     pako: "npm:^2.1.0"
@@ -1876,7 +1876,7 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: e701fb9b727c13cffaf2da589ad743a34f2955e7affd1ad04697a896aac0ab90fec02142475a7eec72c5d7259c05f10074dc689b1ca9e171cb4a8c807fa8740d
+  checksum: 95e798f69d3da762d1507749806fb516416ccfc4e98bfbf3993295e878b398b1c78b0e9b52d3f9ff9e686ddf99346f229534093ca25cadfa8aeb6dde73d38c89
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Adds support for chain-specific ERC20 quote tokens in the Bazaar SDK, enabling Base to use USDC instead of WETH/native ETH for ERC20 offers and listings. This includes parsing, order creation, and validation logic to handle the new quote token configuration.

## Key Changes

- **Chain Configuration** (`chainConfig.ts`):
  - Added `QuoteToken` interface with address, symbol, and decimals
  - Added optional `erc20QuoteToken` field to `BazaarChainConfig`
  - Configured Base (8453) to use USDC (`0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`) as the ERC20 quote token
  - Added `getErc20QuoteToken()` to retrieve chain-specific quote tokens
  - Added `getErc20PaymentToken()` as the single source of truth for ERC20 payment currency (returns configured quote token or synthesized WETH as fallback)

- **Order Creation** (`orderCreation.ts`):
  - Updated `buildErc20OfferOrderComponents()` to use `getErc20PaymentToken()` instead of hardcoded WETH
  - Updated `buildErc20ListingOrderComponents()` to support ERC20 consideration items (USDC on Base) instead of only native currency
  - Both functions now respect the chain's configured quote token for payment/consideration

- **Message Parsing** (`parsing.ts`):
  - Enhanced `parseErc20OfferFromMessage()` to validate that offers use the chain's configured quote token (hides legacy WETH orders on USDC-enabled chains)
  - Enhanced `parseErc20ListingFromMessage()` to validate that all consideration items match the chain's quote token (hides legacy native-payment listings on USDC-enabled chains)
  - Added logic to exclude consideration items that match the quote token when identifying the traded ERC20 token

- **Client** (`BazaarClient.ts`):
  - Updated `processErc20Offers()` to use `getErc20PaymentToken()` for balance validation and offer filtering
  - Updated `prepareCreateErc20Offer()` to use `getErc20PaymentToken()` for approval checks
  - Updated comments to reflect that payment tokens vary by chain

- **Tests**:
  - Updated existing tests to use chain 84532 (Base Sepolia) for legacy WETH behavior
  - Added comprehensive test coverage for USDC-denominated listings and offers on Base
  - Added tests validating that legacy native-payment listings are rejected on Base
  - Added tests validating that legacy WETH offers are rejected on Base
  - Added tests for order creation with USDC consideration on Base vs. native consideration on other chains

## Implementation Details

- The `getErc20PaymentToken()` function provides a unified interface: it returns the configured `erc20QuoteToken` if present, otherwise synthesizes the wrapped native currency as an 18-decimal quote token. This eliminates the need for call sites to combine multiple config lookups.
- On chains with a configured quote token, parsing functions strictly validate that offers/listings use that token, naturally filtering out legacy orders from before the migration.
- Order creation automatically uses the correct payment token based on chain configuration, requiring no changes to caller code.
- Base Sepolia (84532) remains on the legacy WETH/native flow since it has no `erc20QuoteToken` configured, allowing tests to verify both behaviors.

https://claude.ai/code/session_014TDGDzgsVwaoeyYCXznRzF