### PR TITLE
chore: resync yarn.lock with workspace package.json changes

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1228,7 +1228,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@net-protocol/bazaar@npm:^0.2.1, @net-protocol/bazaar@workspace:packages/net-bazaar":
+"@net-protocol/bazaar@npm:^0.2.3, @net-protocol/bazaar@workspace:packages/net-bazaar":
   version: 0.0.0-use.local
   resolution: "@net-protocol/bazaar@workspace:packages/net-bazaar"
   dependencies:
@@ -1263,7 +1263,7 @@ __metadata:
 
 "@net-protocol/chats@file:../net-chats::locator=botchan%40workspace%3Apackages%2Fbotchan":
   version: 0.1.1
-  resolution: "@net-protocol/chats@file:../net-chats#../net-chats::hash=3e9512&locator=botchan%40workspace%3Apackages%2Fbotchan"
+  resolution: "@net-protocol/chats@file:../net-chats#../net-chats::hash=afc09c&locator=botchan%40workspace%3Apackages%2Fbotchan"
   dependencies:
     "@net-protocol/core": "file:../net-core"
   peerDependencies:
@@ -1275,7 +1275,7 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: d4c262ce1a9da47ea307618cbe85602db8afe6adbc45074d66a72beb3865d312faccef73b1a55ba746e3f4947e819be9186df2582614904a82f679b53a38aec6
+  checksum: 8b53212004f6587f2e6bd9cac9dc64d7a1b7d0b027bc3c3edc791407ae7b960aa8fd5f1f904c31cede453ab3e6952d22b69831e27c4b6aa0f632293b10000e60
   languageName: node
   linkType: hard
 
@@ -1302,11 +1302,11 @@ __metadata:
   linkType: soft
 
 "@net-protocol/cli@file:../net-cli::locator=botchan%40workspace%3Apackages%2Fbotchan":
-  version: 0.2.2
-  resolution: "@net-protocol/cli@file:../net-cli#../net-cli::hash=841bae&locator=botchan%40workspace%3Apackages%2Fbotchan"
+  version: 0.2.6
+  resolution: "@net-protocol/cli@file:../net-cli#../net-cli::hash=27c50f&locator=botchan%40workspace%3Apackages%2Fbotchan"
   dependencies:
     "@net-protocol/agents": "npm:^0.1.0"
-    "@net-protocol/bazaar": "npm:^0.2.1"
+    "@net-protocol/bazaar": "npm:^0.2.3"
     "@net-protocol/chats": "npm:^0.1.0"
     "@net-protocol/core": "npm:^0.1.9"
     "@net-protocol/feeds": "npm:^0.1.14"
@@ -1324,7 +1324,7 @@ __metadata:
     viem: "npm:^2.45.0"
   bin:
     netp: ./dist/cli/index.mjs
-  checksum: ebe9cc1b127731f46db26cfeba7cd055a36d31aa9074c58438a1145b8a63d12ae9648d9ccb21916a1eb0beee63161dc1702614a9f2f8a2e1d8342e505d9c61a5
+  checksum: d5f2c5bae44a0234fc7516828ac0f7578248e0e83a54cc5634f82efee11bea2b7101c9e325e899e5fb3cb386d28778c4ba3bbb66a9ff4248a9bd1d3309175431
   languageName: node
   linkType: hard
 
@@ -1333,7 +1333,7 @@ __metadata:
   resolution: "@net-protocol/cli@workspace:packages/net-cli"
   dependencies:
     "@net-protocol/agents": "npm:^0.1.0"
-    "@net-protocol/bazaar": "npm:^0.2.1"
+    "@net-protocol/bazaar": "npm:^0.2.3"
     "@net-protocol/chats": "npm:^0.1.0"
     "@net-protocol/core": "npm:^0.1.9"
     "@net-protocol/feeds": "npm:^0.1.14"
@@ -1362,7 +1362,7 @@ __metadata:
 
 "@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fagents%40workspace%3Apackages%2Fnet-agents":
   version: 0.1.12
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=cbe59b&locator=%40net-protocol%2Fagents%40workspace%3Apackages%2Fnet-agents"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=4cc214&locator=%40net-protocol%2Fagents%40workspace%3Apackages%2Fnet-agents"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1374,13 +1374,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: c5209f3f41890cf007690453eae6fd1bb4412d5482b220ab56a8a95e054b85989e0986ad14f054b6a575524f2021112041a402ceb736882267eeebcf2291cc5f
+  checksum: 1ac9e0ad07be6eec0a22ebd79c6db07dbdf7c3802a6185a926c665a5a238f406bb3d0057316e33371d2c288b126a0a67fddf3f9f72515d109e8e07e4d593cb26
   languageName: node
   linkType: hard
 
-"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fchats%40file%3A..%2Fnet-chats%23..%2Fnet-chats%3A%3Ahash%3D3e9512%26locator%3Dbotchan%2540workspace%253Apackages%252Fbotchan":
+"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fchats%40file%3A..%2Fnet-chats%23..%2Fnet-chats%3A%3Ahash%3Dafc09c%26locator%3Dbotchan%2540workspace%253Apackages%252Fbotchan":
   version: 0.1.12
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=cbe59b&locator=%40net-protocol%2Fchats%40file%3A..%2Fnet-chats%23..%2Fnet-chats%3A%3Ahash%3D3e9512%26locator%3Dbotchan%2540workspace%253Apackages%252Fbotchan"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=4cc214&locator=%40net-protocol%2Fchats%40file%3A..%2Fnet-chats%23..%2Fnet-chats%3A%3Ahash%3Dafc09c%26locator%3Dbotchan%2540workspace%253Apackages%252Fbotchan"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1392,13 +1392,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: c5209f3f41890cf007690453eae6fd1bb4412d5482b220ab56a8a95e054b85989e0986ad14f054b6a575524f2021112041a402ceb736882267eeebcf2291cc5f
+  checksum: 1ac9e0ad07be6eec0a22ebd79c6db07dbdf7c3802a6185a926c665a5a238f406bb3d0057316e33371d2c288b126a0a67fddf3f9f72515d109e8e07e4d593cb26
   languageName: node
   linkType: hard
 
 "@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fchats%40workspace%3Apackages%2Fnet-chats":
   version: 0.1.12
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=cbe59b&locator=%40net-protocol%2Fchats%40workspace%3Apackages%2Fnet-chats"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=4cc214&locator=%40net-protocol%2Fchats%40workspace%3Apackages%2Fnet-chats"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1410,13 +1410,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: c5209f3f41890cf007690453eae6fd1bb4412d5482b220ab56a8a95e054b85989e0986ad14f054b6a575524f2021112041a402ceb736882267eeebcf2291cc5f
+  checksum: 1ac9e0ad07be6eec0a22ebd79c6db07dbdf7c3802a6185a926c665a5a238f406bb3d0057316e33371d2c288b126a0a67fddf3f9f72515d109e8e07e4d593cb26
   languageName: node
   linkType: hard
 
-"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Ffeeds%40file%3A..%2Fnet-feeds%23..%2Fnet-feeds%3A%3Ahash%3D1ca43c%26locator%3Dbotchan%2540workspace%253Apackages%252Fbotchan":
+"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Ffeeds%40file%3A..%2Fnet-feeds%23..%2Fnet-feeds%3A%3Ahash%3D4c79c8%26locator%3Dbotchan%2540workspace%253Apackages%252Fbotchan":
   version: 0.1.12
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=cbe59b&locator=%40net-protocol%2Ffeeds%40file%3A..%2Fnet-feeds%23..%2Fnet-feeds%3A%3Ahash%3D1ca43c%26locator%3Dbotchan%2540workspace%253Apackages%252Fbotchan"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=4cc214&locator=%40net-protocol%2Ffeeds%40file%3A..%2Fnet-feeds%23..%2Fnet-feeds%3A%3Ahash%3D4c79c8%26locator%3Dbotchan%2540workspace%253Apackages%252Fbotchan"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1428,13 +1428,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: c5209f3f41890cf007690453eae6fd1bb4412d5482b220ab56a8a95e054b85989e0986ad14f054b6a575524f2021112041a402ceb736882267eeebcf2291cc5f
+  checksum: 1ac9e0ad07be6eec0a22ebd79c6db07dbdf7c3802a6185a926c665a5a238f406bb3d0057316e33371d2c288b126a0a67fddf3f9f72515d109e8e07e4d593cb26
   languageName: node
   linkType: hard
 
 "@net-protocol/core@file:../net-core::locator=%40net-protocol%2Ffeeds%40workspace%3Apackages%2Fnet-feeds":
   version: 0.1.12
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=cbe59b&locator=%40net-protocol%2Ffeeds%40workspace%3Apackages%2Fnet-feeds"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=4cc214&locator=%40net-protocol%2Ffeeds%40workspace%3Apackages%2Fnet-feeds"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1446,13 +1446,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: c5209f3f41890cf007690453eae6fd1bb4412d5482b220ab56a8a95e054b85989e0986ad14f054b6a575524f2021112041a402ceb736882267eeebcf2291cc5f
+  checksum: 1ac9e0ad07be6eec0a22ebd79c6db07dbdf7c3802a6185a926c665a5a238f406bb3d0057316e33371d2c288b126a0a67fddf3f9f72515d109e8e07e4d593cb26
   languageName: node
   linkType: hard
 
 "@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fnetr%40workspace%3Apackages%2Fnet-netr":
   version: 0.1.12
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=cbe59b&locator=%40net-protocol%2Fnetr%40workspace%3Apackages%2Fnet-netr"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=4cc214&locator=%40net-protocol%2Fnetr%40workspace%3Apackages%2Fnet-netr"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1464,13 +1464,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: c5209f3f41890cf007690453eae6fd1bb4412d5482b220ab56a8a95e054b85989e0986ad14f054b6a575524f2021112041a402ceb736882267eeebcf2291cc5f
+  checksum: 1ac9e0ad07be6eec0a22ebd79c6db07dbdf7c3802a6185a926c665a5a238f406bb3d0057316e33371d2c288b126a0a67fddf3f9f72515d109e8e07e4d593cb26
   languageName: node
   linkType: hard
 
 "@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fprofiles%40workspace%3Apackages%2Fnet-profiles":
   version: 0.1.12
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=cbe59b&locator=%40net-protocol%2Fprofiles%40workspace%3Apackages%2Fnet-profiles"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=4cc214&locator=%40net-protocol%2Fprofiles%40workspace%3Apackages%2Fnet-profiles"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1482,13 +1482,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: c5209f3f41890cf007690453eae6fd1bb4412d5482b220ab56a8a95e054b85989e0986ad14f054b6a575524f2021112041a402ceb736882267eeebcf2291cc5f
+  checksum: 1ac9e0ad07be6eec0a22ebd79c6db07dbdf7c3802a6185a926c665a5a238f406bb3d0057316e33371d2c288b126a0a67fddf3f9f72515d109e8e07e4d593cb26
   languageName: node
   linkType: hard
 
-"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Frelay%40file%3A..%2Fnet-relay%23..%2Fnet-relay%3A%3Ahash%3Db98d44%26locator%3D%2540net-protocol%252Fagents%2540workspace%253Apackages%252Fnet-agents":
+"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Frelay%40file%3A..%2Fnet-relay%23..%2Fnet-relay%3A%3Ahash%3D537a4a%26locator%3D%2540net-protocol%252Fagents%2540workspace%253Apackages%252Fnet-agents":
   version: 0.1.12
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=cbe59b&locator=%40net-protocol%2Frelay%40file%3A..%2Fnet-relay%23..%2Fnet-relay%3A%3Ahash%3Db98d44%26locator%3D%2540net-protocol%252Fagents%2540workspace%253Apackages%252Fnet-agents"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=4cc214&locator=%40net-protocol%2Frelay%40file%3A..%2Fnet-relay%23..%2Fnet-relay%3A%3Ahash%3D537a4a%26locator%3D%2540net-protocol%252Fagents%2540workspace%253Apackages%252Fnet-agents"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1500,13 +1500,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: c5209f3f41890cf007690453eae6fd1bb4412d5482b220ab56a8a95e054b85989e0986ad14f054b6a575524f2021112041a402ceb736882267eeebcf2291cc5f
+  checksum: 1ac9e0ad07be6eec0a22ebd79c6db07dbdf7c3802a6185a926c665a5a238f406bb3d0057316e33371d2c288b126a0a67fddf3f9f72515d109e8e07e4d593cb26
   languageName: node
   linkType: hard
 
 "@net-protocol/core@file:../net-core::locator=%40net-protocol%2Frelay%40workspace%3Apackages%2Fnet-relay":
   version: 0.1.12
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=cbe59b&locator=%40net-protocol%2Frelay%40workspace%3Apackages%2Fnet-relay"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=4cc214&locator=%40net-protocol%2Frelay%40workspace%3Apackages%2Fnet-relay"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1518,13 +1518,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: c5209f3f41890cf007690453eae6fd1bb4412d5482b220ab56a8a95e054b85989e0986ad14f054b6a575524f2021112041a402ceb736882267eeebcf2291cc5f
+  checksum: 1ac9e0ad07be6eec0a22ebd79c6db07dbdf7c3802a6185a926c665a5a238f406bb3d0057316e33371d2c288b126a0a67fddf3f9f72515d109e8e07e4d593cb26
   languageName: node
   linkType: hard
 
 "@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fscore%40workspace%3Apackages%2Fnet-score":
   version: 0.1.12
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=cbe59b&locator=%40net-protocol%2Fscore%40workspace%3Apackages%2Fnet-score"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=4cc214&locator=%40net-protocol%2Fscore%40workspace%3Apackages%2Fnet-score"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1536,13 +1536,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: c5209f3f41890cf007690453eae6fd1bb4412d5482b220ab56a8a95e054b85989e0986ad14f054b6a575524f2021112041a402ceb736882267eeebcf2291cc5f
+  checksum: 1ac9e0ad07be6eec0a22ebd79c6db07dbdf7c3802a6185a926c665a5a238f406bb3d0057316e33371d2c288b126a0a67fddf3f9f72515d109e8e07e4d593cb26
   languageName: node
   linkType: hard
 
-"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3Dca8b19%26locator%3D%2540net-protocol%252Fnetr%2540workspace%253Apackages%252Fnet-netr":
+"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3Dc39363%26locator%3D%2540net-protocol%252Fnetr%2540workspace%253Apackages%252Fnet-netr":
   version: 0.1.12
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=cbe59b&locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3Dca8b19%26locator%3D%2540net-protocol%252Fnetr%2540workspace%253Apackages%252Fnet-netr"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=4cc214&locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3Dc39363%26locator%3D%2540net-protocol%252Fnetr%2540workspace%253Apackages%252Fnet-netr"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1554,13 +1554,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: c5209f3f41890cf007690453eae6fd1bb4412d5482b220ab56a8a95e054b85989e0986ad14f054b6a575524f2021112041a402ceb736882267eeebcf2291cc5f
+  checksum: 1ac9e0ad07be6eec0a22ebd79c6db07dbdf7c3802a6185a926c665a5a238f406bb3d0057316e33371d2c288b126a0a67fddf3f9f72515d109e8e07e4d593cb26
   languageName: node
   linkType: hard
 
-"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3Dca8b19%26locator%3D%2540net-protocol%252Fprofiles%2540workspace%253Apackages%252Fnet-profiles":
+"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3Dc39363%26locator%3D%2540net-protocol%252Fprofiles%2540workspace%253Apackages%252Fnet-profiles":
   version: 0.1.12
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=cbe59b&locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3Dca8b19%26locator%3D%2540net-protocol%252Fprofiles%2540workspace%253Apackages%252Fnet-profiles"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=4cc214&locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3Dc39363%26locator%3D%2540net-protocol%252Fprofiles%2540workspace%253Apackages%252Fnet-profiles"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1572,13 +1572,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: c5209f3f41890cf007690453eae6fd1bb4412d5482b220ab56a8a95e054b85989e0986ad14f054b6a575524f2021112041a402ceb736882267eeebcf2291cc5f
+  checksum: 1ac9e0ad07be6eec0a22ebd79c6db07dbdf7c3802a6185a926c665a5a238f406bb3d0057316e33371d2c288b126a0a67fddf3f9f72515d109e8e07e4d593cb26
   languageName: node
   linkType: hard
 
-"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3Dca8b19%26locator%3D%2540net-protocol%252Fscore%2540workspace%253Apackages%252Fnet-score":
+"@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3Dc39363%26locator%3D%2540net-protocol%252Fscore%2540workspace%253Apackages%252Fnet-score":
   version: 0.1.12
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=cbe59b&locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3Dca8b19%26locator%3D%2540net-protocol%252Fscore%2540workspace%253Apackages%252Fnet-score"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=4cc214&locator=%40net-protocol%2Fstorage%40file%3A..%2Fnet-storage%23..%2Fnet-storage%3A%3Ahash%3Dc39363%26locator%3D%2540net-protocol%252Fscore%2540workspace%253Apackages%252Fnet-score"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1590,13 +1590,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: c5209f3f41890cf007690453eae6fd1bb4412d5482b220ab56a8a95e054b85989e0986ad14f054b6a575524f2021112041a402ceb736882267eeebcf2291cc5f
+  checksum: 1ac9e0ad07be6eec0a22ebd79c6db07dbdf7c3802a6185a926c665a5a238f406bb3d0057316e33371d2c288b126a0a67fddf3f9f72515d109e8e07e4d593cb26
   languageName: node
   linkType: hard
 
 "@net-protocol/core@file:../net-core::locator=%40net-protocol%2Fstorage%40workspace%3Apackages%2Fnet-storage":
   version: 0.1.12
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=cbe59b&locator=%40net-protocol%2Fstorage%40workspace%3Apackages%2Fnet-storage"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=4cc214&locator=%40net-protocol%2Fstorage%40workspace%3Apackages%2Fnet-storage"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1608,13 +1608,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: c5209f3f41890cf007690453eae6fd1bb4412d5482b220ab56a8a95e054b85989e0986ad14f054b6a575524f2021112041a402ceb736882267eeebcf2291cc5f
+  checksum: 1ac9e0ad07be6eec0a22ebd79c6db07dbdf7c3802a6185a926c665a5a238f406bb3d0057316e33371d2c288b126a0a67fddf3f9f72515d109e8e07e4d593cb26
   languageName: node
   linkType: hard
 
 "@net-protocol/core@file:../net-core::locator=botchan%40workspace%3Apackages%2Fbotchan":
   version: 0.1.12
-  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=cbe59b&locator=botchan%40workspace%3Apackages%2Fbotchan"
+  resolution: "@net-protocol/core@file:../net-core#../net-core::hash=4cc214&locator=botchan%40workspace%3Apackages%2Fbotchan"
   dependencies:
     ox: "npm:^0.13.2"
   peerDependencies:
@@ -1626,7 +1626,7 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: c5209f3f41890cf007690453eae6fd1bb4412d5482b220ab56a8a95e054b85989e0986ad14f054b6a575524f2021112041a402ceb736882267eeebcf2291cc5f
+  checksum: 1ac9e0ad07be6eec0a22ebd79c6db07dbdf7c3802a6185a926c665a5a238f406bb3d0057316e33371d2c288b126a0a67fddf3f9f72515d109e8e07e4d593cb26
   languageName: node
   linkType: hard
 
@@ -1655,8 +1655,8 @@ __metadata:
   linkType: soft
 
 "@net-protocol/feeds@file:../net-feeds::locator=botchan%40workspace%3Apackages%2Fbotchan":
-  version: 0.1.17
-  resolution: "@net-protocol/feeds@file:../net-feeds#../net-feeds::hash=1ca43c&locator=botchan%40workspace%3Apackages%2Fbotchan"
+  version: 0.1.18
+  resolution: "@net-protocol/feeds@file:../net-feeds#../net-feeds::hash=4c79c8&locator=botchan%40workspace%3Apackages%2Fbotchan"
   dependencies:
     "@net-protocol/core": "file:../net-core"
   peerDependencies:
@@ -1668,7 +1668,7 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: 667ee127c0f6a65b85be7405c4107b070089d478aeab579640875f39eb5cb57d0e4c0a81825e574c5041a1216da66bba7457d9e95b10913840e0ee39912f5ab3
+  checksum: 870c35f65db86df50e06cf2ea800cf432432472165a604870418d6dfb880a0e95219ffb5cbcf42332deb7d72d3745280b402464067646a58600c453899523b5d
   languageName: node
   linkType: hard
 
@@ -1758,14 +1758,14 @@ __metadata:
 
 "@net-protocol/relay@file:../net-relay::locator=%40net-protocol%2Fagents%40workspace%3Apackages%2Fnet-agents":
   version: 0.1.5
-  resolution: "@net-protocol/relay@file:../net-relay#../net-relay::hash=b98d44&locator=%40net-protocol%2Fagents%40workspace%3Apackages%2Fnet-agents"
+  resolution: "@net-protocol/relay@file:../net-relay#../net-relay::hash=537a4a&locator=%40net-protocol%2Fagents%40workspace%3Apackages%2Fnet-agents"
   dependencies:
     "@net-protocol/core": "file:../net-core"
     "@x402/evm": "npm:^2.1.0"
     "@x402/fetch": "npm:^2.1.0"
   peerDependencies:
     viem: ^2.31.4
-  checksum: 89c8ddcdba885f00d03031b267ae75c9a84269ba55cb8e1088afc606bb05bde9b48623a4c3e62c5802ff3c1178717a2edd32cade475d3152e53417c90a8902cd
+  checksum: a633d752cd55bf8b2a6e84e9d0ab0e2e8f0a95dfa5e3103efe9485c739cd450676365e6ef4e80caa7ccbe1ed6d270b9644256af8c28279ff94058955e7280f47
   languageName: node
   linkType: hard
 
@@ -1822,7 +1822,7 @@ __metadata:
 
 "@net-protocol/storage@file:../net-storage::locator=%40net-protocol%2Fnetr%40workspace%3Apackages%2Fnet-netr":
   version: 0.1.17
-  resolution: "@net-protocol/storage@file:../net-storage#../net-storage::hash=ca8b19&locator=%40net-protocol%2Fnetr%40workspace%3Apackages%2Fnet-netr"
+  resolution: "@net-protocol/storage@file:../net-storage#../net-storage::hash=c39363&locator=%40net-protocol%2Fnetr%40workspace%3Apackages%2Fnet-netr"
   dependencies:
     "@net-protocol/core": "file:../net-core"
     pako: "npm:^2.1.0"
@@ -1836,13 +1836,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: 95e798f69d3da762d1507749806fb516416ccfc4e98bfbf3993295e878b398b1c78b0e9b52d3f9ff9e686ddf99346f229534093ca25cadfa8aeb6dde73d38c89
+  checksum: c886266a37ff83cf559a51bae3adabf40df04c7207b48ecbc7ac8707a7a14d324b1ae06234d69c623d87bee2b76663f7b5c759e6541389e2f0ad78e728eb0a17
   languageName: node
   linkType: hard
 
 "@net-protocol/storage@file:../net-storage::locator=%40net-protocol%2Fprofiles%40workspace%3Apackages%2Fnet-profiles":
   version: 0.1.17
-  resolution: "@net-protocol/storage@file:../net-storage#../net-storage::hash=ca8b19&locator=%40net-protocol%2Fprofiles%40workspace%3Apackages%2Fnet-profiles"
+  resolution: "@net-protocol/storage@file:../net-storage#../net-storage::hash=c39363&locator=%40net-protocol%2Fprofiles%40workspace%3Apackages%2Fnet-profiles"
   dependencies:
     "@net-protocol/core": "file:../net-core"
     pako: "npm:^2.1.0"
@@ -1856,13 +1856,13 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: 95e798f69d3da762d1507749806fb516416ccfc4e98bfbf3993295e878b398b1c78b0e9b52d3f9ff9e686ddf99346f229534093ca25cadfa8aeb6dde73d38c89
+  checksum: c886266a37ff83cf559a51bae3adabf40df04c7207b48ecbc7ac8707a7a14d324b1ae06234d69c623d87bee2b76663f7b5c759e6541389e2f0ad78e728eb0a17
   languageName: node
   linkType: hard
 
 "@net-protocol/storage@file:../net-storage::locator=%40net-protocol%2Fscore%40workspace%3Apackages%2Fnet-score":
   version: 0.1.17
-  resolution: "@net-protocol/storage@file:../net-storage#../net-storage::hash=ca8b19&locator=%40net-protocol%2Fscore%40workspace%3Apackages%2Fnet-score"
+  resolution: "@net-protocol/storage@file:../net-storage#../net-storage::hash=c39363&locator=%40net-protocol%2Fscore%40workspace%3Apackages%2Fnet-score"
   dependencies:
     "@net-protocol/core": "file:../net-core"
     pako: "npm:^2.1.0"
@@ -1876,7 +1876,7 @@ __metadata:
       optional: true
     wagmi:
       optional: true
-  checksum: 95e798f69d3da762d1507749806fb516416ccfc4e98bfbf3993295e878b398b1c78b0e9b52d3f9ff9e686ddf99346f229534093ca25cadfa8aeb6dde73d38c89
+  checksum: c886266a37ff83cf559a51bae3adabf40df04c7207b48ecbc7ac8707a7a14d324b1ae06234d69c623d87bee2b76663f7b5c759e6541389e2f0ad78e728eb0a17
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Runs a clean `yarn install` to bring the committed `yarn.lock` back in sync with `package.json` state already on `main`. The lockfile had drifted from merged changes.

## What changed

- **55 insertions / 55 deletions**, no packages added or removed
- Updated dependency ranges to match merged `package.json`s (e.g. `@net-protocol/bazaar` `^0.2.1` → `^0.2.3`)
- Recomputed workspace `file:` dependency hashes/checksums (net-core/chats/cli/feeds locators)

This is a plain resync — the earlier "16k-line rewrite" we were worried about was a corrupted intermediate state, **not** what a clean `yarn install` produces.

## Verification

- `yarn build` → exit 0 (all workspaces)
- `@net-protocol/feeds` tests → 149/149 pass

## Note

Branched off `main`, so it reflects the merged feeds 0.1.18 but not the still-open #136 (net-cli/botchan bumps). Once #136 merges, the lockfile will take one more tiny update for those two versions — happy to fold that in if you'd rather sequence it differently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)