### PR TITLE
docs(bazaar): fix stale ERC-20 copy & deprecated Bankr endpoints

### DIFF
--- a/skill-references/bazaar.md
+++ b/skill-references/bazaar.md
@@ -208,8 +208,8 @@ netp bazaar create-listing \
 ```
 
 The agent should:
-1. Submit each approval transaction via `/agent/submit`
-2. Sign the `eip712` data via `/agent/sign` with `signatureType: "eth_signTypedData_v4"`
+1. Submit each approval transaction (e.g. via Bankr's `/wallet/submit`)
+2. Sign the `eip712` data (e.g. via Bankr's `/wallet/sign` with `signatureType: "eth_signTypedData_v4"`)
 3. Save the output to a file, then use `submit-listing` to build the final transaction
 
 ## Create Offer
@@ -389,7 +389,7 @@ netp bazaar list-erc20-listings \
     "priceWei": "1000000000000000000",
     "pricePerToken": "0.000000000000000001",
     "pricePerTokenWei": "1",
-    "currency": "eth",
+    "currency": "usdc",
     "expirationDate": 1770537792,
     "orderStatus": 2
   }
@@ -424,14 +424,14 @@ JSON output has the same field shapes and types as `list-erc20-listings` (`price
 
 ## Create ERC-20 Listing
 
-Create an ERC-20 listing (sell `tokenAmount` of a token for the chain's native currency). Dual mode:
+Create an ERC-20 listing (sell `tokenAmount` of a token for the chain's ERC-20 payment token — USDC on Base, wrapped native elsewhere). Dual mode:
 
 **With private key (full flow):**
 ```bash
 netp bazaar create-erc20-listing \
   --token-address <address> \
   --token-amount <raw-units> \
-  --price <native-amount> \
+  --price <payment-token-amount> \
   [--target-fulfiller <address>] \
   --chain-id 8453 \
   --private-key 0x...
@@ -444,7 +444,7 @@ Steps executed: approve Seaport (directly — no conduit) to spend the ERC-20 ->
 netp bazaar create-erc20-listing \
   --token-address <address> \
   --token-amount <raw-units> \
-  --price <native-amount> \
+  --price <payment-token-amount> \
   --offerer <address> \
   --chain-id 8453
 ```
@@ -637,7 +637,7 @@ netp bazaar buy-listing \
   --chain-id 8453 \
   --encode-only
 
-# 3. Submit via agent (e.g., Bankr /agent/submit)
+# 3. Submit via agent (e.g., Bankr /wallet/submit)
 # Include the fulfillment.value as the transaction value
 ```
 
@@ -702,7 +702,9 @@ netp bazaar buy-erc20-listing \
   --chain-id 8453 \
   --encode-only
 
-# 3. Submit via agent. Include fulfillment.value (total native-currency price in wei).
+# 3. Submit approvals[] in order (a USDC approve on Base), then the fulfillment tx.
+#    On Base, fulfillment.value is "0" — Seaport pulls USDC via the approve.
+#    On chains without a configured quote token, fulfillment.value carries the native price in wei.
 ```
 
 ## Accept an ERC-20 Offer (Encode-Only)


### PR DESCRIPTION
## Summary
- `create-erc20-listing`: lead sentence and `--price` placeholder said "native currency" — wrong for Base, where ERC-20 listings settle in USDC. Now matches `create-erc20-offer` wording ("chain's ERC-20 payment token — USDC on Base, wrapped native elsewhere") and `--price <payment-token-amount>`.
- `Buy an ERC-20 Listing` workflow step 3 said to include `fulfillment.value` as a "native-currency price in wei" — contradicted the body of the section. Now correctly notes that on Base `fulfillment.value` is `"0"` (Seaport pulls USDC via the included approve), and native value only applies on chains without a configured quote token.
- `list-erc20-listings` example output: `"currency": "eth"` → `"usdc"` to match the `--chain-id 8453` example (ERC-20 bazaar only runs on Base / HyperEVM, so `"eth"` matched neither).
- Replaced three references to the deprecated Bankr `/agent/sign` and `/agent/submit` endpoints with the current `/wallet/sign` / `/wallet/submit` Wallet API.

## Test plan
- [ ] Skim rendered `skill-references/bazaar.md` to confirm wording reads cleanly
- [ ] `grep -n "/agent/submit\|/agent/sign" skill-references/bazaar.md` returns nothing
- [ ] `grep -n "native-amount\|native currency" skill-references/bazaar.md` only matches intended NFT/native cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)