### PR TITLE
feat(cli): accept --encode-only on create-erc20-{offer,listing}, fix --price help text

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -501,7 +501,7 @@ netp storage upload --file ./data.json --key "my-key" --text "desc" --chain-id 8
 # Returns: {"storageKey": "my-key", "transactions": [{"to": "0x...", "data": "0x...", ...}]}
 ```
 
-`--encode-only` works with all netp write commands: `storage upload`, `token deploy`, `upvote token`, `upvote user`, `bazaar buy-listing`, `bazaar submit-listing`, `bazaar submit-offer`, `bazaar accept-offer`, `bazaar cancel-listing`, `bazaar cancel-offer`, `bazaar create-erc20-listing`, `bazaar create-erc20-offer`, `bazaar buy-erc20-listing`, `bazaar submit-erc20-listing`, `bazaar submit-erc20-offer`, `bazaar accept-erc20-offer`, `bazaar cancel-erc20-listing`, `bazaar cancel-erc20-offer`. (NFT `create-listing` / `create-offer` use the implicit "omit `--private-key` + pass `--offerer`" form instead — see [bazaar.md § Command Modes & Address Flags](https://raw.githubusercontent.com/stuckinaboot/net-public/main/skill-references/bazaar.md).)
+`--encode-only` works with `storage upload`, `token deploy`, `upvote token`, `upvote user`, and every `netp bazaar` write command. For the bazaar specifically, see [bazaar.md § Command Modes & Address Flags](https://raw.githubusercontent.com/stuckinaboot/net-public/main/skill-references/bazaar.md) — it lists each subcommand alongside the role-named address flag (`--offerer` / `--buyer` / `--seller` / `--maker`) you must pair with `--encode-only` when no `--private-key` is present.
 
 For feeds, messaging, and profiles, use `botchan --encode-only` instead (see Botchan section above).
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -501,7 +501,7 @@ netp storage upload --file ./data.json --key "my-key" --text "desc" --chain-id 8
 # Returns: {"storageKey": "my-key", "transactions": [{"to": "0x...", "data": "0x...", ...}]}
 ```
 
-`--encode-only` works with all netp write commands: `storage upload`, `token deploy`, `upvote token`, `upvote user`, `bazaar buy-listing`, `bazaar submit-listing`, `bazaar submit-offer`, `bazaar accept-offer`, `bazaar cancel-listing`, `bazaar cancel-offer`, `bazaar buy-erc20-listing`, `bazaar submit-erc20-listing`, `bazaar submit-erc20-offer`, `bazaar accept-erc20-offer`, `bazaar cancel-erc20-listing`, `bazaar cancel-erc20-offer`.
+`--encode-only` works with all netp write commands: `storage upload`, `token deploy`, `upvote token`, `upvote user`, `bazaar buy-listing`, `bazaar submit-listing`, `bazaar submit-offer`, `bazaar accept-offer`, `bazaar cancel-listing`, `bazaar cancel-offer`, `bazaar create-erc20-listing`, `bazaar create-erc20-offer`, `bazaar buy-erc20-listing`, `bazaar submit-erc20-listing`, `bazaar submit-erc20-offer`, `bazaar accept-erc20-offer`, `bazaar cancel-erc20-listing`, `bazaar cancel-erc20-offer`. (NFT `create-listing` / `create-offer` use the implicit "omit `--private-key` + pass `--offerer`" form instead — see [bazaar.md § Command Modes & Address Flags](https://raw.githubusercontent.com/stuckinaboot/net-public/main/skill-references/bazaar.md).)
 
 For feeds, messaging, and profiles, use `botchan --encode-only` instead (see Botchan section above).
 

--- a/packages/net-cli/package.json
+++ b/packages/net-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@net-protocol/cli",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "CLI tool for Net Protocol",
   "type": "module",
   "bin": {

--- a/packages/net-cli/src/commands/bazaar/create-erc20-listing.ts
+++ b/packages/net-cli/src/commands/bazaar/create-erc20-listing.ts
@@ -20,7 +20,7 @@ export async function executeCreateErc20Listing(options: CreateErc20ListingOptio
   );
 
   if (!hasPrivateKey || options.encodeOnly) {
-    await executeKeylessMode(options);
+    await executeEncodeOnly(options);
     return;
   }
 
@@ -124,9 +124,9 @@ export async function executeCreateErc20Listing(options: CreateErc20ListingOptio
   }
 }
 
-async function executeKeylessMode(options: CreateErc20ListingOptions): Promise<void> {
+async function executeEncodeOnly(options: CreateErc20ListingOptions): Promise<void> {
   if (!options.offerer) {
-    exitWithError("--offerer is required when using --encode-only or not providing --private-key");
+    exitWithError("--offerer is required when using --encode-only without --private-key");
   }
 
   const readOnlyOptions = parseReadOnlyOptions({

--- a/packages/net-cli/src/commands/bazaar/create-erc20-listing.ts
+++ b/packages/net-cli/src/commands/bazaar/create-erc20-listing.ts
@@ -19,7 +19,7 @@ export async function executeCreateErc20Listing(options: CreateErc20ListingOptio
     process.env.PRIVATE_KEY
   );
 
-  if (!hasPrivateKey) {
+  if (!hasPrivateKey || options.encodeOnly) {
     await executeKeylessMode(options);
     return;
   }
@@ -126,7 +126,7 @@ export async function executeCreateErc20Listing(options: CreateErc20ListingOptio
 
 async function executeKeylessMode(options: CreateErc20ListingOptions): Promise<void> {
   if (!options.offerer) {
-    exitWithError("--offerer is required when not providing --private-key");
+    exitWithError("--offerer is required when using --encode-only or not providing --private-key");
   }
 
   const readOnlyOptions = parseReadOnlyOptions({

--- a/packages/net-cli/src/commands/bazaar/create-erc20-offer.ts
+++ b/packages/net-cli/src/commands/bazaar/create-erc20-offer.ts
@@ -20,7 +20,7 @@ export async function executeCreateErc20Offer(options: CreateErc20OfferOptions):
   );
 
   if (!hasPrivateKey || options.encodeOnly) {
-    await executeKeylessMode(options);
+    await executeEncodeOnly(options);
     return;
   }
 
@@ -124,9 +124,9 @@ export async function executeCreateErc20Offer(options: CreateErc20OfferOptions):
   }
 }
 
-async function executeKeylessMode(options: CreateErc20OfferOptions): Promise<void> {
+async function executeEncodeOnly(options: CreateErc20OfferOptions): Promise<void> {
   if (!options.offerer) {
-    exitWithError("--offerer is required when using --encode-only or not providing --private-key");
+    exitWithError("--offerer is required when using --encode-only without --private-key");
   }
 
   const readOnlyOptions = parseReadOnlyOptions({

--- a/packages/net-cli/src/commands/bazaar/create-erc20-offer.ts
+++ b/packages/net-cli/src/commands/bazaar/create-erc20-offer.ts
@@ -19,7 +19,7 @@ export async function executeCreateErc20Offer(options: CreateErc20OfferOptions):
     process.env.PRIVATE_KEY
   );
 
-  if (!hasPrivateKey) {
+  if (!hasPrivateKey || options.encodeOnly) {
     await executeKeylessMode(options);
     return;
   }
@@ -126,7 +126,7 @@ export async function executeCreateErc20Offer(options: CreateErc20OfferOptions):
 
 async function executeKeylessMode(options: CreateErc20OfferOptions): Promise<void> {
   if (!options.offerer) {
-    exitWithError("--offerer is required when not providing --private-key");
+    exitWithError("--offerer is required when using --encode-only or not providing --private-key");
   }
 
   const readOnlyOptions = parseReadOnlyOptions({

--- a/packages/net-cli/src/commands/bazaar/create-listing.ts
+++ b/packages/net-cli/src/commands/bazaar/create-listing.ts
@@ -20,8 +20,8 @@ export async function executeCreateListing(options: CreateListingOptions): Promi
     process.env.PRIVATE_KEY
   );
 
-  if (!hasPrivateKey) {
-    await executeKeylessMode(options);
+  if (!hasPrivateKey || options.encodeOnly) {
+    await executeEncodeOnly(options);
     return;
   }
 
@@ -121,9 +121,9 @@ export async function executeCreateListing(options: CreateListingOptions): Promi
   }
 }
 
-async function executeKeylessMode(options: CreateListingOptions): Promise<void> {
+async function executeEncodeOnly(options: CreateListingOptions): Promise<void> {
   if (!options.offerer) {
-    exitWithError("--offerer is required when not providing --private-key");
+    exitWithError("--offerer is required when using --encode-only without --private-key");
   }
 
   const readOnlyOptions = parseReadOnlyOptions({

--- a/packages/net-cli/src/commands/bazaar/create-offer.ts
+++ b/packages/net-cli/src/commands/bazaar/create-offer.ts
@@ -19,8 +19,8 @@ export async function executeCreateOffer(options: CreateOfferOptions): Promise<v
     process.env.PRIVATE_KEY
   );
 
-  if (!hasPrivateKey) {
-    await executeKeylessMode(options);
+  if (!hasPrivateKey || options.encodeOnly) {
+    await executeEncodeOnly(options);
     return;
   }
 
@@ -118,9 +118,9 @@ export async function executeCreateOffer(options: CreateOfferOptions): Promise<v
   }
 }
 
-async function executeKeylessMode(options: CreateOfferOptions): Promise<void> {
+async function executeEncodeOnly(options: CreateOfferOptions): Promise<void> {
   if (!options.offerer) {
-    exitWithError("--offerer is required when not providing --private-key");
+    exitWithError("--offerer is required when using --encode-only without --private-key");
   }
 
   const readOnlyOptions = parseReadOnlyOptions({

--- a/packages/net-cli/src/commands/bazaar/index.ts
+++ b/packages/net-cli/src/commands/bazaar/index.ts
@@ -266,15 +266,16 @@ export function registerBazaarCommand(program: Command): void {
     });
 
   const createErc20ListingCommand = new Command("create-erc20-listing")
-    .description("Create an ERC-20 token listing (with --private-key: full flow; without: output EIP-712 data)")
+    .description("Create an ERC-20 token listing (with --private-key: full flow; without or with --encode-only: output EIP-712 data)")
     .requiredOption("--token-address <address>", "ERC-20 token contract address")
     .requiredOption("--token-amount <amount>", "Token amount in raw units (bigint string)")
-    .requiredOption("--price <eth>", "Total price in ETH for the token amount")
+    .requiredOption("--price <amount>", "Total price in payment-token units (USDC on Base, WETH elsewhere)")
     .option("--target-fulfiller <address>", "Make a private listing for this address")
-    .option("--offerer <address>", "Offerer address (required without --private-key)")
+    .option("--offerer <address>", "Offerer address (required without --private-key or with --encode-only)")
     .option(...privateKeyOption)
     .option(...chainIdOption)
     .option(...rpcUrlOption)
+    .option("--encode-only", "Output EIP-712 data and approval calldata as JSON instead of executing")
     .action(async (options) => {
       await executeCreateErc20Listing({
         tokenAddress: options.tokenAddress,
@@ -285,18 +286,20 @@ export function registerBazaarCommand(program: Command): void {
         privateKey: options.privateKey,
         chainId: options.chainId,
         rpcUrl: options.rpcUrl,
+        encodeOnly: options.encodeOnly,
       });
     });
 
   const createErc20OfferCommand = new Command("create-erc20-offer")
-    .description("Create an ERC-20 token offer (with --private-key: full flow; without: output EIP-712 data)")
+    .description("Create an ERC-20 token offer (with --private-key: full flow; without or with --encode-only: output EIP-712 data)")
     .requiredOption("--token-address <address>", "ERC-20 token contract address")
     .requiredOption("--token-amount <amount>", "Token amount in raw units (bigint string)")
-    .requiredOption("--price <eth>", "Total price in ETH for the token amount")
-    .option("--offerer <address>", "Offerer address (required without --private-key)")
+    .requiredOption("--price <amount>", "Total price in payment-token units (USDC on Base, WETH elsewhere)")
+    .option("--offerer <address>", "Offerer address (required without --private-key or with --encode-only)")
     .option(...privateKeyOption)
     .option(...chainIdOption)
     .option(...rpcUrlOption)
+    .option("--encode-only", "Output EIP-712 data and approval calldata as JSON instead of executing")
     .action(async (options) => {
       await executeCreateErc20Offer({
         tokenAddress: options.tokenAddress,
@@ -306,6 +309,7 @@ export function registerBazaarCommand(program: Command): void {
         privateKey: options.privateKey,
         chainId: options.chainId,
         rpcUrl: options.rpcUrl,
+        encodeOnly: options.encodeOnly,
       });
     });
 

--- a/packages/net-cli/src/commands/bazaar/index.ts
+++ b/packages/net-cli/src/commands/bazaar/index.ts
@@ -89,15 +89,16 @@ export function registerBazaarCommand(program: Command): void {
     });
 
   const createListingCommand = new Command("create-listing")
-    .description("Create an NFT listing (with --private-key: full flow; without: output EIP-712 data)")
+    .description("Create an NFT listing (with --private-key: full flow; without or with --encode-only: output EIP-712 data)")
     .requiredOption("--nft-address <address>", "NFT contract address")
     .requiredOption("--token-id <id>", "Token ID to list")
     .requiredOption("--price <eth>", "Price in ETH (e.g., 0.1)")
     .option("--target-fulfiller <address>", "Make a private listing for this address")
-    .option("--offerer <address>", "Offerer address (required without --private-key)")
+    .option("--offerer <address>", "Offerer address (required without --private-key or with --encode-only)")
     .option(...privateKeyOption)
     .option(...chainIdOption)
     .option(...rpcUrlOption)
+    .option("--encode-only", "Output EIP-712 data and approval calldata as JSON instead of executing")
     .action(async (options) => {
       await executeCreateListing({
         nftAddress: options.nftAddress,
@@ -108,17 +109,19 @@ export function registerBazaarCommand(program: Command): void {
         privateKey: options.privateKey,
         chainId: options.chainId,
         rpcUrl: options.rpcUrl,
+        encodeOnly: options.encodeOnly,
       });
     });
 
   const createOfferCommand = new Command("create-offer")
-    .description("Create a collection offer (with --private-key: full flow; without: output EIP-712 data)")
+    .description("Create a collection offer (with --private-key: full flow; without or with --encode-only: output EIP-712 data)")
     .requiredOption("--nft-address <address>", "NFT contract address")
     .requiredOption("--price <eth>", "Offer price in ETH (e.g., 0.1)")
-    .option("--offerer <address>", "Offerer address (required without --private-key)")
+    .option("--offerer <address>", "Offerer address (required without --private-key or with --encode-only)")
     .option(...privateKeyOption)
     .option(...chainIdOption)
     .option(...rpcUrlOption)
+    .option("--encode-only", "Output EIP-712 data and approval calldata as JSON instead of executing")
     .action(async (options) => {
       await executeCreateOffer({
         nftAddress: options.nftAddress,
@@ -127,6 +130,7 @@ export function registerBazaarCommand(program: Command): void {
         privateKey: options.privateKey,
         chainId: options.chainId,
         rpcUrl: options.rpcUrl,
+        encodeOnly: options.encodeOnly,
       });
     });
 

--- a/packages/net-cli/src/commands/bazaar/types.ts
+++ b/packages/net-cli/src/commands/bazaar/types.ts
@@ -111,6 +111,7 @@ export interface CreateErc20ListingOptions {
   privateKey?: string;
   chainId?: number;
   rpcUrl?: string;
+  encodeOnly?: boolean;
 }
 
 export interface CreateErc20OfferOptions {
@@ -121,6 +122,7 @@ export interface CreateErc20OfferOptions {
   privateKey?: string;
   chainId?: number;
   rpcUrl?: string;
+  encodeOnly?: boolean;
 }
 
 export interface SubmitErc20ListingOptions {

--- a/packages/net-cli/src/commands/bazaar/types.ts
+++ b/packages/net-cli/src/commands/bazaar/types.ts
@@ -28,6 +28,7 @@ export interface CreateListingOptions {
   privateKey?: string;
   chainId?: number;
   rpcUrl?: string;
+  encodeOnly?: boolean;
 }
 
 export interface CreateOfferOptions {
@@ -37,6 +38,7 @@ export interface CreateOfferOptions {
   privateKey?: string;
   chainId?: number;
   rpcUrl?: string;
+  encodeOnly?: boolean;
 }
 
 export interface SubmitListingOptions {

--- a/skill-references/bazaar.md
+++ b/skill-references/bazaar.md
@@ -20,8 +20,21 @@ ERC-20 listings and ERC-20 offers are paid in the chain's **configured ERC-20 pa
 The SDK exposes the per-chain mapping via `getErc20PaymentToken(chainId)` from `@net-protocol/bazaar`, which returns `{ address, symbol, decimals }`. The CLI uses this to scale `--price` correctly, so a `--price 5 --chain-id 8453` means **5 USDC** (parsed as `5_000_000` base units), not 5e18 of anything. When passing through the keyless flow to an external signer, the emitted `approvals` array contains an approve to **Seaport directly** for the right payment token (USDC on Base, wrapped native elsewhere).
 
 All commands support two modes:
-1. **With `--private-key`**: Full flow (approve, sign, submit) executed directly
-2. **Without `--private-key`**: Outputs transaction data / EIP-712 data for external signing (agents, hardware wallets)
+1. **With `--private-key`**: Full flow (approve, sign, submit) executed directly. The acting address is derived from the key.
+2. **Without `--private-key`** (or with `--encode-only`): Outputs transaction data / EIP-712 data for external signing (agents, hardware wallets). Because there's no key for the CLI to derive an address from, you must pass the acting address via a **role-named flag** specific to the command: `--offerer` when creating an order, `--buyer` / `--seller` when fulfilling one, `--maker` when cancelling. `submit-*` is the exception — the offerer is already inside the signed order data, so no address flag is needed.
+
+`--encode-only` is the explicit form for mode 2. Read-only commands (`list-*`, `owned-nfts`) don't sign anything and ignore both flags.
+
+### Command Flag Matrix
+
+| Action | Commands | Required address flag in mode 2 | `--encode-only` accepted |
+|---|---|---|---|
+| Read | `list-listings`, `list-offers`, `list-sales`, `list-erc20-listings`, `list-erc20-offers`, `owned-nfts` | — | — |
+| Create | `create-listing`, `create-offer`, `create-erc20-listing`, `create-erc20-offer` | `--offerer` | ERC-20 variants only (NFT `create-*` uses implicit "omit `--private-key`") |
+| Submit signed order | `submit-listing`, `submit-offer`, `submit-erc20-listing`, `submit-erc20-offer` | — (offerer is in the signed order) | yes |
+| Buy listing | `buy-listing`, `buy-erc20-listing` | `--buyer` | yes |
+| Accept offer | `accept-offer`, `accept-erc20-offer` | `--seller` | yes |
+| Cancel | `cancel-listing`, `cancel-offer`, `cancel-erc20-listing`, `cancel-erc20-offer` | `--maker` | yes |
 
 ## Approval Spender (Important)
 

--- a/skill-references/bazaar.md
+++ b/skill-references/bazaar.md
@@ -30,7 +30,7 @@ All commands support two modes:
 | Action | Commands | Required address flag in mode 2 | `--encode-only` accepted |
 |---|---|---|---|
 | Read | `list-listings`, `list-offers`, `list-sales`, `list-erc20-listings`, `list-erc20-offers`, `owned-nfts` | — | — |
-| Create | `create-listing`, `create-offer`, `create-erc20-listing`, `create-erc20-offer` | `--offerer` | ERC-20 variants only (NFT `create-*` uses implicit "omit `--private-key`") |
+| Create | `create-listing`, `create-offer`, `create-erc20-listing`, `create-erc20-offer` | `--offerer` | yes |
 | Submit signed order | `submit-listing`, `submit-offer`, `submit-erc20-listing`, `submit-erc20-offer` | — (offerer is in the signed order) | yes |
 | Buy listing | `buy-listing`, `buy-erc20-listing` | `--buyer` | yes |
 | Accept offer | `accept-offer`, `accept-erc20-offer` | `--seller` | yes |
@@ -241,7 +241,7 @@ netp bazaar create-offer \
 |-----------|----------|-------------|
 | `--nft-address` | Yes | NFT contract address. Offer applies to any token in this collection. |
 | `--price` | Yes | Bid amount in the chain's native currency unit (e.g. `0.1`). The actual currency moved on-chain is the **wrapped** native currency (WETH on Base/Ethereum) — the offerer pre-approves WETH to Seaport, and the fulfiller pulls it on accept. The offerer must hold enough WETH (or enough native currency for the CLI to wrap). |
-| `--offerer` | No | Required without `--private-key`. |
+| `--offerer` | No | Required without `--private-key` or with `--encode-only` (see Modes & Address Flags above). |
 
 `--price` is the **total** WETH the offerer is bidding, expressed as a decimal. The approval emitted in `approvals` (keyless mode) is a WETH `approve` to **Seaport directly** (not a conduit — see "Approval Spender" above).
 
@@ -456,7 +456,7 @@ netp bazaar create-erc20-listing \
 | `--token-amount` | Yes | Amount to sell in **raw units** (bigint string, e.g. `1000000000000000000` for 1.0 of an 18-decimal token) |
 | `--price` | Yes | **Total** price in the chain's ERC-20 payment token (USDC on Base, native/wrapped-native on chains without a configured quote token), expressed as a decimal (e.g. `5` = 5 USDC on Base). The CLI scales by the payment token's decimals — `5` → `5_000_000` base units on Base USDC, `5` → `5e18` base units on a WETH chain. Do not pre-scale. |
 | `--target-fulfiller` | No | Make a private listing for this address |
-| `--offerer` | No | Required without `--private-key` |
+| `--offerer` | No | Required without `--private-key` or with `--encode-only` (see Modes & Address Flags above). |
 
 Output format is the same as `create-listing` (EIP-712 data + approvals). Use `submit-erc20-listing` for the follow-up.
 
@@ -490,7 +490,7 @@ netp bazaar create-erc20-offer \
 | `--token-address` | Yes | ERC-20 token contract address (the token being bid on). |
 | `--token-amount` | Yes | Amount to buy in **raw units** (bigint string, e.g. `1000000000000000000` for 1.0 of an 18-decimal token). |
 | `--price` | Yes | **Total** amount of the chain's ERC-20 payment token bid for the whole `token-amount`, expressed as a decimal. On Base that's USDC (`--price 5` = 5 USDC = 5_000_000 base units); on chains without a configured quote token it's the wrapped native currency. The CLI scales by the payment token's decimals automatically. |
-| `--offerer` | No | Required without `--private-key`. |
+| `--offerer` | No | Required without `--private-key` or with `--encode-only` (see Modes & Address Flags above). |
 
 The approval emitted in `approvals` (keyless mode) is a payment-token `approve` to **Seaport directly** (not a conduit — see "Approval Spender" above). On Base that's a USDC approve; on a wrapped-native chain it's a WETH/wrapped-native approve. Use `submit-erc20-offer` for the follow-up.
 


### PR DESCRIPTION
## Why

Two LLM-unfriendly papercuts on the ERC-20 bazaar create commands that surfaced after the USDC migration:

**1. Misleading `--price` help text.** Both `create-erc20-offer` and `create-erc20-listing` still advertised:

```
--price <eth>    Total price in ETH for the token amount
```

Post-USDC migration, the price is denominated in the chain's payment token — USDC (6 decimals) on Base, WETH (18 decimals) elsewhere — not ETH. An LLM reading `--help` would correctly conclude "this takes an ETH-denominated number" and pass the wrong scale.

**2. `--encode-only` not accepted on create-*.** Every other bazaar action (`buy-listing`, `accept-offer`, `submit-*`, `cancel-*`) accepts `--encode-only` to emit JSON instead of broadcasting. The `create-erc20-*` commands didn't — they used a different "omit `--private-key` + pass `--offerer`" pattern. An agent that reached for `--encode-only` got an unknown-option error and tended to fall back to wrong guesses about what the command needed.

## Changes

- `--price <eth>` / "Total price in ETH for the token amount" → `--price <amount>` / "Total price in payment-token units (USDC on Base, WETH elsewhere)" on both `create-erc20-offer` and `create-erc20-listing`.
- Added `--encode-only` to both commands. When set, routes to the existing keyless path (still requires `--offerer` since the address is part of the EIP-712 message). Behavior is identical to the current keyless mode; this just gives it a recognized flag name that matches the rest of the CLI surface.
- Updated command `.description()` and the `--offerer` help string to mention `--encode-only` as a trigger.

## Verification

- `yarn test`: 307/311 pass (same 4 live-API integration skips as on main).
- `yarn build`: clean.
- Manual smoke: `netp bazaar create-erc20-offer --token-address ... --token-amount ... --price 1.50 --offerer ... --chain-id 8453 --encode-only` emits the expected EIP-712 typed-data JSON with `approvals` and `orderParameters`.
- `--help` output now reads:
  ```
  --price <amount>     Total price in payment-token units (USDC on Base, WETH elsewhere)
  --offerer <address>  Offerer address (required without --private-key or with --encode-only)
  --encode-only        Output EIP-712 data and approval calldata as JSON instead of executing
  ```

## Version

`@net-protocol/cli`: 0.2.5 → **0.2.6**

---
_Generated by [Claude Code](https://claude.ai/code/session_014TDGDzgsVwaoeyYCXznRzF)_