### PR TITLE
Hybrid read primitive for off-wallet chains (net-core + net-feeds)

### DIFF
--- a/packages/net-core/package.json
+++ b/packages/net-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@net-protocol/core",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "Core Net protocol SDK for interacting with Net smart contracts",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/net-core/src/hooks/useNetMessageCount.ts
+++ b/packages/net-core/src/hooks/useNetMessageCount.ts
@@ -1,23 +1,22 @@
-import { useReadContract } from "wagmi";
 import { useMemo } from "react";
 import { getNetMessageCountReadConfig } from "../client/messages";
+import { useNetReadContract } from "./useNetReadContract";
 import { UseNetMessageCountOptions } from "../types";
 
 export function useNetMessageCount(params: UseNetMessageCountOptions) {
+  const { chainId, filter, refetchInterval } = params;
+  const enabled = params.enabled ?? true;
+
   const readContractArgs = useMemo(
-    () => getNetMessageCountReadConfig({
-      chainId: params.chainId,
-      filter: params.filter,
-    }),
-    [params.chainId, params.filter]
+    () => getNetMessageCountReadConfig({ chainId, filter }),
+    [chainId, filter]
   );
 
-  const { data, isLoading, error, refetch } = useReadContract({
+  // useNetReadContract reads via wagmi for configured chains and via the SDK's
+  // standalone client for SDK-supported chains absent from the wagmi config.
+  const { data, isLoading, error, refetch } = useNetReadContract({
     ...readContractArgs,
-    query: {
-      refetchInterval: params.refetchInterval,
-      enabled: params.enabled,
-    },
+    query: { enabled, refetchInterval },
   });
 
   return {
@@ -27,4 +26,3 @@ export function useNetMessageCount(params: UseNetMessageCountOptions) {
     refetch,
   };
 }
-

--- a/packages/net-core/src/hooks/useNetMessages.ts
+++ b/packages/net-core/src/hooks/useNetMessages.ts
@@ -1,30 +1,31 @@
-import { useReadContract } from "wagmi";
 import { useMemo } from "react";
 import { getNetMessagesReadConfig } from "../client/messages";
+import { useNetReadContract } from "./useNetReadContract";
 import { UseNetMessagesOptions, NetMessage } from "../types";
 
 export function useNetMessages(params: UseNetMessagesOptions) {
+  const { chainId, filter, startIndex, endIndex } = params;
+  const enabled = params.enabled ?? true;
+
   const readContractArgs = useMemo(
     () =>
       getNetMessagesReadConfig({
-        chainId: params.chainId,
-        filter: params.filter,
-        startIndex: params.startIndex,
-        endIndex: params.endIndex,
+        chainId,
+        filter,
+        startIndex,
+        endIndex,
       }),
-    [params.chainId, params.filter, params.startIndex, params.endIndex]
+    [chainId, filter, startIndex, endIndex]
   );
 
-  const { data, isLoading, error, refetch } = useReadContract({
+  // useNetReadContract reads via wagmi for configured chains and via the SDK's
+  // standalone client for SDK-supported chains absent from the wagmi config.
+  const { data, isLoading, error, refetch } = useNetReadContract({
     ...readContractArgs,
-    query: {
-      enabled: params.enabled,
-    },
+    query: { enabled },
   });
 
-  const messages = useMemo(() => {
-    return (data as NetMessage[]) ?? [];
-  }, [data]);
+  const messages = useMemo(() => (data as NetMessage[]) ?? [], [data]);
 
   return {
     messages,

--- a/packages/net-core/src/hooks/useNetReadContract.ts
+++ b/packages/net-core/src/hooks/useNetReadContract.ts
@@ -1,0 +1,220 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useReadContract, useReadContracts, usePublicClient } from "wagmi";
+import { readContract, multicall } from "viem/actions";
+import type { Abi, PublicClient } from "viem";
+import { getPublicClient, getChainRpcUrls } from "../chainConfig";
+
+/**
+ * Hybrid contract-read primitives that work for any chain the SDK supports —
+ * even chains that aren't in the consumer's wagmi config.
+ *
+ * wagmi's useReadContract/useReadContracts read through the WagmiProvider's
+ * config, so they return nothing for a chain that isn't listed there (e.g. a
+ * testnet deliberately kept out of the wallet/network picker). These wrappers
+ * keep the wagmi path for configured chains (unchanged behavior, shared cache)
+ * and transparently fall back to the SDK's standalone client (getPublicClient)
+ * for chains that are SDK-supported but absent from the wagmi config — the same
+ * approach useNetMessagesBatchAsync already takes.
+ *
+ * They're drop-in replacements: swap `import { useReadContract } from "wagmi"`
+ * for `import { useNetReadContract } from "@net-protocol/core/react"`.
+ */
+
+export interface NetReadContractConfig {
+  address?: `0x${string}`;
+  abi: Abi;
+  functionName: string;
+  args?: readonly unknown[];
+  chainId?: number;
+  query?: { enabled?: boolean; refetchInterval?: number };
+}
+
+export interface NetContractCall {
+  address: `0x${string}`;
+  abi: Abi;
+  functionName: string;
+  args?: readonly unknown[];
+  chainId?: number;
+}
+
+export interface NetReadContractResult<T = unknown> {
+  data: T | undefined;
+  isLoading: boolean;
+  error: Error | undefined;
+  refetch: () => void;
+}
+
+// Stable, bigint-safe serialization for effect dependency keys.
+function serializeArgs(args?: readonly unknown[]): string {
+  return JSON.stringify(args ?? [], (_key, value) =>
+    typeof value === "bigint" ? `${value.toString()}n` : value
+  );
+}
+
+// True when the chain isn't in the wagmi config but the SDK can read it directly.
+// Always calls usePublicClient (no conditional hooks); the arg just varies.
+function useStandaloneStrategy(chainId?: number): boolean {
+  const wagmiClient = usePublicClient(chainId != null ? { chainId } : undefined);
+  return (
+    !wagmiClient && chainId != null && getChainRpcUrls({ chainId }).length > 0
+  );
+}
+
+// Standalone read via the SDK's own client. useEffect/useState (not react-query)
+// so the primitive carries no provider requirement beyond wagmi itself.
+function useStandaloneReader<T>(params: {
+  enabled: boolean;
+  chainId?: number;
+  cacheKey: string;
+  refetchInterval?: number;
+  fetcher: (client: PublicClient) => Promise<T>;
+}): NetReadContractResult<T> {
+  const { enabled, chainId, cacheKey, refetchInterval, fetcher } = params;
+  const active = enabled && chainId != null;
+
+  // Latest fetcher captured by ref so the effect can depend on cacheKey (stable)
+  // rather than the closure identity (new every render).
+  const fetcherRef = useRef(fetcher);
+  fetcherRef.current = fetcher;
+
+  const [data, setData] = useState<T | undefined>(undefined);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | undefined>(undefined);
+  const [nonce, setNonce] = useState(0);
+  const refetch = useCallback(() => setNonce((n) => n + 1), []);
+
+  useEffect(() => {
+    if (!active) {
+      setData(undefined);
+      setIsLoading(false);
+      setError(undefined);
+      return;
+    }
+    let cancelled = false;
+    const run = async () => {
+      setIsLoading(true);
+      setError(undefined);
+      try {
+        const client = getPublicClient({ chainId: chainId as number });
+        const result = await fetcherRef.current(client);
+        if (!cancelled) setData(result);
+      } catch (e) {
+        if (!cancelled) {
+          setData(undefined);
+          setError(e as Error);
+        }
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    };
+    run();
+    const timer = refetchInterval ? setInterval(run, refetchInterval) : undefined;
+    return () => {
+      cancelled = true;
+      if (timer) clearInterval(timer);
+    };
+  }, [active, chainId, cacheKey, refetchInterval, nonce]);
+
+  return { data, isLoading: active && isLoading, error, refetch };
+}
+
+export function useNetReadContract(
+  config: NetReadContractConfig
+): NetReadContractResult {
+  const { address, abi, functionName, args, chainId, query } = config;
+  const enabled = query?.enabled ?? true;
+  const refetchInterval = query?.refetchInterval;
+  const useStandalone = useStandaloneStrategy(chainId);
+
+  const wagmi = useReadContract({
+    address,
+    abi,
+    functionName,
+    args: args as unknown[] | undefined,
+    chainId,
+    query: { enabled: enabled && !useStandalone, refetchInterval },
+  });
+
+  const cacheKey = useMemo(
+    () => `${chainId}:${address}:${functionName}:${serializeArgs(args)}`,
+    [chainId, address, functionName, args]
+  );
+
+  const standalone = useStandaloneReader({
+    enabled: enabled && useStandalone,
+    chainId,
+    cacheKey,
+    refetchInterval,
+    fetcher: (client) =>
+      readContract(client, {
+        address: address as `0x${string}`,
+        abi,
+        functionName,
+        args: args as unknown[],
+      }),
+  });
+
+  if (useStandalone) return standalone;
+  return {
+    data: wagmi.data,
+    isLoading: wagmi.isLoading,
+    error: wagmi.error as Error | undefined,
+    refetch: wagmi.refetch,
+  };
+}
+
+export function useNetReadContracts<T = unknown[]>(config: {
+  contracts: readonly NetContractCall[];
+  allowFailure?: boolean;
+  query?: { enabled?: boolean; refetchInterval?: number };
+}): NetReadContractResult<T> {
+  const { contracts, allowFailure = true, query } = config;
+  const enabled = query?.enabled ?? true;
+  const refetchInterval = query?.refetchInterval;
+
+  // Standalone multicall reads a single chain. If the batch spans chains
+  // (not a pattern in practice), stay on wagmi.
+  const chainId = contracts[0]?.chainId;
+  const sameChain = contracts.every((c) => c.chainId === chainId);
+  const useStandalone = useStandaloneStrategy(sameChain ? chainId : undefined);
+
+  const wagmi = useReadContracts({
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    contracts: contracts as any,
+    allowFailure,
+    query: { enabled: enabled && !useStandalone, refetchInterval },
+  });
+
+  const cacheKey = useMemo(
+    () =>
+      `${chainId}:${allowFailure}:${contracts
+        .map((c) => `${c.address}:${c.functionName}:${serializeArgs(c.args)}`)
+        .join("|")}`,
+    [chainId, allowFailure, contracts]
+  );
+
+  const standalone = useStandaloneReader<T>({
+    enabled: enabled && useStandalone,
+    chainId,
+    cacheKey,
+    refetchInterval,
+    fetcher: (client) =>
+      multicall(client, {
+        allowFailure,
+        contracts: contracts.map((c) => ({
+          address: c.address,
+          abi: c.abi,
+          functionName: c.functionName,
+          args: c.args as unknown[],
+        })),
+      }) as Promise<T>,
+  });
+
+  if (useStandalone) return standalone;
+  return {
+    data: wagmi.data as T | undefined,
+    isLoading: wagmi.isLoading,
+    error: wagmi.error as Error | undefined,
+    refetch: wagmi.refetch,
+  };
+}

--- a/packages/net-core/src/react.ts
+++ b/packages/net-core/src/react.ts
@@ -2,6 +2,10 @@
 export { useNetMessages } from "./hooks/useNetMessages";
 export { useNetMessageCount } from "./hooks/useNetMessageCount";
 export { useNetMessagesBatchAsync } from "./hooks/useNetMessagesBatchAsync";
+export {
+  useNetReadContract,
+  useNetReadContracts,
+} from "./hooks/useNetReadContract";
 export { NetProvider } from "./hooks/NetProvider";
 
 // Re-export types used by hooks
@@ -10,3 +14,8 @@ export type {
   UseNetMessageCountOptions,
   UseNetMessagesBatchAsyncOptions,
 } from "./types";
+export type {
+  NetReadContractConfig,
+  NetContractCall,
+  NetReadContractResult,
+} from "./hooks/useNetReadContract";

--- a/packages/net-feeds/package.json
+++ b/packages/net-feeds/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@net-protocol/feeds",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "Feed functionality for Net Protocol - topic-based message streams",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/net-feeds/src/__tests__/useFeedMessageCountBatch.test.ts
+++ b/packages/net-feeds/src/__tests__/useFeedMessageCountBatch.test.ts
@@ -10,6 +10,8 @@ vi.mock("wagmi", async (importOriginal) => {
   return {
     ...actual,
     useReadContract: vi.fn(),
+    // A configured chain has a wagmi client → reads stay on the wagmi path.
+    usePublicClient: vi.fn(() => ({})),
   };
 });
 

--- a/packages/net-feeds/src/__tests__/useFeedRegistry.test.ts
+++ b/packages/net-feeds/src/__tests__/useFeedRegistry.test.ts
@@ -11,6 +11,8 @@ vi.mock("wagmi", async () => {
   return {
     ...actual,
     useReadContract: vi.fn(),
+    // A configured chain has a wagmi client → reads stay on the wagmi path.
+    usePublicClient: vi.fn(() => ({})),
   };
 });
 

--- a/packages/net-feeds/src/hooks/useAgentRegistry.ts
+++ b/packages/net-feeds/src/hooks/useAgentRegistry.ts
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { useReadContract } from "wagmi";
+import { useNetReadContract } from "@net-protocol/core/react";
 import { getAgentRegistryContract } from "../constants";
 import type {
   UseAgentRegistryOptions,
@@ -57,7 +57,7 @@ export function useIsAgentRegistered({
   // Throws on chains where AgentRegistry isn't deployed (e.g. Base Sepolia)
   const contract = getAgentRegistryContract(chainId);
 
-  const { data, isLoading, error, refetch } = useReadContract({
+  const { data, isLoading, error, refetch } = useNetReadContract({
     address: contract.address,
     abi: contract.abi,
     functionName: "isAgentRegistered",

--- a/packages/net-feeds/src/hooks/useCommentCountBatch.ts
+++ b/packages/net-feeds/src/hooks/useCommentCountBatch.ts
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { useReadContracts } from "wagmi";
+import { useNetReadContracts } from "@net-protocol/core/react";
 import { NULL_ADDRESS, getNetContract } from "@net-protocol/core";
 import { getCommentTopic, generatePostHash } from "../utils/commentUtils";
 import type { UseCommentCountBatchOptions, NetMessage } from "../types";
@@ -53,8 +53,11 @@ export function useCommentCountBatch({
     [posts]
   );
 
-  // Use wagmi's multicall to fetch all counts in one request
-  const { data, isLoading, error, refetch } = useReadContracts({
+  // Multicall to fetch all counts in one request. Reads via wagmi for
+  // configured chains and via the SDK's standalone client otherwise.
+  const { data, isLoading, error, refetch } = useNetReadContracts<
+    { status: "success" | "failure"; result?: unknown }[]
+  >({
     contracts,
     query: {
       enabled: enabled && posts.length > 0,

--- a/packages/net-feeds/src/hooks/useFeedMessageCountBatch.ts
+++ b/packages/net-feeds/src/hooks/useFeedMessageCountBatch.ts
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { useReadContract } from "wagmi";
+import { useNetReadContract } from "@net-protocol/core/react";
 import { NULL_ADDRESS } from "@net-protocol/core";
 import { normalizeFeedTopic } from "../utils/feedUtils";
 import { TOPIC_COUNT_BULK_HELPER_CONTRACT } from "../constants";
@@ -45,7 +45,7 @@ export function useFeedMessageCountBatch({
   );
 
   // Use TopicCountBulkHelper to fetch all counts in a single RPC call
-  const { data, isLoading, error, refetch } = useReadContract({
+  const { data, isLoading, error, refetch } = useNetReadContract({
     abi: TOPIC_COUNT_BULK_HELPER_CONTRACT.abi,
     address: TOPIC_COUNT_BULK_HELPER_CONTRACT.address,
     functionName: "getMessageCountsForTopics",

--- a/packages/net-feeds/src/hooks/useFeedRegistry.ts
+++ b/packages/net-feeds/src/hooks/useFeedRegistry.ts
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { useReadContract } from "wagmi";
+import { useNetReadContract } from "@net-protocol/core/react";
 import {
   FEED_REGISTRY_CONTRACT,
   MAX_FEED_NAME_LENGTH,
@@ -111,7 +111,7 @@ export function useIsFeedRegistered({
   feedName,
   enabled = true,
 }: UseIsFeedRegisteredOptions) {
-  const { data, isLoading, error, refetch } = useReadContract({
+  const { data, isLoading, error, refetch } = useNetReadContract({
     address: FEED_REGISTRY_CONTRACT.address,
     abi: FEED_REGISTRY_CONTRACT.abi,
     functionName: "isFeedRegistered",


### PR DESCRIPTION
## Problem

The SDK's React read hooks call wagmi's `useReadContract` / `useReadContracts`, which read through the consumer's **wagmi config**. Any chain not in that config returns empty — even when the SDK has built-in RPC for it. This made feeds on intentionally-hidden chains unreadable in production (e.g. the net-stream "build in public" feed on Base Sepolia, which is gated out of the wallet/network picker).

`useNetMessagesBatchAsync` already read such chains via `getPublicClient`, so the wagmi-coupled hooks were the inconsistent outliers. There were **~24 such read sites across 6 packages**, so the right fix is the underlying mechanism, not per-hook patches.

## Fix: a hybrid read primitive

New in `@net-protocol/core/react`:
- `useNetReadContract` — drop-in for `useReadContract`
- `useNetReadContracts` — drop-in for `useReadContracts` (standalone path uses viem `multicall`)

Behavior: **wagmi client if the chain is configured** (unchanged — same cache, same behavior); **else the SDK's standalone `getPublicClient`** if the chain is SDK-supported. The two paths are mutually exclusive (one is always `enabled: false`), so configured chains see zero extra reads. The standalone path uses `useEffect`/`getPublicClient` (matching `useNetMessagesBatchAsync`) — **no react-query dependency added**.

Migration is a near-mechanical import swap, and any future read hook gets off-wallet support for free.

## Changes
**net-core** (`0.1.12 → 0.1.13`)
- `hooks/useNetReadContract.ts` (new) — the two primitives
- `useNetMessageCount` / `useNetMessages` refactored onto the primitive (single source of truth)
- exported from the react entrypoint

**net-feeds** (`0.1.18 → 0.1.19`) — adopt the primitive in its 4 wagmi-coupled hooks
- `useIsFeedRegistered`, `useIsAgentRegistered`, `useFeedMessageCountBatch`, `useCommentCountBatch`
- tests: mock `usePublicClient` (configured chains take the wagmi path)

## Verification
- `net-core`: typecheck + build clean, **75/75 tests pass**; standalone read verified live on Base Sepolia (`feed-net-stream` → 23 posts).
- `net-feeds`: typecheck clean, **149/149 tests pass**.

## Not covered (incremental follow-up)
The same wagmi coupling exists in `net-netr` (3), `net-profiles` (1), `net-score` (7), `net-storage` (8). They can adopt the primitive the same way, one package at a time. Also: hooks that throw when a contract isn't deployed on a chain (e.g. AgentRegistry on Base Sepolia) stay chain-gated — the primitive makes reads *reach* a chain, not conjure missing contracts.

## Rollout
Publish `@net-protocol/core@0.1.13` first (consumed by net #854 for the feed). `@net-protocol/feeds@0.1.19` delivers the auxiliary-hook fixes to feeds consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)