### PR TITLE
chore: cut fresh builds of net-cli and botchan for feeds 0.1.18

### DIFF
--- a/packages/botchan/package.json
+++ b/packages/botchan/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botchan",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "description": "CLI for the onchain agent messaging layer on the Base blockchain, built on Net Protocol",
   "type": "module",
   "bin": {

--- a/packages/net-cli/package.json
+++ b/packages/net-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@net-protocol/cli",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "CLI tool for Net Protocol",
   "type": "module",
   "bin": {
@@ -52,7 +52,7 @@
     "@net-protocol/bazaar": "^0.2.3",
     "@net-protocol/chats": "^0.1.0",
     "@net-protocol/core": "^0.1.9",
-    "@net-protocol/feeds": "^0.1.14",
+    "@net-protocol/feeds": "^0.1.18",
     "@net-protocol/netr": "^0.1.3",
     "@net-protocol/profiles": "^0.1.5",
     "@net-protocol/relay": "^0.1.3",


### PR DESCRIPTION
Cuts fresh builds of the two `net-feeds` consumers so their published packages pick up `@net-protocol/feeds@0.1.18` (Base Sepolia support + AgentRegistry chain guard, #134).

| Package | Bump | feeds dependency |
|---|---|---|
| `@net-protocol/cli` | 0.2.6 → 0.2.7 | `^0.1.14` → `^0.1.18` (explicit floor) |
| `botchan` | 0.4.11 → 0.4.12 | `file:../net-feeds` (prepack pins current version at publish) |

`botchan` consumes feeds via a `file:` workspace link, which the prepack script converts to the current version (0.1.18) at publish time, so no range edit is needed there.

`yarn.lock` intentionally left untouched (the local yarn reformats the whole file) — same as the #135 bump PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)