### PR TITLE
fix(cli): scale ERC20 `--price` by chain's payment-token decimals (fixes 10¹² overflow on Base USDC)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -582,8 +582,8 @@ The only legitimate reason to read allowance state yourself is a non-submitting 
 | **Upvoting (users)** | Price fetched from contract (currently 0.000025 ETH per upvote). Output includes a non-zero `value` field — you **must** include it. Only Base (8453) is supported. |
 | **Bazaar approvals** | The CLI handles all approval logic. The `approvals` array in every encode-only output is exhaustive — submit it verbatim, no pre-flight `allowance` / `isApprovedForAll` check needed. **Net Bazaar uses Seaport directly (no conduit).** Do NOT add `setApprovalForAll`/`approve` txs for any "conduit" or "bazaar contract"; an empty `approvals` array means none are needed. See "Bazaar Approvals" under Encode-Only Transaction Formats above. |
 | **Bazaar (NFT)** | NFT listings/offers are supported on Base (8453) and Ethereum (1). All write commands support `--encode-only`. |
-| **Bazaar (ERC-20)** | ERC-20 listings/offers are supported on Base (8453) and HyperEVM (999). ERC-20 commands use `--token-address` + `--token-amount` (raw bigint units). Listings pay in the chain's native currency (ETH or HYPE); offers pay in the wrapped native currency (WETH or wrapped HYPE), which the offerer pre-approves. |
-| **Bazaar JSON fields (ERC-20)** | `pricePerToken` is a **string** (not a number) for full-decimal precision; `pricePerTokenWei` is `priceWei / tokenAmount` (bigint integer division — often rounds to `"0"` for 18-decimal tokens). `currency` is the native-chain symbol (`"eth"`, `"hype"`), not the wrapped-token name. |
+| **Bazaar (ERC-20)** | ERC-20 listings/offers are supported on Base (8453) and HyperEVM (999). ERC-20 commands use `--token-address` + `--token-amount` (raw bigint units). Both listings and offers settle in the chain's **ERC-20 payment token**: USDC on Base (`--price 5` = 5 USDC), wrapped native (WHYPE) on HyperEVM. The CLI reads `getErc20PaymentToken(chainId)` from `@net-protocol/bazaar` and scales `--price` by that token's decimals — do not pre-scale. |
+| **Bazaar JSON fields (ERC-20)** | `pricePerToken` is a **string** (not a number) for full-decimal precision; `pricePerTokenWei` is `priceWei / tokenAmount` (bigint integer division — often rounds to `"0"` for 18-decimal tokens). `currency` is the payment-token symbol — `"usdc"` on Base, native chain symbol (`"hype"`, etc.) elsewhere. |
 | **Chain IDs** | Base = `8453`, Base Sepolia = `84532`. Mismatched chain IDs are the #1 cause of "data not found." |
 
 ---
@@ -686,11 +686,11 @@ When transactions are submitted externally (e.g., via Bankr after using `--encod
 - "Buy an NFT" → `netp bazaar buy-listing --order-hash 0x... --nft-address 0x... --buyer 0xMyAddr --chain-id 8453 --encode-only`
 - "What NFTs do I own?" → `netp bazaar owned-nfts --nft-address 0x... --owner 0xMyAddr --chain-id 8453 --json`
 - "Browse ERC-20 listings for a token" → `netp bazaar list-erc20-listings --token-address 0x... --chain-id 8453 --json`
-- "Sell my ERC-20 tokens" / "Create an ERC-20 listing" → `netp bazaar create-erc20-listing --token-address 0x... --token-amount 1000000000000000000 --price 0.05 --offerer 0xMyAddr --chain-id 8453` (keyless; sign then `submit-erc20-listing`)
-- "Make an offer on an ERC-20 token" → `netp bazaar create-erc20-offer --token-address 0x... --token-amount 1000000000000000000 --price 0.05 --offerer 0xMyAddr --chain-id 8453` (bid is paid in wrapped native currency; keyless; sign then `submit-erc20-offer`)
+- "Sell my ERC-20 tokens" / "Create an ERC-20 listing" → `netp bazaar create-erc20-listing --token-address 0x... --token-amount 1000000000000000000 --price 5 --offerer 0xMyAddr --chain-id 8453` (`--price` is in the chain's ERC-20 payment token: USDC on Base, native/wrapped-native elsewhere — `--price 5` on Base = 5 USDC; keyless flow, sign then `submit-erc20-listing`)
+- "Make an offer on an ERC-20 token" → `netp bazaar create-erc20-offer --token-address 0x... --token-amount 1000000000000000000 --price 5 --offerer 0xMyAddr --chain-id 8453` (bid paid in the chain's ERC-20 payment token: USDC on Base, wrapped native elsewhere; keyless, sign then `submit-erc20-offer`)
 - "Check ERC-20 offers for a token" → `netp bazaar list-erc20-offers --token-address 0x... --chain-id 8453 --json`
-- "Buy ERC-20 tokens from a listing" → `netp bazaar buy-erc20-listing --order-hash 0x... --token-address 0x... --buyer 0xMyAddr --chain-id 8453 --encode-only`
-- "Accept an ERC-20 offer (sell tokens for wrapped native currency)" → `netp bazaar accept-erc20-offer --order-hash 0x... --token-address 0x... --seller 0xMyAddr --chain-id 8453 --encode-only`
+- "Buy ERC-20 tokens from a listing" → `netp bazaar buy-erc20-listing --order-hash 0x... --token-address 0x... --buyer 0xMyAddr --chain-id 8453 --encode-only` (on Base, `approvals` may include a USDC approve and `fulfillment.value` is `"0"`; on chains without a configured quote token, `fulfillment.value` carries the native payment)
+- "Accept an ERC-20 offer (sell tokens for the chain's payment token)" → `netp bazaar accept-erc20-offer --order-hash 0x... --token-address 0x... --seller 0xMyAddr --chain-id 8453 --encode-only` (payout in USDC on Base, wrapped native elsewhere)
 
 ### Onchain Agents (use netp)
 - "Create an agent" → `netp agent create "My Agent" --system-prompt "You are helpful." --chain-id 8453`

--- a/packages/net-cli/package.json
+++ b/packages/net-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@net-protocol/cli",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "CLI tool for Net Protocol",
   "type": "module",
   "bin": {
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@net-protocol/agents": "^0.1.0",
-    "@net-protocol/bazaar": "^0.2.1",
+    "@net-protocol/bazaar": "^0.2.3",
     "@net-protocol/chats": "^0.1.0",
     "@net-protocol/core": "^0.1.9",
     "@net-protocol/feeds": "^0.1.14",

--- a/packages/net-cli/src/__tests__/commands/bazaar/erc20-bankr.test.ts
+++ b/packages/net-cli/src/__tests__/commands/bazaar/erc20-bankr.test.ts
@@ -59,6 +59,14 @@ vi.mock("@net-protocol/bazaar", () => ({
     getErc20Listings: mockGetErc20Listings,
     getErc20Offers: mockGetErc20Offers,
   })),
+  // Base's quote token (USDC, 6 decimals). The CLI reads this to decide
+  // how to scale the `--price` arg into base units; mocking it keeps the
+  // test deterministic on TEST_CHAIN_ID = Base.
+  getErc20PaymentToken: vi.fn().mockReturnValue({
+    address: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+    symbol: "USDC",
+    decimals: 6,
+  }),
 }));
 
 // Mock @net-protocol/core

--- a/packages/net-cli/src/commands/bazaar/create-erc20-listing.ts
+++ b/packages/net-cli/src/commands/bazaar/create-erc20-listing.ts
@@ -2,28 +2,15 @@ import chalk from "chalk";
 import {
   createWalletClient,
   http,
-  parseUnits,
   encodeFunctionData,
 } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
-import { BazaarClient, getErc20PaymentToken } from "@net-protocol/bazaar";
+import { BazaarClient } from "@net-protocol/bazaar";
 import { getChainRpcUrls, getBaseDataSuffix } from "@net-protocol/core";
 import { parseCommonOptions, parseReadOnlyOptions } from "../../cli/shared";
 import { exitWithError } from "../../shared/output";
+import { parseErc20Price } from "./format";
 import type { CreateErc20ListingOptions } from "./types";
-
-/**
- * Parse `--price` into base units using the chain's ERC20 payment token
- * decimals (USDC=6 on Base, WETH=18 elsewhere). Using `parseEther` here
- * would silently inflate USDC prices by 10^12.
- */
-function parseErc20PriceWei(chainId: number, price: string): bigint {
-  const paymentToken = getErc20PaymentToken(chainId);
-  if (!paymentToken) {
-    exitWithError(`Chain ${chainId} has no ERC20 payment token configured`);
-  }
-  return parseUnits(price, paymentToken.decimals);
-}
 
 export async function executeCreateErc20Listing(options: CreateErc20ListingOptions): Promise<void> {
   const hasPrivateKey = !!(
@@ -50,10 +37,11 @@ export async function executeCreateErc20Listing(options: CreateErc20ListingOptio
     rpcUrl: commonOptions.rpcUrl,
   });
 
-  const priceWei = parseErc20PriceWei(commonOptions.chainId, options.price);
+  const { priceWei, symbol: paymentSymbol } = parseErc20Price(
+    commonOptions.chainId,
+    options.price
+  );
   const tokenAmount = BigInt(options.tokenAmount);
-  const paymentSymbol =
-    getErc20PaymentToken(commonOptions.chainId)?.symbol ?? "";
 
   try {
     console.log(chalk.blue("Preparing ERC-20 listing..."));
@@ -151,7 +139,7 @@ async function executeKeylessMode(options: CreateErc20ListingOptions): Promise<v
     rpcUrl: readOnlyOptions.rpcUrl,
   });
 
-  const priceWei = parseErc20PriceWei(readOnlyOptions.chainId, options.price);
+  const { priceWei } = parseErc20Price(readOnlyOptions.chainId, options.price);
   const tokenAmount = BigInt(options.tokenAmount);
 
   try {

--- a/packages/net-cli/src/commands/bazaar/create-erc20-listing.ts
+++ b/packages/net-cli/src/commands/bazaar/create-erc20-listing.ts
@@ -2,15 +2,28 @@ import chalk from "chalk";
 import {
   createWalletClient,
   http,
-  parseEther,
+  parseUnits,
   encodeFunctionData,
 } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
-import { BazaarClient } from "@net-protocol/bazaar";
+import { BazaarClient, getErc20PaymentToken } from "@net-protocol/bazaar";
 import { getChainRpcUrls, getBaseDataSuffix } from "@net-protocol/core";
 import { parseCommonOptions, parseReadOnlyOptions } from "../../cli/shared";
 import { exitWithError } from "../../shared/output";
 import type { CreateErc20ListingOptions } from "./types";
+
+/**
+ * Parse `--price` into base units using the chain's ERC20 payment token
+ * decimals (USDC=6 on Base, WETH=18 elsewhere). Using `parseEther` here
+ * would silently inflate USDC prices by 10^12.
+ */
+function parseErc20PriceWei(chainId: number, price: string): bigint {
+  const paymentToken = getErc20PaymentToken(chainId);
+  if (!paymentToken) {
+    exitWithError(`Chain ${chainId} has no ERC20 payment token configured`);
+  }
+  return parseUnits(price, paymentToken.decimals);
+}
 
 export async function executeCreateErc20Listing(options: CreateErc20ListingOptions): Promise<void> {
   const hasPrivateKey = !!(
@@ -37,8 +50,10 @@ export async function executeCreateErc20Listing(options: CreateErc20ListingOptio
     rpcUrl: commonOptions.rpcUrl,
   });
 
-  const priceWei = parseEther(options.price);
+  const priceWei = parseErc20PriceWei(commonOptions.chainId, options.price);
   const tokenAmount = BigInt(options.tokenAmount);
+  const paymentSymbol =
+    getErc20PaymentToken(commonOptions.chainId)?.symbol ?? "";
 
   try {
     console.log(chalk.blue("Preparing ERC-20 listing..."));
@@ -111,7 +126,7 @@ export async function executeCreateErc20Listing(options: CreateErc20ListingOptio
 
     console.log(
       chalk.green(
-        `ERC-20 listing created successfully!\n  Transaction: ${hash}\n  Token: ${options.tokenAddress}\n  Amount: ${options.tokenAmount}\n  Price: ${options.price} ETH`
+        `ERC-20 listing created successfully!\n  Transaction: ${hash}\n  Token: ${options.tokenAddress}\n  Amount: ${options.tokenAmount}\n  Price: ${options.price} ${paymentSymbol}`
       )
     );
   } catch (error) {
@@ -136,7 +151,7 @@ async function executeKeylessMode(options: CreateErc20ListingOptions): Promise<v
     rpcUrl: readOnlyOptions.rpcUrl,
   });
 
-  const priceWei = parseEther(options.price);
+  const priceWei = parseErc20PriceWei(readOnlyOptions.chainId, options.price);
   const tokenAmount = BigInt(options.tokenAmount);
 
   try {

--- a/packages/net-cli/src/commands/bazaar/create-erc20-offer.ts
+++ b/packages/net-cli/src/commands/bazaar/create-erc20-offer.ts
@@ -2,15 +2,28 @@ import chalk from "chalk";
 import {
   createWalletClient,
   http,
-  parseEther,
+  parseUnits,
   encodeFunctionData,
 } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
-import { BazaarClient } from "@net-protocol/bazaar";
+import { BazaarClient, getErc20PaymentToken } from "@net-protocol/bazaar";
 import { getChainRpcUrls, getBaseDataSuffix } from "@net-protocol/core";
 import { parseCommonOptions, parseReadOnlyOptions } from "../../cli/shared";
 import { exitWithError } from "../../shared/output";
 import type { CreateErc20OfferOptions } from "./types";
+
+/**
+ * Parse `--price` into base units using the chain's ERC20 payment token
+ * decimals (USDC=6 on Base, WETH=18 elsewhere). Using `parseEther` here
+ * would silently inflate USDC prices by 10^12.
+ */
+function parseErc20PriceWei(chainId: number, price: string): bigint {
+  const paymentToken = getErc20PaymentToken(chainId);
+  if (!paymentToken) {
+    exitWithError(`Chain ${chainId} has no ERC20 payment token configured`);
+  }
+  return parseUnits(price, paymentToken.decimals);
+}
 
 export async function executeCreateErc20Offer(options: CreateErc20OfferOptions): Promise<void> {
   const hasPrivateKey = !!(
@@ -37,8 +50,10 @@ export async function executeCreateErc20Offer(options: CreateErc20OfferOptions):
     rpcUrl: commonOptions.rpcUrl,
   });
 
-  const priceWei = parseEther(options.price);
+  const priceWei = parseErc20PriceWei(commonOptions.chainId, options.price);
   const tokenAmount = BigInt(options.tokenAmount);
+  const paymentSymbol =
+    getErc20PaymentToken(commonOptions.chainId)?.symbol ?? "";
 
   try {
     console.log(chalk.blue("Preparing ERC-20 offer..."));
@@ -61,7 +76,8 @@ export async function executeCreateErc20Offer(options: CreateErc20OfferOptions):
       dataSuffix: getBaseDataSuffix(commonOptions.chainId),
     });
 
-    // Send approval txs if needed (WETH approval)
+    // Send approval txs if needed (payment-token approval — USDC on Base,
+    // WETH elsewhere; the SDK emits the right token for the chain).
     for (const approval of prepared.approvals) {
       console.log(chalk.blue("Sending approval transaction..."));
       const calldata = encodeFunctionData({
@@ -110,7 +126,7 @@ export async function executeCreateErc20Offer(options: CreateErc20OfferOptions):
 
     console.log(
       chalk.green(
-        `ERC-20 offer created successfully!\n  Transaction: ${hash}\n  Token: ${options.tokenAddress}\n  Amount: ${options.tokenAmount}\n  Price: ${options.price} ETH`
+        `ERC-20 offer created successfully!\n  Transaction: ${hash}\n  Token: ${options.tokenAddress}\n  Amount: ${options.tokenAmount}\n  Price: ${options.price} ${paymentSymbol}`
       )
     );
   } catch (error) {
@@ -135,7 +151,7 @@ async function executeKeylessMode(options: CreateErc20OfferOptions): Promise<voi
     rpcUrl: readOnlyOptions.rpcUrl,
   });
 
-  const priceWei = parseEther(options.price);
+  const priceWei = parseErc20PriceWei(readOnlyOptions.chainId, options.price);
   const tokenAmount = BigInt(options.tokenAmount);
 
   try {

--- a/packages/net-cli/src/commands/bazaar/create-erc20-offer.ts
+++ b/packages/net-cli/src/commands/bazaar/create-erc20-offer.ts
@@ -2,28 +2,15 @@ import chalk from "chalk";
 import {
   createWalletClient,
   http,
-  parseUnits,
   encodeFunctionData,
 } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
-import { BazaarClient, getErc20PaymentToken } from "@net-protocol/bazaar";
+import { BazaarClient } from "@net-protocol/bazaar";
 import { getChainRpcUrls, getBaseDataSuffix } from "@net-protocol/core";
 import { parseCommonOptions, parseReadOnlyOptions } from "../../cli/shared";
 import { exitWithError } from "../../shared/output";
+import { parseErc20Price } from "./format";
 import type { CreateErc20OfferOptions } from "./types";
-
-/**
- * Parse `--price` into base units using the chain's ERC20 payment token
- * decimals (USDC=6 on Base, WETH=18 elsewhere). Using `parseEther` here
- * would silently inflate USDC prices by 10^12.
- */
-function parseErc20PriceWei(chainId: number, price: string): bigint {
-  const paymentToken = getErc20PaymentToken(chainId);
-  if (!paymentToken) {
-    exitWithError(`Chain ${chainId} has no ERC20 payment token configured`);
-  }
-  return parseUnits(price, paymentToken.decimals);
-}
 
 export async function executeCreateErc20Offer(options: CreateErc20OfferOptions): Promise<void> {
   const hasPrivateKey = !!(
@@ -50,10 +37,11 @@ export async function executeCreateErc20Offer(options: CreateErc20OfferOptions):
     rpcUrl: commonOptions.rpcUrl,
   });
 
-  const priceWei = parseErc20PriceWei(commonOptions.chainId, options.price);
+  const { priceWei, symbol: paymentSymbol } = parseErc20Price(
+    commonOptions.chainId,
+    options.price
+  );
   const tokenAmount = BigInt(options.tokenAmount);
-  const paymentSymbol =
-    getErc20PaymentToken(commonOptions.chainId)?.symbol ?? "";
 
   try {
     console.log(chalk.blue("Preparing ERC-20 offer..."));
@@ -151,7 +139,7 @@ async function executeKeylessMode(options: CreateErc20OfferOptions): Promise<voi
     rpcUrl: readOnlyOptions.rpcUrl,
   });
 
-  const priceWei = parseErc20PriceWei(readOnlyOptions.chainId, options.price);
+  const { priceWei } = parseErc20Price(readOnlyOptions.chainId, options.price);
   const tokenAmount = BigInt(options.tokenAmount);
 
   try {

--- a/packages/net-cli/src/commands/bazaar/format.ts
+++ b/packages/net-cli/src/commands/bazaar/format.ts
@@ -1,6 +1,36 @@
+import { parseUnits } from "viem";
+import { getErc20PaymentToken } from "@net-protocol/bazaar";
+import { exitWithError } from "../../shared/output";
+
 /**
  * Format a price number for display (removes trailing zeros)
  */
 export function formatEthPrice(price: number): string {
   return price.toFixed(6).replace(/\.?0+$/, "");
+}
+
+/**
+ * Parse `--price` for an ERC-20 bazaar command into payment-token base units,
+ * and return the payment token's display symbol alongside it.
+ *
+ * The chain's ERC-20 payment token comes from
+ * `getErc20PaymentToken(chainId)` — USDC (6 decimals) on Base, wrapped
+ * native (18 decimals) elsewhere. Using a hardcoded scale (e.g.
+ * `parseEther`) would silently 10^12-inflate USDC prices on Base.
+ *
+ * The combined return shape avoids the two-lookup-per-command pattern
+ * (one for decimals, one for the success-message symbol).
+ */
+export function parseErc20Price(
+  chainId: number,
+  price: string
+): { priceWei: bigint; symbol: string } {
+  const paymentToken = getErc20PaymentToken(chainId);
+  if (!paymentToken) {
+    exitWithError(`Chain ${chainId} has no ERC20 payment token configured`);
+  }
+  return {
+    priceWei: parseUnits(price, paymentToken.decimals),
+    symbol: paymentToken.symbol,
+  };
 }

--- a/skill-references/bazaar.md
+++ b/skill-references/bazaar.md
@@ -10,7 +10,14 @@ Net Bazaar is built on Seaport (v1.6). It supports:
 - Private listings (targeted to a specific buyer)
 - EIP-712 signed orders (gasless order creation)
 
-NFT listings and ERC-20 listings are paid in the chain's native currency (ETH on Base/Ethereum, HYPE on HyperEVM). NFT collection offers and ERC-20 offers are paid in the wrapped native currency (WETH or wrapped HYPE) — the offerer pre-approves it so the fulfiller can pull it on acceptance.
+NFT listings and NFT collection offers are paid in the chain's native currency / its wrapped form (ETH/WETH on Base/Ethereum, HYPE/wrapped HYPE on HyperEVM).
+
+ERC-20 listings and ERC-20 offers are paid in the chain's **configured ERC-20 payment token**, which varies by chain:
+
+- **Base (8453)**: USDC (`0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`, 6 decimals) — both offers and listings settle in USDC
+- **HyperEVM (999)** and other ERC-20-supporting chains without a configured quote token: wrapped native currency (e.g. WHYPE, 18 decimals)
+
+The SDK exposes the per-chain mapping via `getErc20PaymentToken(chainId)` from `@net-protocol/bazaar`, which returns `{ address, symbol, decimals }`. The CLI uses this to scale `--price` correctly, so a `--price 5 --chain-id 8453` means **5 USDC** (parsed as `5_000_000` base units), not 5e18 of anything. When passing through the keyless flow to an external signer, the emitted `approvals` array contains an approve to **Seaport directly** for the right payment token (USDC on Base, wrapped native elsewhere).
 
 All commands support two modes:
 1. **With `--private-key`**: Full flow (approve, sign, submit) executed directly
@@ -336,7 +343,7 @@ netp bazaar accept-offer \
 
 # ERC-20 Commands
 
-ERC-20 bazaar lets you list a specific quantity of an ERC-20 token for the chain's native currency, or offer wrapped native currency for a specific quantity of an ERC-20 token. Supported on **Base (8453)** and **HyperEVM (999)** only. The command shape mirrors the NFT commands, with `--token-address` in place of `--nft-address` and an explicit `--token-amount` (raw units, bigint string).
+ERC-20 bazaar lets you list a specific quantity of an ERC-20 token, or offer to buy a specific quantity, with payment in the chain's configured ERC-20 payment token — **USDC on Base (8453)**, wrapped native currency (e.g. WHYPE) on **HyperEVM (999)**. The command shape mirrors the NFT commands, with `--token-address` in place of `--nft-address` and an explicit `--token-amount` (raw units, bigint string). The CLI reads the chain's payment token via `getErc20PaymentToken(chainId)` and scales `--price` by that token's decimals automatically.
 
 ## List ERC-20 Listings
 
@@ -379,11 +386,11 @@ netp bazaar list-erc20-listings \
 Field semantics (from `packages/net-bazaar/src/types.ts`):
 
 - `tokenAmount`: raw token units as a bigint string (no decimal scaling applied).
-- `price`: total price as a JS number (the chain's native currency — ETH on Base, HYPE on HyperEVM).
-- `priceWei`: total price in wei as a bigint string.
-- `pricePerTokenWei`: **bigint string**, computed as `priceWei / tokenAmount` (integer division — frequently rounds to `"0"` for 18-decimal tokens with sub-ETH-per-token prices).
-- `pricePerToken`: **string** (not a number), full-decimal-precision native currency per single raw token unit. Use this field, not `pricePerTokenWei`, when you need an accurate per-unit price.
-- `currency`: native-chain currency symbol (`"eth"`, `"hype"`, etc.) — not the wrapped-token name.
+- `price`: total price as a JS number, expressed in the chain's ERC-20 payment token (USDC on Base, native/wrapped-native elsewhere). Already formatted using the payment token's decimals.
+- `priceWei`: total price in payment-token base units as a bigint string. For USDC on Base this is base units of USDC (6 decimals); on a chain without a configured quote token it's native wei (18 decimals).
+- `pricePerTokenWei`: **bigint string**, computed as `priceWei / tokenAmount` (integer division — frequently rounds to `"0"` for 18-decimal traded tokens with sub-unit-per-token prices).
+- `pricePerToken`: **string** (not a number), full-decimal-precision payment-token amount per single raw token unit. Use this, not `pricePerTokenWei`, when you need an accurate per-unit price.
+- `currency`: payment-token symbol, lowercased. `"usdc"` on Base, native chain symbol (`"eth"`, `"hype"`, etc.) on chains without a configured quote token.
 - `expirationDate`: Unix seconds.
 
 Listings are sorted by price per token ascending.
@@ -400,7 +407,7 @@ netp bazaar list-erc20-offers \
   [--json]
 ```
 
-JSON output has the same field shapes and types as `list-erc20-listings` (`pricePerToken` is a string, `currency` is the native symbol such as `"eth"` / `"hype"`). Offer **payment is in the wrapped native currency** — WETH on Base, wrapped HYPE on HyperEVM — and the offerer pre-approves it so the seller can pull it on acceptance. Offers are sorted by price per token descending and filtered to those where the maker still has enough wrapped-currency balance.
+JSON output has the same field shapes and types as `list-erc20-listings` (`pricePerToken` is a string, `currency` is the payment-token symbol such as `"usdc"` / `"hype"`). Offer **payment is in the chain's configured ERC-20 payment token** — USDC on Base, wrapped HYPE on HyperEVM — and the offerer pre-approves it so the seller can pull it on acceptance. Offers are sorted by price per token descending and filtered to those where the maker still has enough payment-token balance.
 
 ## Create ERC-20 Listing
 
@@ -434,7 +441,7 @@ netp bazaar create-erc20-listing \
 |-----------|----------|-------------|
 | `--token-address` | Yes | ERC-20 token contract address |
 | `--token-amount` | Yes | Amount to sell in **raw units** (bigint string, e.g. `1000000000000000000` for 1.0 of an 18-decimal token) |
-| `--price` | Yes | **Total** price in the chain's native currency (ETH on Base, HYPE on HyperEVM) for the whole `token-amount`, expressed as a decimal (e.g. `0.05`) |
+| `--price` | Yes | **Total** price in the chain's ERC-20 payment token (USDC on Base, native/wrapped-native on chains without a configured quote token), expressed as a decimal (e.g. `5` = 5 USDC on Base). The CLI scales by the payment token's decimals — `5` → `5_000_000` base units on Base USDC, `5` → `5e18` base units on a WETH chain. Do not pre-scale. |
 | `--target-fulfiller` | No | Make a private listing for this address |
 | `--offerer` | No | Required without `--private-key` |
 
@@ -442,14 +449,14 @@ Output format is the same as `create-listing` (EIP-712 data + approvals). Use `s
 
 ## Create ERC-20 Offer
 
-Create an ERC-20 offer (bid wrapped native currency for `tokenAmount` of a token). Same dual mode:
+Create an ERC-20 offer (bid the chain's ERC-20 payment token for `tokenAmount` of a token). Same dual mode:
 
 **With private key:**
 ```bash
 netp bazaar create-erc20-offer \
   --token-address <address> \
   --token-amount <raw-units> \
-  --price <wrapped-native-amount> \
+  --price <payment-token-amount> \
   --chain-id 8453 \
   --private-key 0x...
 ```
@@ -459,7 +466,7 @@ netp bazaar create-erc20-offer \
 netp bazaar create-erc20-offer \
   --token-address <address> \
   --token-amount <raw-units> \
-  --price <wrapped-native-amount> \
+  --price <payment-token-amount> \
   --offerer <address> \
   --chain-id 8453
 ```
@@ -469,10 +476,10 @@ netp bazaar create-erc20-offer \
 |-----------|----------|-------------|
 | `--token-address` | Yes | ERC-20 token contract address (the token being bid on). |
 | `--token-amount` | Yes | Amount to buy in **raw units** (bigint string, e.g. `1000000000000000000` for 1.0 of an 18-decimal token). |
-| `--price` | Yes | **Total** amount of the wrapped native currency (WETH on Base, wrapped HYPE on HyperEVM) bid for the whole `token-amount`, expressed as a decimal (e.g. `0.05`). |
+| `--price` | Yes | **Total** amount of the chain's ERC-20 payment token bid for the whole `token-amount`, expressed as a decimal. On Base that's USDC (`--price 5` = 5 USDC = 5_000_000 base units); on chains without a configured quote token it's the wrapped native currency. The CLI scales by the payment token's decimals automatically. |
 | `--offerer` | No | Required without `--private-key`. |
 
-The approval emitted in `approvals` (keyless mode) is a wrapped-native `approve` to **Seaport directly** (not a conduit — see "Approval Spender" above). Use `submit-erc20-offer` for the follow-up.
+The approval emitted in `approvals` (keyless mode) is a payment-token `approve` to **Seaport directly** (not a conduit — see "Approval Spender" above). On Base that's a USDC approve; on a wrapped-native chain it's a WETH/wrapped-native approve. Use `submit-erc20-offer` for the follow-up.
 
 ## Submit ERC-20 Listing
 
@@ -504,7 +511,10 @@ netp bazaar submit-erc20-offer \
 
 ## Buy ERC-20 Listing
 
-Buy an ERC-20 listing by order hash (pays in the chain's native currency):
+Buy an ERC-20 listing by order hash. Payment shape depends on the chain's ERC-20 bazaar configuration:
+
+- **Chains with a configured ERC-20 payment token (Base USDC):** payment is ERC-20. The encode-only `approvals` array will include a USDC `approve` to Seaport if the buyer's allowance is insufficient; `fulfillment.value` is **`"0"`**.
+- **Chains without a configured quote token:** payment is native currency. `approvals` is empty and `fulfillment.value` is the listing's total price in native wei.
 
 **With private key:**
 ```bash
@@ -525,24 +535,31 @@ netp bazaar buy-erc20-listing \
   --encode-only
 ```
 
-**Encode-only output:**
+**Encode-only output (Base, USDC-paying):**
 ```json
 {
-  "approvals": [],
+  "approvals": [
+    {
+      "to": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+      "data": "0x095ea7b3...",
+      "chainId": 8453,
+      "value": "0"
+    }
+  ],
   "fulfillment": {
     "to": "0x...",
     "data": "0x...",
     "chainId": 8453,
-    "value": "50000000000000000"
+    "value": "0"
   }
 }
 ```
 
-The `value` field is the listing's total price in wei of the chain's native currency (ETH on Base, HYPE on HyperEVM). The agent must include this value when submitting the fulfillment transaction.
+The agent must submit each entry in `approvals` (in order, if any) and then the `fulfillment` transaction. On a chain without a configured quote token, `fulfillment.value` carries the native payment and must be sent with the tx.
 
 ## Accept ERC-20 Offer
 
-Accept an ERC-20 offer by selling your tokens (receive wrapped native currency — WETH on Base, wrapped HYPE on HyperEVM). The fulfillment transaction's `value` is **zero** — the buyer's wrapped currency was pre-approved and is pulled by Seaport on acceptance.
+Accept an ERC-20 offer by selling your tokens (receive the chain's ERC-20 payment token — USDC on Base, wrapped native elsewhere). The fulfillment transaction's `value` is **zero** — the buyer's payment token was pre-approved and is pulled by Seaport on acceptance.
 
 **With private key:**
 ```bash
@@ -711,7 +728,7 @@ netp bazaar list-erc20-listings --token-address 0x... --chain-id 8453 --json | j
 | "Listing not found" | Order hash doesn't match any active listing | Listing may have been fulfilled or cancelled |
 | "ERC-20 listing with order hash ... not found or no longer active" | Same, for ERC-20 listings | Re-query `list-erc20-listings` |
 | "ERC-20 offer with order hash ... not found or no longer active" | Same, for ERC-20 offers | Re-query `list-erc20-offers` |
-| "Insufficient funds" | Not enough native currency (NFT/ERC-20 listing buy) or wrapped native currency (ERC-20 offer accept) | Fund wallet with price + gas |
+| "Insufficient funds" | Not enough native currency for an NFT listing buy or for the gas component of any tx; not enough payment-token (USDC on Base, wrapped native elsewhere) for an ERC-20 listing buy or to honor a previously-made ERC-20 offer | Fund wallet with price + gas |
 | "--offerer is required" | Keyless mode needs offerer address | Add `--offerer 0x...` flag |
 | "--buyer is required" | Encode-only buy needs buyer address | Add `--buyer 0x...` flag |
 | "--seller is required" | Encode-only accept needs seller address | Add `--seller 0x...` flag |
@@ -722,7 +739,8 @@ netp bazaar list-erc20-listings --token-address 0x... --chain-id 8453 --json | j
 Gas estimates below are for Base; HyperEVM and Ethereum will differ.
 
 - **Creating listings/offers (NFT or ERC-20)**: Gas for approval tx + submit tx (~0.001-0.003 ETH on Base)
-- **Buying NFT listings / ERC-20 listings**: Listing price (in the chain's native currency) + gas (~0.0005-0.002 ETH on Base)
+- **Buying NFT listings**: Listing price (in the chain's native currency) + gas (~0.0005-0.002 ETH on Base)
+- **Buying ERC-20 listings**: Listing price in the chain's ERC-20 payment token (USDC on Base, native elsewhere) + gas. On Base, a USDC approve tx may also be needed (~0.0005-0.002 ETH gas)
 - **Accepting NFT offers**: Gas for NFT approval + fulfillment (~0.001-0.003 ETH on Base); payment received in WETH (no ETH transfer in the fulfillment tx)
-- **Accepting ERC-20 offers**: Gas for ERC-20 approval (if needed) + fulfillment; payment received in the wrapped native currency (WETH on Base, wrapped HYPE on HyperEVM); fulfillment tx `value` is zero
+- **Accepting ERC-20 offers**: Gas for ERC-20 approval (if needed) + fulfillment; payment received in the chain's ERC-20 payment token (USDC on Base, wrapped HYPE on HyperEVM); fulfillment tx `value` is zero
 - **Reading data**: Free (view calls)


### PR DESCRIPTION
## Why

The CLI's `create-erc20-offer` and `create-erc20-listing` parsed `--price` via `parseEther` (18 decimals). Correct on chains where the ERC20 bazaar payment token is 18 decimals (WETH-paying chains like HyperEVM), but **catastrophically wrong on Base** where the payment token is USDC (6 decimals):

```
netp bazaar create-erc20-offer --price 5 --chain-id 8453 ...
```

User intent: bid 5 USDC. What actually happened:

```
priceWei = parseEther("5") = 5e18
→ an offer for 5e18 USDC base units = $5,000,000,000,000
```

Either fails on insufficient balance or — if a user has the funds — burns them at catastrophic scale. The success message also hardcoded `"ETH"` and the inline comment said `"WETH approval"`, both misleading on Base.

## Fix

Resolve the chain's ERC20 payment token via `getErc20PaymentToken(chainId)` (from `@net-protocol/bazaar`), then `parseUnits(options.price, paymentToken.decimals)`:

```ts
function parseErc20PriceWei(chainId: number, price: string): bigint {
  const paymentToken = getErc20PaymentToken(chainId);
  if (!paymentToken) {
    exitWithError(`Chain ${chainId} has no ERC20 payment token configured`);
  }
  return parseUnits(price, paymentToken.decimals);
}
```

Applied to both keyless and direct-execution paths in both `create-erc20-offer.ts` and `create-erc20-listing.ts`. Success message now shows the actual payment symbol (`USDC` on Base, `WETH` elsewhere).

## What was NOT changed

- `buy-erc20-listing` and `accept-erc20-offer` — these consume `prepared.fulfillment.value` and the approvals array from the SDK and pass them through. The SDK at 0.2.3 already emits the right values (`value: 0` + USDC approve in the approvals list) for ERC20-paying orders, so these work via passthrough.
- `list-erc20-listings`, `list-erc20-offers`, `cancel-erc20-*`, `format.ts` — token-agnostic or read `listing.currency` / `sale.currency` from the SDK (now correctly `"usdc"` on Base post-#130).

## Test fixture

`erc20-bankr.test.ts` mocked `@net-protocol/bazaar` without `getErc20PaymentToken`. Added it to the mock with Base's USDC config (6 decimals) so the USDC-scaled `priceWei` is what gets passed to the `prepareCreateErc20{Offer,Listing}` mocks.

## Verification

- `yarn test`: **304/311 pass**. Same single pre-existing flake (`erc20-bankr-integration.test.ts`'s `beforeAll({skip})` API quirk) as on main; the 7 previously-failing tests in `erc20-bankr.test.ts` (caused by the mock missing `getErc20PaymentToken`) now pass.
- Typecheck clean on touched files. Unrelated pre-existing typecheck errors in `@net-protocol/storage` (FileReader DOM type) remain.

## Versions

- `@net-protocol/cli`: 0.2.4 → **0.2.5** (USDC behavior fix on Base for the two create-* commands)
- `@net-protocol/bazaar` dep range: `^0.2.1` → **`^0.2.3`** (need `getErc20PaymentToken` — though `^0.2.1` would satisfy it — and benefits from the parseSale fix in 0.2.3 for any sale data the CLI surfaces)

## Doc follow-up

`SKILL.md` and `skill-references/bazaar.md` still describe the ERC20 bazaar as wrapped-native-only and don't mention USDC on Base. Worth a separate doc PR — flagged but not in scope here.

---
_Generated by [Claude Code](https://claude.ai/code/session_014TDGDzgsVwaoeyYCXznRzF)_