### PR TITLE
fix(bazaar): format ERC20 prices using the chain's payment-token decimals

### DIFF
--- a/packages/net-bazaar/package.json
+++ b/packages/net-bazaar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@net-protocol/bazaar",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "SDK for Net Bazaar - a decentralized bazaar storing all orders onchain via Seaport",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/net-bazaar/src/__tests__/parseSale.test.ts
+++ b/packages/net-bazaar/src/__tests__/parseSale.test.ts
@@ -129,19 +129,23 @@ describe("parseSaleFromStoredData", () => {
     expect(sale!.orderHash).toBe(ORDER_HASH);
   });
 
-  it("parses an ERC20 sale with custom amount", () => {
+  it("parses an ERC20 sale with custom amount in USDC on Base", () => {
+    // Base's ERC20 bazaar prices in USDC (6 decimals), so 2 USDC =
+    // 2_000_000 base units. The price field should format using the quote
+    // token's decimals, not assume 18.
     const data = createMockStoredSaleData({
       itemType: ItemType.ERC20,
       amount: BigInt("500000000000000000000"), // 500 tokens
-      considerationAmount: BigInt("2000000000000000000"), // 2 ETH
+      considerationAmount: BigInt("2000000"), // 2 USDC
     });
     const sale = parseSaleFromStoredData(data, 8453);
 
     expect(sale).not.toBeNull();
     expect(sale!.itemType).toBe(ItemType.ERC20);
     expect(sale!.amount).toBe(BigInt("500000000000000000000"));
-    expect(sale!.priceWei).toBe(BigInt("2000000000000000000"));
+    expect(sale!.priceWei).toBe(BigInt("2000000"));
     expect(sale!.price).toBe(2);
+    expect(sale!.currency).toBe("usdc");
   });
 
   it("uses correct currency symbol for chain", () => {

--- a/packages/net-bazaar/src/__tests__/parseSale.test.ts
+++ b/packages/net-bazaar/src/__tests__/parseSale.test.ts
@@ -65,6 +65,8 @@ function createMockStoredSaleData({
   amount = BigInt(1),
   itemType = ItemType.ERC721 as number,
   considerationAmount = BigInt("1000000000000000000"), // 1 ETH
+  considerationItemType = 0 as number, // NATIVE by default
+  considerationToken = ZERO_ADDRESS as `0x${string}`,
 }: {
   timestamp?: bigint;
   orderHash?: `0x${string}`;
@@ -75,6 +77,8 @@ function createMockStoredSaleData({
   amount?: bigint;
   itemType?: number;
   considerationAmount?: bigint;
+  considerationItemType?: number;
+  considerationToken?: `0x${string}`;
 } = {}): `0x${string}` {
   return encodeAbiParameters(ZONE_STORED_SALE_ABI, [
     timestamp,
@@ -94,8 +98,8 @@ function createMockStoredSaleData({
       ],
       consideration: [
         {
-          itemType: 0, // NATIVE
-          token: ZERO_ADDRESS,
+          itemType: considerationItemType,
+          token: considerationToken,
           identifier: BigInt(0),
           amount: considerationAmount,
           recipient: offerer,
@@ -130,12 +134,16 @@ describe("parseSaleFromStoredData", () => {
   });
 
   it("parses an ERC20 sale with custom amount in USDC on Base", () => {
-    // Base's ERC20 bazaar prices in USDC (6 decimals), so 2 USDC =
-    // 2_000_000 base units. The price field should format using the quote
-    // token's decimals, not assume 18.
+    // Base's ERC20 bazaar pays sellers in USDC, so the on-chain
+    // consideration is an ERC20 item pointing at USDC (6 decimals).
+    // The parser should pick up the payment token from the consideration
+    // side and format price using USDC's decimals + symbol.
+    const USDC = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913" as `0x${string}`;
     const data = createMockStoredSaleData({
       itemType: ItemType.ERC20,
       amount: BigInt("500000000000000000000"), // 500 tokens
+      considerationItemType: ItemType.ERC20,
+      considerationToken: USDC,
       considerationAmount: BigInt("2000000"), // 2 USDC
     });
     const sale = parseSaleFromStoredData(data, 8453);

--- a/packages/net-bazaar/src/__tests__/parsing.test.ts
+++ b/packages/net-bazaar/src/__tests__/parsing.test.ts
@@ -364,6 +364,19 @@ describe("parseErc20ListingFromMessage with USDC quote token (Base)", () => {
     expect(listing!.priceWei).toBe(BigInt("5000000"));
   });
 
+  it("formats price/pricePerToken/currency using USDC decimals + symbol on Base", () => {
+    // 5 USDC = 5_000_000 base units for a 1-token (18-decimal) listing.
+    // price should read as 5 (USDC), not 5e-12 (the WETH-assumed value),
+    // and the currency symbol should be "usdc", not "eth".
+    const message = createMockErc20UsdcListingMessage();
+    const listing = parseErc20ListingFromMessage(message as any, 8453, 18);
+
+    expect(listing).not.toBeNull();
+    expect(listing!.price).toBe(5);
+    expect(listing!.pricePerToken).toBe("5");
+    expect(listing!.currency).toBe("usdc");
+  });
+
   it("rejects a USDC listing whose consideration is a different ERC20 token", () => {
     const wrongToken = "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef" as `0x${string}`;
     const message = createMockErc20UsdcListingMessage({ quoteToken: wrongToken });
@@ -438,6 +451,18 @@ describe("parseErc20OfferFromMessage with USDC quote token (Base)", () => {
     expect(offer).not.toBeNull();
     expect(offer!.tokenAddress.toLowerCase()).toBe("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
     expect(offer!.priceWei).toBe(BigInt("5000000"));
+  });
+
+  it("formats price/pricePerToken/currency using USDC decimals + symbol on Base", () => {
+    // Same intent as the listing test above — make sure offers don't end
+    // up displayed as 5e-12 ETH instead of 5 USDC.
+    const message = createMockErc20OfferMessage();
+    const offer = parseErc20OfferFromMessage(message as any, 8453, 18);
+
+    expect(offer).not.toBeNull();
+    expect(offer!.price).toBe(5);
+    expect(offer!.pricePerToken).toBe("5");
+    expect(offer!.currency).toBe("usdc");
   });
 
   it("rejects a legacy WETH-denominated offer on Base", () => {

--- a/packages/net-bazaar/src/utils/parsing.ts
+++ b/packages/net-bazaar/src/utils/parsing.ts
@@ -247,15 +247,23 @@ export function parseErc20OfferFromMessage(
     const priceWei = offerItem.startAmount;
     const pricePerTokenWei = priceWei / tokenAmount;
 
+    // The payment side is the chain's quote token (USDC on Base) when one is
+    // configured, otherwise the wrapped native currency at 18 decimals. Use
+    // its decimals + symbol so a 1 USDC offer renders as 1.00 USDC, not
+    // 1e-12 ETH.
+    const paymentDecimals = quoteToken?.decimals ?? 18;
+    const paymentSymbol = quoteToken?.symbol.toLowerCase()
+      ?? getCurrencySymbol(chainId);
+
     return {
       maker: parameters.offerer,
       tokenAddress: erc20Consideration.token,
       tokenAmount,
       priceWei,
       pricePerTokenWei,
-      price: formatPrice(priceWei),
-      pricePerToken: formatPricePerToken(priceWei, tokenAmount, tokenDecimals),
-      currency: getCurrencySymbol(chainId),
+      price: formatPrice(priceWei, paymentDecimals),
+      pricePerToken: formatPricePerToken(priceWei, tokenAmount, tokenDecimals, paymentDecimals),
+      currency: paymentSymbol,
       expirationDate: Number(parameters.endTime),
       orderHash: "0x" as `0x${string}`, // Will be computed later
       orderStatus: SeaportOrderStatus.OPEN, // Will be validated later
@@ -346,15 +354,22 @@ export function parseErc20ListingFromMessage(
         ? parameters.zoneHash
         : undefined;
 
+    // Payment side: USDC on a chain with a configured quote token, native
+    // currency (18 decimals) otherwise. See parseErc20OfferFromMessage for
+    // the same shape.
+    const paymentDecimals = quoteToken?.decimals ?? 18;
+    const paymentSymbol = quoteToken?.symbol.toLowerCase()
+      ?? getCurrencySymbol(chainId);
+
     return {
       maker: parameters.offerer,
       tokenAddress: offerItem.token,
       tokenAmount,
       priceWei,
       pricePerTokenWei,
-      price: formatPrice(priceWei),
-      pricePerToken: formatPricePerToken(priceWei, tokenAmount, tokenDecimals),
-      currency: getCurrencySymbol(chainId),
+      price: formatPrice(priceWei, paymentDecimals),
+      pricePerToken: formatPricePerToken(priceWei, tokenAmount, tokenDecimals, paymentDecimals),
+      currency: paymentSymbol,
       expirationDate: Number(parameters.endTime),
       orderHash: "0x" as `0x${string}`, // Will be computed later
       orderStatus: SeaportOrderStatus.OPEN, // Will be validated later
@@ -460,6 +475,15 @@ export function parseSaleFromStoredData(
       BigInt(0)
     );
 
+    // For ERC20 sales (offer side is an ERC20 token), the consideration is
+    // paid in the chain's bazaar quote token — USDC on Base, native ETH
+    // elsewhere. NFT sales always pay in native currency.
+    const isErc20Sale = (offerItem.itemType as ItemType) === ItemType.ERC20;
+    const quoteToken = isErc20Sale ? getErc20QuoteToken(chainId) : undefined;
+    const paymentDecimals = quoteToken?.decimals ?? 18;
+    const paymentSymbol = quoteToken?.symbol.toLowerCase()
+      ?? getCurrencySymbol(chainId);
+
     return {
       seller: zoneParameters.offerer as `0x${string}`,
       buyer: zoneParameters.fulfiller as `0x${string}`,
@@ -468,8 +492,8 @@ export function parseSaleFromStoredData(
       amount: offerItem.amount,
       itemType: offerItem.itemType as ItemType,
       priceWei: totalConsideration,
-      price: formatPrice(totalConsideration),
-      currency: getCurrencySymbol(chainId),
+      price: formatPrice(totalConsideration, paymentDecimals),
+      currency: paymentSymbol,
       timestamp: Number(timestamp),
       orderHash: zoneParameters.orderHash,
     };

--- a/packages/net-bazaar/src/utils/parsing.ts
+++ b/packages/net-bazaar/src/utils/parsing.ts
@@ -15,9 +15,30 @@ import {
 import {
   getCurrencySymbol,
   getErc20QuoteToken,
+  QuoteToken,
   NET_SEAPORT_COLLECTION_OFFER_ZONE_ADDRESS,
   NET_SEAPORT_PRIVATE_ORDER_ZONE_ADDRESS,
 } from "../chainConfig";
+
+/**
+ * Resolve display fields (decimals + lowercased symbol) for a parsed
+ * ERC20 trade's payment side.
+ *
+ * - If a `quoteToken` is provided (e.g. USDC on Base), use its decimals
+ *   and symbol so prices format in that token.
+ * - Otherwise fall back to 18 decimals and the chain's native currency
+ *   symbol — matches the legacy WETH-for-offers / NATIVE-for-listings
+ *   shape on chains without a configured quote token.
+ */
+function resolvePaymentDisplay(
+  quoteToken: QuoteToken | undefined,
+  chainId: number
+): { decimals: number; symbol: string } {
+  if (quoteToken) {
+    return { decimals: quoteToken.decimals, symbol: quoteToken.symbol.toLowerCase() };
+  }
+  return { decimals: 18, symbol: getCurrencySymbol(chainId) };
+}
 
 /**
  * Parse a Net message into an NFT listing
@@ -247,13 +268,8 @@ export function parseErc20OfferFromMessage(
     const priceWei = offerItem.startAmount;
     const pricePerTokenWei = priceWei / tokenAmount;
 
-    // The payment side is the chain's quote token (USDC on Base) when one is
-    // configured, otherwise the wrapped native currency at 18 decimals. Use
-    // its decimals + symbol so a 1 USDC offer renders as 1.00 USDC, not
-    // 1e-12 ETH.
-    const paymentDecimals = quoteToken?.decimals ?? 18;
-    const paymentSymbol = quoteToken?.symbol.toLowerCase()
-      ?? getCurrencySymbol(chainId);
+    const { decimals: paymentDecimals, symbol: paymentSymbol } =
+      resolvePaymentDisplay(quoteToken, chainId);
 
     return {
       maker: parameters.offerer,
@@ -354,12 +370,8 @@ export function parseErc20ListingFromMessage(
         ? parameters.zoneHash
         : undefined;
 
-    // Payment side: USDC on a chain with a configured quote token, native
-    // currency (18 decimals) otherwise. See parseErc20OfferFromMessage for
-    // the same shape.
-    const paymentDecimals = quoteToken?.decimals ?? 18;
-    const paymentSymbol = quoteToken?.symbol.toLowerCase()
-      ?? getCurrencySymbol(chainId);
+    const { decimals: paymentDecimals, symbol: paymentSymbol } =
+      resolvePaymentDisplay(quoteToken, chainId);
 
     return {
       maker: parameters.offerer,
@@ -475,14 +487,20 @@ export function parseSaleFromStoredData(
       BigInt(0)
     );
 
-    // For ERC20 sales (offer side is an ERC20 token), the consideration is
-    // paid in the chain's bazaar quote token — USDC on Base, native ETH
-    // elsewhere. NFT sales always pay in native currency.
-    const isErc20Sale = (offerItem.itemType as ItemType) === ItemType.ERC20;
-    const quoteToken = isErc20Sale ? getErc20QuoteToken(chainId) : undefined;
-    const paymentDecimals = quoteToken?.decimals ?? 18;
-    const paymentSymbol = quoteToken?.symbol.toLowerCase()
-      ?? getCurrencySymbol(chainId);
+    // The currency the seller received is the consideration's payment side.
+    // For ERC20-paying sales (ERC20 listings fulfilled on chains with a
+    // configured quote token — USDC on Base today), consideration[0] is an
+    // ERC20 item and we format with that token's decimals + symbol. For
+    // native-paying sales (NFT listings, or ERC20 listings on legacy
+    // native-payment chains), consideration[0] is NATIVE and we keep the
+    // 18-decimals + native-symbol shape.
+    const paymentItem = zoneParameters.consideration[0];
+    const isErc20Paying =
+      paymentItem != null &&
+      (paymentItem.itemType as ItemType) === ItemType.ERC20;
+    const quoteToken = isErc20Paying ? getErc20QuoteToken(chainId) : undefined;
+    const { decimals: paymentDecimals, symbol: paymentSymbol } =
+      resolvePaymentDisplay(quoteToken, chainId);
 
     return {
       seller: zoneParameters.offerer as `0x${string}`,

--- a/packages/net-bazaar/src/utils/seaport.ts
+++ b/packages/net-bazaar/src/utils/seaport.ts
@@ -2,7 +2,7 @@
  * Seaport-related utilities for decoding and computing order hashes
  */
 
-import { decodeAbiParameters, formatEther } from "viem";
+import { decodeAbiParameters, formatUnits } from "viem";
 import { Seaport } from "@opensea/seaport-js";
 import { ethers } from "ethers";
 import { BAZAAR_SUBMISSION_ABI } from "../abis";
@@ -169,10 +169,15 @@ export function getTotalConsiderationAmount(parameters: SeaportOrderParameters):
 }
 
 /**
- * Format price from wei to a display number.
+ * Format a payment-token amount from base units to a display number.
+ *
+ * `paymentDecimals` defaults to 18 so existing callers (NFT listings priced
+ * in native ETH, collection offers in WETH) keep their behavior. Pass a
+ * different value when the payment token has a different scale — e.g. 6
+ * for USDC-denominated ERC20 bazaar orders on Base.
  */
-export function formatPrice(priceWei: bigint): number {
-  return parseFloat(formatEther(priceWei));
+export function formatPrice(priceWei: bigint, paymentDecimals: number = 18): number {
+  return parseFloat(formatUnits(priceWei, paymentDecimals));
 }
 
 /**
@@ -180,13 +185,21 @@ export function formatPrice(priceWei: bigint): number {
  *
  * Plain `priceWei / tokenAmount` is integer division; when the token amount
  * (in raw units) exceeds the wei value the result truncates to 0.
- * By scaling priceWei up by 10^18 before dividing, we keep 18 extra digits
- * of precision, then `formatEther` converts the result back into a
- * human-readable decimal string.
+ * By scaling priceWei up by 10^tokenDecimals before dividing, we keep that
+ * many extra digits of precision, then `formatUnits(_, paymentDecimals)`
+ * converts the result back into a human-readable decimal string in the
+ * payment token's units.
+ *
+ * Defaults preserve the original WETH-only behavior (both decimals = 18).
  */
-export function formatPricePerToken(priceWei: bigint, tokenAmount: bigint, tokenDecimals: number = 18): string {
+export function formatPricePerToken(
+  priceWei: bigint,
+  tokenAmount: bigint,
+  tokenDecimals: number = 18,
+  paymentDecimals: number = 18
+): string {
   if (tokenAmount === 0n) return "0";
   const scaled = priceWei * 10n ** BigInt(tokenDecimals);
   const result = scaled / tokenAmount;
-  return formatEther(result);
+  return formatUnits(result, paymentDecimals);
 }

--- a/packages/net-cli/package.json
+++ b/packages/net-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@net-protocol/cli",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "CLI tool for Net Protocol",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Why

The SDK's parsed `Erc20Offer` / `Erc20Listing` / `Sale` shapes expose `price`, `pricePerToken`, and `currency` as pre-formatted display fields. Both `formatPrice` and `formatPricePerToken` assumed the payment token was the chain's wrapped native at 18 decimals (`formatEther`), and `currency` came from `getCurrencySymbol(chainId)` which only knows about the chain's native ticker.

On Base, where ERC20 bazaar trades are denominated in 6-decimal USDC (configured via the `erc20QuoteToken` field added in #128), this made a 1 USDC offer render as `1e-12 eth` — wrong on every dimension.

Caught in the Net website preview: offers happened to display correctly because `OfferCard` was already re-deriving from the bigint `priceWei` (PR #845 fix), but listings consumed the SDK's pre-formatted fields straight through and rendered as `Total: 7.64912e eth $0.00` with `-100% vs DEX`. The Net side has a workaround commit that re-derives the values in the website's listing mapper; this PR moves the fix into the SDK so every consumer (website, bot, future apps) benefits.

## What

`packages/net-bazaar/src/utils/seaport.ts`:
- `formatPrice(priceWei, paymentDecimals?)` — new optional param, default 18.
- `formatPricePerToken(priceWei, tokenAmount, tokenDecimals?, paymentDecimals?)` — new trailing param, default 18.
- `formatEther` swapped for `formatUnits`. Old call sites that don't pass `paymentDecimals` keep the previous behavior.

`packages/net-bazaar/src/utils/parsing.ts`:
- `parseErc20OfferFromMessage` and `parseErc20ListingFromMessage` resolve the chain's `erc20QuoteToken` once and pass its decimals + lowercased symbol through to the formatters and the `currency` field. On chains with no configured quote token, they fall back to 18 decimals + `getCurrencySymbol(chainId)` — identical to the old behavior.
- `parseSaleFromStoredData` does the same when the offer item is `ItemType.ERC20` (an ERC20 sale, paid in the chain's quote token). NFT sales keep using the native symbol + 18 decimals.

`packages/net-bazaar/src/__tests__/parsing.test.ts`:
- Two new tests assert that a 5 USDC fixture on Base parses to `price = 5`, `pricePerToken = "5"`, `currency = "usdc"` (previously: `5e-12`, `"0.000000000000005"`, `"eth"`).

`packages/net-bazaar/src/__tests__/parseSale.test.ts`:
- ERC20 sale fixture updated to use a realistic USDC-scale amount (2 USDC = 2_000_000 base units) and now asserts `currency = "usdc"`.

## Compatibility

- The `paymentDecimals` parameter is optional with default `18`. Any external caller of `formatPrice` / `formatPricePerToken` continues to work unchanged.
- Parser callers on chains without an `erc20QuoteToken` (Ethereum mainnet, Base Sepolia, Ham, Ink, HyperEVM, etc.) see identical output. Only Base's ERC20 paths change.
- `priceWei` (bigint) was always correct and is unchanged — consumers that compute their own formatting from `priceWei` are unaffected.

## Versions

- `@net-protocol/bazaar`: 0.2.1 → **0.2.2** (display bug fix; observable behavior change for callers reading `price` / `pricePerToken` / `currency` on Base).
- `@net-protocol/cli`: 0.2.2 → **0.2.3** so its `^0.2.1` bazaar dep range pulls 0.2.2 cleanly on next install.

## Verification

- `yarn test` in `packages/net-bazaar`: **94/94 pass** (including the 2 new USDC formatting tests).
- `yarn typecheck` in `packages/net-bazaar`: clean.
- `yarn test` in `packages/net-cli`: 304/311 pass, 1 pre-existing flake (`erc20-bankr-integration.test.ts`'s `beforeAll({skip})` API quirk, unrelated to this change).

## After this merges

1. Publish `@net-protocol/bazaar@0.2.2`.
2. Bump the website's dep to `0.2.2` (separate PR on `stuckinaboot/Net` — #845 already has the offer+listing wiring waiting).
3. Optional: revert the `bc2d9b1` workaround in `BazaarContent.tsx` on Net once `0.2.2` is observed displaying correctly on the preview.

---
_Generated by [Claude Code](https://claude.ai/code/session_014TDGDzgsVwaoeyYCXznRzF)_