### PR TITLE
fix(bazaar): match consideration token by address when parsing sales (fixes legacy WETH sales showing as inflated USDC)

### DIFF
--- a/packages/net-bazaar/package.json
+++ b/packages/net-bazaar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@net-protocol/bazaar",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "SDK for Net Bazaar - a decentralized bazaar storing all orders onchain via Seaport",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/net-bazaar/src/__tests__/parseSale.test.ts
+++ b/packages/net-bazaar/src/__tests__/parseSale.test.ts
@@ -156,6 +156,37 @@ describe("parseSaleFromStoredData", () => {
     expect(sale!.currency).toBe("usdc");
   });
 
+  it("does NOT format a non-quote-token ERC20 consideration with the quote token's decimals", () => {
+    // Regression for a real bug observed on the live bazaar:
+    //
+    // Legacy ERC20 listings on Base (created before the USDC migration)
+    // had a WETH item in consideration[0]. When parsed by the previous
+    // implementation, the parser saw `consideration[0].itemType === ERC20`,
+    // assumed the trade was USDC-paying, and formatted the WETH base units
+    // (18 decimals) using USDC's 6 decimals — inflating a $0.0035 fair
+    // trade into a "$994,764 USDC" display, off by 10^12.
+    //
+    // Now: an ERC20 payment whose token is NOT the chain's configured
+    // quote token (USDC) should fall back to wrapped-native semantics
+    // (18 decimals, "WETH" symbol).
+    const WETH_BASE = "0x4200000000000000000000000000000000000006" as `0x${string}`;
+    const data = createMockStoredSaleData({
+      itemType: ItemType.ERC20,
+      amount: BigInt("1111000000000000000000"), // 1,111 ALPHA (18 decimals)
+      considerationItemType: ItemType.ERC20,
+      considerationToken: WETH_BASE,
+      // 9.94e11 WETH base units ≈ 9.94e-7 WETH ≈ $0.0035 at $3500/ETH
+      considerationAmount: BigInt("994764506934"),
+    });
+    const sale = parseSaleFromStoredData(data, 8453);
+
+    expect(sale).not.toBeNull();
+    expect(sale!.priceWei).toBe(BigInt("994764506934"));
+    // Formatted with WETH's 18 decimals, not USDC's 6 decimals.
+    expect(sale!.price).toBeCloseTo(9.94764506934e-7, 18);
+    expect(sale!.currency).toBe("weth");
+  });
+
   it("uses correct currency symbol for chain", () => {
     const data = createMockStoredSaleData();
     const sale = parseSaleFromStoredData(data, 666666666); // Degen chain

--- a/packages/net-bazaar/src/utils/parsing.ts
+++ b/packages/net-bazaar/src/utils/parsing.ts
@@ -15,6 +15,7 @@ import {
 import {
   getCurrencySymbol,
   getErc20QuoteToken,
+  getWrappedNativeCurrency,
   QuoteToken,
   NET_SEAPORT_COLLECTION_OFFER_ZONE_ADDRESS,
   NET_SEAPORT_PRIVATE_ORDER_ZONE_ADDRESS,
@@ -488,19 +489,43 @@ export function parseSaleFromStoredData(
     );
 
     // The currency the seller received is the consideration's payment side.
-    // For ERC20-paying sales (ERC20 listings fulfilled on chains with a
-    // configured quote token — USDC on Base today), consideration[0] is an
-    // ERC20 item and we format with that token's decimals + symbol. For
-    // native-paying sales (NFT listings, or ERC20 listings on legacy
-    // native-payment chains), consideration[0] is NATIVE and we keep the
-    // 18-decimals + native-symbol shape.
+    // Match `consideration[0].token` against the chain's configured quote
+    // token by address — not just by itemType — so legacy ERC20-paying
+    // sales (e.g. WETH-denominated listings filled before a chain migrated
+    // to USDC) don't get force-formatted through the quote token's
+    // decimals/symbol.
+    //
+    // - NATIVE consideration → 18 decimals + native symbol (e.g. "eth").
+    // - ERC20 consideration whose token matches the chain's quote token
+    //   (USDC on Base) → quote-token decimals + symbol ("usdc", 6).
+    // - ERC20 consideration whose token is anything else (e.g. legacy WETH
+    //   sales on Base) → assume the wrapped native at 18 decimals and use
+    //   that symbol; don't reuse the quote-token decimals or we silently
+    //   inflate the price by `10^(18 - quoteDecimals)`.
     const paymentItem = zoneParameters.consideration[0];
-    const isErc20Paying =
-      paymentItem != null &&
-      (paymentItem.itemType as ItemType) === ItemType.ERC20;
-    const quoteToken = isErc20Paying ? getErc20QuoteToken(chainId) : undefined;
-    const { decimals: paymentDecimals, symbol: paymentSymbol } =
-      resolvePaymentDisplay(quoteToken, chainId);
+    const paymentItemType = paymentItem?.itemType as ItemType | undefined;
+    const quoteToken = getErc20QuoteToken(chainId);
+    const wrappedNative = getWrappedNativeCurrency(chainId);
+
+    let paymentDecimals: number;
+    let paymentSymbol: string;
+    if (paymentItemType === ItemType.ERC20 && paymentItem) {
+      const paymentToken = paymentItem.token.toLowerCase();
+      if (quoteToken && paymentToken === quoteToken.address.toLowerCase()) {
+        paymentDecimals = quoteToken.decimals;
+        paymentSymbol = quoteToken.symbol.toLowerCase();
+      } else {
+        // Some other ERC20 — almost always WETH on chains that had ERC20
+        // listings/offers before the quote-token migration.
+        paymentDecimals = 18;
+        paymentSymbol = (
+          wrappedNative?.symbol ?? getCurrencySymbol(chainId)
+        ).toLowerCase();
+      }
+    } else {
+      paymentDecimals = 18;
+      paymentSymbol = getCurrencySymbol(chainId);
+    }
 
     return {
       seller: zoneParameters.offerer as `0x${string}`,

--- a/packages/net-cli/package.json
+++ b/packages/net-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@net-protocol/cli",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "CLI tool for Net Protocol",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Why

Spotted on the live bazaar's Sales tab for an ERC20 token on Base: sales that filled before the USDC migration (so their on-chain consideration was WETH, not USDC) rendered with absurdly large "USDC" totals — a real $0.0035 fair trade displayed as `"$994,764 USDC"`. Off by exactly 10¹².

## Root cause

In `parseSaleFromStoredData`, the parser asked only `consideration[0].itemType === ItemType.ERC20` to decide whether to format the sale as the chain's quote token (USDC on Base):

```ts
const isErc20Paying = paymentItem?.itemType === ItemType.ERC20;
const quoteToken = isErc20Paying ? getErc20QuoteToken(chainId) : undefined;
const { decimals: paymentDecimals, symbol: paymentSymbol } =
  resolvePaymentDisplay(quoteToken, chainId);
```

Any other ERC20 — most commonly WETH from legacy listings, but also any third-party token — got force-formatted through USDC's 6 decimals and the "usdc" symbol. WETH base units (18 decimals) read by the USDC formatter inflate by exactly 10¹², which is the off-by-12 behavior on the affected cards.

## Fix

Also compare `consideration[0].token` against the configured `erc20QuoteToken.address`. Three branches now:

1. **NATIVE consideration** → 18 decimals + native chain symbol (`"eth"`). Unchanged for NFT listings and legacy native-payment ERC20 listings.
2. **ERC20 consideration whose token IS the configured quote token** → quote-token decimals + symbol (real USDC sales on Base).
3. **ERC20 consideration whose token is something else** → assume wrapped native at 18 decimals and use that symbol (`"weth"`). This is the catch-all that fixes the live bug.

Pseudocode of the resolved branches:

```ts
if (paymentItemType === ItemType.ERC20 && paymentItem) {
  if (quoteToken && paymentItem.token === quoteToken.address) {
    // Real USDC sale
    paymentDecimals = quoteToken.decimals; paymentSymbol = quoteToken.symbol;
  } else {
    // Some other ERC20 — almost always WETH from legacy listings
    paymentDecimals = 18; paymentSymbol = wrappedNative.symbol ?? native;
  }
} else {
  paymentDecimals = 18; paymentSymbol = native;
}
```

## Regression test

`packages/net-bazaar/src/__tests__/parseSale.test.ts`:

```ts
it("does NOT format a non-quote-token ERC20 consideration with the quote token's decimals", () => {
  const WETH_BASE = "0x4200000000000000000000000000000000000006";
  const data = createMockStoredSaleData({
    itemType: ItemType.ERC20,
    amount: BigInt("1111000000000000000000"),       // 1,111 ALPHA
    considerationItemType: ItemType.ERC20,
    considerationToken: WETH_BASE,
    considerationAmount: BigInt("994764506934"),    // ~9.94e-7 WETH, ~$0.0035
  });
  const sale = parseSaleFromStoredData(data, 8453);

  expect(sale!.price).toBeCloseTo(9.94764506934e-7, 18);  // not 994764.506934!
  expect(sale!.currency).toBe("weth");
});
```

Pre-fix this test would have shown `sale.price = 994764.506934` and `sale.currency = "usdc"`. Post-fix it correctly shows the actual WETH amount.

## Verification

- `yarn test` in `packages/net-bazaar`: **95/95 pass** (was 94/94 before the new regression test)
- `yarn typecheck` in `packages/net-bazaar`: clean
- `yarn test` in `packages/net-cli`: 307/311 pass, same pre-existing flake as before (`erc20-bankr-integration.test.ts`'s `beforeAll({skip})` API quirk — unrelated)

## Compatibility

- USDC-paying sales (real Base USDC trades, post-migration): unchanged. The `paymentItem.token === quoteToken.address` branch covers them with the same decimals/symbol as before.
- Native-payment sales (NFT listings, legacy ERC20-NATIVE listings): unchanged. NATIVE branch is identical.
- WETH-payment sales (legacy ERC20 listings or any other non-USDC ERC20 paid trade): **changes from buggy USDC-formatted display to correct WETH-formatted display.** This is a fix, not a behavior regression — the previous numbers were garbage.

## Versions

- `@net-protocol/bazaar`: 0.2.2 → **0.2.3**
- `@net-protocol/cli`: 0.2.3 → **0.2.4** (so its `^0.2.2` dep range pulls 0.2.3 on next install)

## After merge

1. Publish `@net-protocol/bazaar@0.2.3` and `@net-protocol/cli@0.2.4`.
2. Bump the Net website's dep to `0.2.3` — sales tab on Base ERC20 bazaars will then render legacy WETH-paying sales correctly.

The per-token math discrepancy on the *correctly-labeled* "eth" cards (cards 1 & 5 in the original screenshot) is a separate issue I still can't fully pin down statically. That's likely in the SalesTab inline `pricePerToken` formula or a `decimals` resolution timing issue on the website side, not the SDK — addressing in a follow-up after this fix lands and we can see what's left.

---
_Generated by [Claude Code](https://claude.ai/code/session_014TDGDzgsVwaoeyYCXznRzF)_