### PR TITLE
Add Robinhood Chain (4663) support across packages

### DIFF
--- a/packages/net-bazaar/package.json
+++ b/packages/net-bazaar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@net-protocol/bazaar",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "SDK for Net Bazaar - a decentralized bazaar storing all orders onchain via Seaport",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/net-bazaar/src/chainConfig.ts
+++ b/packages/net-bazaar/src/chainConfig.ts
@@ -264,6 +264,22 @@ const BAZAAR_CHAIN_CONFIGS: Record<number, BazaarChainConfig> = {
     },
     currencySymbol: "eth",
   },
+
+  // Robinhood Chain (ETH-native Arbitrum L2)
+  4663: {
+    bazaarAddress: DEFAULT_BAZAAR_ADDRESS,
+    collectionOffersAddress: DEFAULT_COLLECTION_OFFERS_ADDRESS,
+    seaportAddress: DEFAULT_SEAPORT_ADDRESS,
+    feeCollectorAddress: DEFAULT_FEE_COLLECTOR_ADDRESS,
+    nftFeeBps: DEFAULT_NFT_FEE_BPS,
+    wrappedNativeCurrency: {
+      // WETH on Robinhood Chain (non-standard address; not the OP predeploy)
+      address: "0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73",
+      name: "Wrapped Ether",
+      symbol: "WETH",
+    },
+    currencySymbol: "eth",
+  },
 };
 
 /**

--- a/packages/net-bazaar/src/client/BazaarClient.ts
+++ b/packages/net-bazaar/src/client/BazaarClient.ts
@@ -126,6 +126,7 @@ const CHAIN_RPC_URLS: Record<number, string[]> = {
   999: ["https://rpc.hyperliquid.xyz/evm"],
   9745: ["https://rpc.plasma.to"],
   143: ["https://rpc3.monad.xyz"],
+  4663: ["https://rpc.mainnet.chain.robinhood.com"],
 };
 
 // ERC20 decimals ABI for on-chain lookup

--- a/packages/net-core/package.json
+++ b/packages/net-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@net-protocol/core",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "Core Net protocol SDK for interacting with Net smart contracts",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/net-core/src/chainConfig.ts
+++ b/packages/net-core/src/chainConfig.ts
@@ -144,6 +144,19 @@ const CHAIN_CONFIG: Record<number, ChainConfig> = {
     nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 },
     blockExplorer: { name: "MegaETH Explorer", url: "https://mega.etherscan.com" },
   },
+  // Robinhood Chain (ETH-native Arbitrum L2)
+  4663: {
+    name: "Robinhood",
+    slug: "robinhood",
+    type: "mainnet",
+    rpcUrls: ["https://rpc.mainnet.chain.robinhood.com"],
+    netContractAddress: "0x00000000B24D62781dB359b07880a105cD0b64e6",
+    nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 },
+    blockExplorer: {
+      name: "Robinhood Chain Explorer",
+      url: "https://robinhoodchain.blockscout.com",
+    },
+  },
   // Base Sepolia (testnet)
   84532: {
     name: "Base Sepolia",

--- a/packages/net-netr/package.json
+++ b/packages/net-netr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@net-protocol/netr",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Netr Token SDK for deploying and interacting with memecoin-NFT pairs on Net Protocol",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/net-netr/src/__tests__/chainConfig.test.ts
+++ b/packages/net-netr/src/__tests__/chainConfig.test.ts
@@ -31,6 +31,10 @@ describe("chainConfig", () => {
       expect(isNetrSupportedChain(999)).toBe(true);
     });
 
+    it("should return true for Robinhood (4663)", () => {
+      expect(isNetrSupportedChain(4663)).toBe(true);
+    });
+
     it("should return false for Ethereum mainnet (1)", () => {
       expect(isNetrSupportedChain(1)).toBe(false);
     });
@@ -48,6 +52,7 @@ describe("chainConfig", () => {
       expect(chainIds).toContain(9745);
       expect(chainIds).toContain(143);
       expect(chainIds).toContain(999);
+      expect(chainIds).toContain(4663);
     });
 
     it("should return array of numbers", () => {
@@ -59,9 +64,9 @@ describe("chainConfig", () => {
       });
     });
 
-    it("should have 4 supported chains", () => {
+    it("should have 5 supported chains", () => {
       const chainIds = getNetrSupportedChainIds();
-      expect(chainIds.length).toBe(4);
+      expect(chainIds.length).toBe(5);
     });
   });
 
@@ -96,6 +101,20 @@ describe("chainConfig", () => {
 
       expect(config).toBeDefined();
       expect(config?.name).toBe("HyperEVM");
+    });
+
+    it("should return config for Robinhood", () => {
+      const config = getNetrChainConfig(4663);
+
+      expect(config).toBeDefined();
+      expect(config?.name).toBe("Robinhood");
+    });
+
+    it("should use the non-standard WETH address for Robinhood", () => {
+      const config = getNetrChainConfig(4663);
+      expect(config?.wethAddress.toLowerCase()).toBe(
+        "0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73".toLowerCase()
+      );
     });
 
     it("should return undefined for unsupported chain", () => {
@@ -197,6 +216,10 @@ describe("chainConfig", () => {
       expect(getInitialTick(143)).toBe(-115000);
     });
 
+    it("should return initial tick for Robinhood (4663)", () => {
+      expect(getInitialTick(4663)).toBe(-230400);
+    });
+
     it("should return undefined for unsupported chain", () => {
       expect(getInitialTick(1)).toBeUndefined();
     });
@@ -226,6 +249,10 @@ describe("chainConfig", () => {
 
     it("should return mint price for Monad (143) - 1 MONAD", () => {
       expect(getMintPrice(143)).toBe(BigInt("1000000000000000000"));
+    });
+
+    it("should return mint price for Robinhood (4663) - 0.0005 ETH", () => {
+      expect(getMintPrice(4663)).toBe(BigInt("500000000000000"));
     });
 
     it("should return undefined for unsupported chain", () => {

--- a/packages/net-netr/src/chainConfig.ts
+++ b/packages/net-netr/src/chainConfig.ts
@@ -54,6 +54,17 @@ const NETR_CHAIN_CONFIG: Record<number, NetrChainConfig> = {
     initialTick: -177400,
     mintPrice: BigInt("50000000000000000"), // 0.05 HYPE
   },
+  // Robinhood Chain (ETH-native Arbitrum L2)
+  4663: {
+    name: "Robinhood",
+    bangerV4Address: "0x00000000CDaB5161815cD4005fAc11AC3a796F63",
+    // WETH on Robinhood Chain (non-standard address; not the OP predeploy)
+    wethAddress: "0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73",
+    storageAddress: "0x00000000db40fcb9f4466330982372e27fd7bbf5",
+    netAddress: "0x00000000B24D62781dB359b07880a105cD0b64e6",
+    initialTick: -230400,
+    mintPrice: BigInt("500000000000000"), // 0.0005 ETH
+  },
 };
 
 export function getNetrContract(chainId: number): { address: `0x${string}`; abi: Abi } {


### PR DESCRIPTION
## Summary
Adds support for Robinhood Chain (chain ID 4663), an ETH-native Arbitrum L2, across the net-protocol SDK packages.

## Key Changes

- **net-bazaar**: Added Robinhood Chain configuration with default contract addresses and WETH token details (non-standard address: `0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73`)
- **net-core**: Added chain metadata including RPC URL, NET contract address, and block explorer configuration
- **net-netr**: Added Netr-specific configuration with BangerV4, storage, and NET contract addresses, plus pricing parameters (0.0005 ETH mint price)
- **net-bazaar BazaarClient**: Added RPC URL mapping for Robinhood Chain

## Package version bumps (ready to publish)

| Package | Old → New |
|---------|-----------|
| `@net-protocol/core` | 0.1.12 → **0.1.13** |
| `@net-protocol/bazaar` | 0.2.3 → **0.2.4** |
| `@net-protocol/netr` | 0.1.5 → **0.1.6** |

**Publish order** (so `file:` deps resolve to real versions at prepack): `core` → `bazaar` → `netr`. `net-netr` references `core` via `file:../net-core`, which the prepack script rewrites to the exact version at publish, so publishing `core@0.1.13` before `netr@0.1.6` makes netr depend on the new core.

## On-chain deployment status ✅

All five Net contracts are **deployed and verified on-chain** on Robinhood Chain (4663) at their deterministic addresses:

| Contract | Address |
|----------|---------|
| Storage | `0x00000000DB40fcB9f4466330982372e27Fd7Bbf5` |
| NET | `0x00000000B24D62781dB359b07880a105cD0b64e6` |
| InscribedDrops | `0x0000004c6cc2cA10Cf4d67C8902659085D31e1Dc` |
| LockerFactoryV3 | `0x000000072A11b938808Fd0FF440aD41CB050f1dc` |
| BangerV4 | `0x00000000CDaB5161815cD4005fAc11AC3a796F63` |

BangerV4's `onlyOwner` config verified on-chain: owner `0xcC4193…`, weth `0x0Bd7D308…`, uniswapV3Factory `0x1f7d7550…`, positionManager `0x58daec31…`, swapRouter `0xCaf681a6…` (SwapRouter02), liquidityLocker `0x00000007…`. Uniswap 1% fee tier (10000) confirmed enabled (tickSpacing 200).

## Implementation Details

- Uses default Bazaar contract addresses (same as other chains) for consistency
- WETH address is non-standard and differs from OP predeploy conventions (documented in comments)
- Mint price set to 500000000000000 wei (0.0005 ETH) for Netr operations
- Initial tick set to -230400 for Netr configuration
- RPC endpoint: `https://rpc.mainnet.chain.robinhood.com`
- Block explorer: Robinhood Chain Explorer (Blockscout)

https://claude.ai/code/session_01RFYMXvkzLSWtpUe9gRCjb3

🤖 Generated with [Claude Code](https://claude.com/claude-code)