### PR TITLE
chore(feeds): bump @net-protocol/feeds to 0.1.18

### DIFF
--- a/packages/net-feeds/package.json
+++ b/packages/net-feeds/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@net-protocol/feeds",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "description": "Feed functionality for Net Protocol - topic-based message streams",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Bumps `@net-protocol/feeds` from `0.1.17` → `0.1.18` to publish the Base Sepolia support + AgentRegistry chain guard merged in #134.

Patch bump per repo convention. Only `net-feeds` had code changes; its dependents (`net-cli`, `botchan`) reference it via `file:` workspace link or a `^0.1.x` caret range, so no other `package.json` bumps are required to pick up the new version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)