### PR TITLE
feat(feeds): support Base Sepolia; guard AgentRegistry on unsupported chains

### DIFF
--- a/packages/net-feeds/src/__tests__/agentRegistryChainGuard.test.ts
+++ b/packages/net-feeds/src/__tests__/agentRegistryChainGuard.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  getAgentRegistryContract,
+  AGENT_REGISTRY_CONTRACT,
+  AGENT_REGISTRY_CHAIN_IDS,
+} from "../constants";
+import { AgentRegistryClient } from "../client/AgentRegistryClient";
+import { NetClient } from "@net-protocol/core";
+import { BASE_CHAIN_ID } from "./test-utils";
+
+const BASE_SEPOLIA_CHAIN_ID = 84532;
+
+// Mock NetClient so AgentRegistryClient construction doesn't touch the network
+vi.mock("@net-protocol/core", async () => {
+  const actual = await vi.importActual("@net-protocol/core");
+  return {
+    ...actual,
+    NetClient: vi.fn(),
+  };
+});
+
+describe("AgentRegistry chain guard", () => {
+  beforeEach(() => {
+    (NetClient as any).mockImplementation(() => ({
+      getMessageCount: vi.fn(),
+      getMessages: vi.fn(),
+    }));
+  });
+
+  describe("getAgentRegistryContract", () => {
+    it("returns the contract on Base mainnet", () => {
+      expect(getAgentRegistryContract(BASE_CHAIN_ID)).toBe(
+        AGENT_REGISTRY_CONTRACT
+      );
+    });
+
+    it("throws on Base Sepolia (not deployed there)", () => {
+      expect(() => getAgentRegistryContract(BASE_SEPOLIA_CHAIN_ID)).toThrow(
+        /AgentRegistry is not deployed on chain 84532/
+      );
+    });
+
+    it("does not allowlist Base Sepolia", () => {
+      expect(AGENT_REGISTRY_CHAIN_IDS).not.toContain(BASE_SEPOLIA_CHAIN_ID);
+    });
+  });
+
+  describe("AgentRegistryClient", () => {
+    it("constructs on Base mainnet", () => {
+      expect(
+        () => new AgentRegistryClient({ chainId: BASE_CHAIN_ID })
+      ).not.toThrow();
+    });
+
+    it("throws when constructed for Base Sepolia", () => {
+      expect(
+        () => new AgentRegistryClient({ chainId: BASE_SEPOLIA_CHAIN_ID })
+      ).toThrow(/AgentRegistry is not deployed on chain 84532/);
+    });
+  });
+});

--- a/packages/net-feeds/src/client/AgentRegistryClient.ts
+++ b/packages/net-feeds/src/client/AgentRegistryClient.ts
@@ -1,6 +1,7 @@
 import { NetClient } from "@net-protocol/core";
+import type { Abi } from "viem";
 import {
-  AGENT_REGISTRY_CONTRACT,
+  getAgentRegistryContract,
   AGENT_TOPIC,
 } from "../constants";
 import type {
@@ -29,6 +30,7 @@ export type GetRegisteredAgentsOptions = {
  */
 export class AgentRegistryClient {
   private netClient: NetClient;
+  private contract: { abi: Abi; address: `0x${string}` };
 
   /**
    * Creates a new AgentRegistryClient instance.
@@ -36,8 +38,11 @@ export class AgentRegistryClient {
    * @param params - Client configuration
    * @param params.chainId - Chain ID to interact with
    * @param params.overrides - Optional RPC URL overrides
+   * @throws If AgentRegistry is not deployed on the given chain
    */
   constructor(params: AgentRegistryClientOptions) {
+    // Throws early on chains where AgentRegistry isn't deployed (e.g. Base Sepolia)
+    this.contract = getAgentRegistryContract(params.chainId);
     this.netClient = new NetClient({
       chainId: params.chainId,
       overrides: params.overrides,
@@ -53,7 +58,7 @@ export class AgentRegistryClient {
   async isAgentRegistered(address: `0x${string}`): Promise<boolean> {
     const count = await this.netClient.getMessageCount({
       filter: {
-        appAddress: AGENT_REGISTRY_CONTRACT.address,
+        appAddress: this.contract.address,
         maker: address,
         topic: AGENT_TOPIC,
       },
@@ -77,7 +82,7 @@ export class AgentRegistryClient {
     // Get total count of registered agents
     const count = await this.netClient.getMessageCount({
       filter: {
-        appAddress: AGENT_REGISTRY_CONTRACT.address,
+        appAddress: this.contract.address,
         topic: AGENT_TOPIC,
       },
     });
@@ -92,7 +97,7 @@ export class AgentRegistryClient {
     // Get messages from the registry
     const messages = await this.netClient.getMessages({
       filter: {
-        appAddress: AGENT_REGISTRY_CONTRACT.address,
+        appAddress: this.contract.address,
         topic: AGENT_TOPIC,
       },
       startIndex,
@@ -114,7 +119,7 @@ export class AgentRegistryClient {
   async getRegisteredAgentCount(): Promise<number> {
     return this.netClient.getMessageCount({
       filter: {
-        appAddress: AGENT_REGISTRY_CONTRACT.address,
+        appAddress: this.contract.address,
         topic: AGENT_TOPIC,
       },
     });
@@ -128,8 +133,8 @@ export class AgentRegistryClient {
    */
   prepareRegisterAgent(): WriteTransactionConfig {
     return {
-      abi: AGENT_REGISTRY_CONTRACT.abi,
-      to: AGENT_REGISTRY_CONTRACT.address,
+      abi: this.contract.abi,
+      to: this.contract.address,
       functionName: "registerAgent",
       args: [],
     };
@@ -141,6 +146,6 @@ export class AgentRegistryClient {
    * @returns The contract address
    */
   getContractAddress(): `0x${string}` {
-    return AGENT_REGISTRY_CONTRACT.address;
+    return this.contract.address;
   }
 }

--- a/packages/net-feeds/src/constants.ts
+++ b/packages/net-feeds/src/constants.ts
@@ -16,24 +16,51 @@ export const MAX_COMMENT_NESTING_DEPTH = 3 as const;
 // Maximum feed name length (enforced by FeedRegistry contract)
 export const MAX_FEED_NAME_LENGTH = 64 as const;
 
-// FeedRegistry contract - deployed on Base mainnet only
+// FeedRegistry contract - deterministic CREATE2 address, deployed on Base
+// mainnet (8453) and Base Sepolia (84532). Same address/bytecode on each.
 export const FEED_REGISTRY_CONTRACT = {
   abi: feedRegistryAbi as Abi,
   address: "0x000000049ad5f63b6074d3466aa00415c012fc4c" as `0x${string}`,
 } as const;
 
-// TopicCountBulkHelper contract - for batching comment count queries
-// Deployed on Base mainnet (same address on all chains via CREATE2)
+// TopicCountBulkHelper contract - for batching comment count queries.
+// Deterministic CREATE2 address, deployed on Base mainnet (8453) and Base
+// Sepolia (84532). Same address/bytecode on each.
 export const TOPIC_COUNT_BULK_HELPER_CONTRACT = {
   abi: topicCountBulkHelperAbi as Abi,
   address: "0x00000007221A01A02CEa1130d688325cA553566e" as `0x${string}`,
 } as const;
 
-// AgentRegistry contract - deployed on Base mainnet only
+// AgentRegistry contract - currently deployed on Base mainnet (8453) only.
+// Not yet deployed on Base Sepolia. Resolve via getAgentRegistryContract() to
+// get a clear error on unsupported chains instead of a low-level revert.
 export const AGENT_REGISTRY_CONTRACT = {
   abi: agentRegistryAbi as Abi,
   address: "0x0000000c0744c5c7fea376db557b0eadc38c2150" as `0x${string}`,
 } as const;
+
+// Chains where the AgentRegistry contract is deployed. FeedRegistry and
+// TopicCountBulkHelper are not allowlisted here because their deterministic
+// CREATE2 deployments live on additional chains beyond Base + Base Sepolia.
+export const AGENT_REGISTRY_CHAIN_IDS: number[] = [8453];
+
+/**
+ * Resolve the AgentRegistry contract for a chain, throwing a clear error when
+ * the contract is not deployed there (e.g. Base Sepolia / 84532).
+ */
+export function getAgentRegistryContract(chainId: number): {
+  abi: Abi;
+  address: `0x${string}`;
+} {
+  if (!AGENT_REGISTRY_CHAIN_IDS.includes(chainId)) {
+    throw new Error(
+      `AgentRegistry is not deployed on chain ${chainId}. Supported chains: ${AGENT_REGISTRY_CHAIN_IDS.join(
+        ", "
+      )}.`
+    );
+  }
+  return AGENT_REGISTRY_CONTRACT;
+}
 
 // Agent topic used by the AgentRegistry contract (single char for gas efficiency)
 export const AGENT_TOPIC = "a" as const;

--- a/packages/net-feeds/src/hooks/useAgentRegistry.ts
+++ b/packages/net-feeds/src/hooks/useAgentRegistry.ts
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import { useReadContract } from "wagmi";
-import { AGENT_REGISTRY_CONTRACT } from "../constants";
+import { getAgentRegistryContract } from "../constants";
 import type {
   UseAgentRegistryOptions,
   UseIsAgentRegisteredOptions,
@@ -16,24 +16,27 @@ import type {
  * @returns Object with prepareRegisterAgent and contractAddress
  */
 export function useAgentRegistry({ chainId }: UseAgentRegistryOptions) {
+  // Throws on chains where AgentRegistry isn't deployed (e.g. Base Sepolia)
+  const contract = getAgentRegistryContract(chainId);
+
   /**
    * Prepares a transaction configuration for registering as an agent.
    */
   const prepareRegisterAgent = useMemo(
     () => (): WriteTransactionConfig => {
       return {
-        abi: AGENT_REGISTRY_CONTRACT.abi,
-        to: AGENT_REGISTRY_CONTRACT.address,
+        abi: contract.abi,
+        to: contract.address,
         functionName: "registerAgent",
         args: [],
       };
     },
-    []
+    [contract]
   );
 
   return {
     prepareRegisterAgent,
-    contractAddress: AGENT_REGISTRY_CONTRACT.address,
+    contractAddress: contract.address,
   };
 }
 
@@ -51,9 +54,12 @@ export function useIsAgentRegistered({
   agentAddress,
   enabled = true,
 }: UseIsAgentRegisteredOptions) {
+  // Throws on chains where AgentRegistry isn't deployed (e.g. Base Sepolia)
+  const contract = getAgentRegistryContract(chainId);
+
   const { data, isLoading, error, refetch } = useReadContract({
-    address: AGENT_REGISTRY_CONTRACT.address,
-    abi: AGENT_REGISTRY_CONTRACT.abi,
+    address: contract.address,
+    abi: contract.abi,
     functionName: "isAgentRegistered",
     args: [agentAddress],
     chainId,

--- a/packages/net-feeds/src/hooks/useRegisteredAgents.ts
+++ b/packages/net-feeds/src/hooks/useRegisteredAgents.ts
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import { useNetMessages, useNetMessageCount } from "@net-protocol/core/react";
-import { AGENT_REGISTRY_CONTRACT, AGENT_TOPIC } from "../constants";
+import { getAgentRegistryContract, AGENT_TOPIC } from "../constants";
 import type { UseRegisteredAgentsOptions, RegisteredAgent } from "../types";
 
 /**
@@ -22,13 +22,16 @@ export function useRegisteredAgents({
   isLoading: boolean;
   refetch: () => void;
 } {
+  // Throws on chains where AgentRegistry isn't deployed (e.g. Base Sepolia)
+  const contract = getAgentRegistryContract(chainId);
+
   // Build filter for AgentRegistry app messages
   const filter = useMemo(
     () => ({
-      appAddress: AGENT_REGISTRY_CONTRACT.address,
+      appAddress: contract.address,
       topic: AGENT_TOPIC,
     }),
-    []
+    [contract]
   );
 
   // Get total count of registered agents

--- a/packages/net-feeds/src/index.ts
+++ b/packages/net-feeds/src/index.ts
@@ -27,6 +27,8 @@ export {
   MAX_FEED_NAME_LENGTH,
   FEED_REGISTRY_CONTRACT,
   AGENT_REGISTRY_CONTRACT,
+  AGENT_REGISTRY_CHAIN_IDS,
+  getAgentRegistryContract,
   AGENT_TOPIC,
 } from "./constants";
 


### PR DESCRIPTION
## Summary

Adds **Base Sepolia (84532)** support to `net-feeds` and adds a clear chain guard for the one contract not deployed there.

Key finding (verified on-chain): feed/post/comment functionality already worked on Base Sepolia — the clients/hooks pass `chainId` straight through, and **FeedRegistry** + **TopicCountBulkHelper** are live at the same CREATE2 addresses (bytecode confirmed **identical** to Base mainnet). The real gap was **AgentRegistry**, which is **not** deployed on 84532 and would have produced a cryptic `returned no data ("0x")` revert.

## Changes

- **`constants.ts`** — Corrected stale "Base mainnet only" comments (FeedRegistry/TopicCountBulkHelper are multi-chain via CREATE2). Added `AGENT_REGISTRY_CHAIN_IDS` (`[8453]`) and a `getAgentRegistryContract(chainId)` resolver that throws `AgentRegistry is not deployed on chain <id>` on unsupported chains.
- **`AgentRegistryClient.ts`** — Resolves the contract in the constructor, so it throws *early* rather than mid-call.
- **`useAgentRegistry` / `useIsAgentRegistered` / `useRegisteredAgents`** — Route through the guard.
- **`index.ts`** — Exported `getAgentRegistryContract` + `AGENT_REGISTRY_CHAIN_IDS`.
- **New test** — `agentRegistryChainGuard.test.ts` (passes on 8453, throws on 84532).

Throwing on unsupported chains matches the existing codebase convention (`getNetContract`, `getBazaarChainConfig`, `getPublicClient`).

## Intentionally left permissive

FeedRegistry/TopicCountBulkHelper are **not** allowlisted — their CREATE2 deployments may exist on chains beyond the two verified, and an allowlist could break currently-working chains (e.g. Degen). They already work on Sepolia as-is.

## Follow-up

To truly support AgentRegistry on Sepolia, deploy it and add the chain id to `AGENT_REGISTRY_CHAIN_IDS` (one line).

## Verification

- `yarn test` → 149/149 pass (incl. 5 new guard tests)
- `yarn typecheck` → clean
- `yarn build` → success

🤖 Generated with [Claude Code](https://claude.com/claude-code)