### PR TITLE
Add Robinhood Chain (4663) support for token deployment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,9 +64,9 @@ All contracts use the same address across all supported EVM chains:
 
 ## Supported Chains
 
-**Messages & Storage:** Base (8453), Ethereum (1), Degen (666666666), Ham (5112), Ink (57073), Unichain (130), HyperEVM (999), Plasma (9745), Monad (143), Base Sepolia (84532), Sepolia (11155111)
+**Messages & Storage:** Base (8453), Ethereum (1), Degen (666666666), Ham (5112), Ink (57073), Unichain (130), HyperEVM (999), Plasma (9745), Monad (143), Robinhood (4663), Base Sepolia (84532), Sepolia (11155111)
 
-**Token Deployment (Netr):** Base (8453), Plasma (9745), Monad (143), HyperEVM (999)
+**Token Deployment (Netr):** Base (8453), Plasma (9745), Monad (143), HyperEVM (999), Robinhood Chain (4663)
 
 ## Code Patterns
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -542,7 +542,7 @@ Submit each transaction in order. After uploading, data is accessible at:
 https://netprotocol.app/app/token/{chainSlug}/{lowercase(tokenAddress)}
 ```
 
-The token page renders for any ERC-20 (not just Netr-deployed) on any visible chain. Slugs: `base` (8453), `ethereum` (1), `unichain` (130), `monad` (143), `hyperliquid` (999), `megaeth` (4326), `ink` (57073), `plasma` (9745), `base_sepolia` (84532, testnet), `sepolia` (11155111, testnet). `degen` and `ham` are hidden — those URLs 404. Note that token *deploy* is still restricted to Base/Plasma/Monad/HyperEVM, and *upvoting* is Base-only — but viewing a token page works wherever the chain is visible.
+The token page renders for any ERC-20 (not just Netr-deployed) on any visible chain. Slugs: `base` (8453), `ethereum` (1), `unichain` (130), `monad` (143), `hyperliquid` (999), `megaeth` (4326), `ink` (57073), `plasma` (9745), `robinhood` (4663), `base_sepolia` (84532, testnet), `sepolia` (11155111, testnet). `degen` and `ham` are hidden — those URLs 404. Note that token *deploy* is still restricted to Base/Plasma/Monad/HyperEVM/Robinhood, and *upvoting* is Base-only — but viewing a token page works wherever the chain is visible.
 
 For a deploy via `--encode-only`, the address is the `predictedAddress` field — you can share the URL the moment you have it, no need to wait for confirmation. (Or, post-confirmation, `netp token info --json` and `netp upvote info --json` return the same URL as `tokenUrl`.)
 
@@ -576,7 +576,7 @@ The only legitimate reason to read allowance state yourself is a non-submitting 
 | Area | Constraint |
 |------|-----------|
 | **Storage** | Auto-chunked into ≤80KB transactions. Submit every transaction in the `transactions` array in order. Uploads are idempotent — safe to retry. |
-| **Token deploy** | `--name`, `--symbol`, and `--image` are all required. Token deployment only works on Base (8453), Plasma (9745), Monad (143), and HyperEVM (999). |
+| **Token deploy** | `--name`, `--symbol`, and `--image` are all required. Token deployment only works on Base (8453), Plasma (9745), Monad (143), HyperEVM (999), and Robinhood Chain (4663). Robinhood is an ETH-native Arbitrum L2, so its economics mirror Base (ETH gas, 0.0005 ETH mint price). |
 | **Token deploy with initial buy** | Output includes a non-zero `value` field (price in wei). You **must** include this value when submitting. |
 | **Upvoting (tokens)** | Each upvote costs 0.000025 ETH. Output includes a non-zero `value` field — you **must** include it. Only Base (8453) is supported. `--encode-only` still requires RPC access for pool discovery. |
 | **Upvoting (users)** | Price fetched from contract (currently 0.000025 ETH per upvote). Output includes a non-zero `value` field — you **must** include it. Only Base (8453) is supported. |
@@ -601,6 +601,7 @@ The only legitimate reason to read allowance state yourself is a non-submitting 
 | HyperEVM | 999 | Yes | Yes | Yes | Yes | No | Yes (ERC-20) | No |
 | Plasma | 9745 | Yes | Yes | Yes | Yes | No | No | No |
 | Monad | 143 | Yes | Yes | Yes | Yes | No | No | No |
+| Robinhood | 4663 | Yes | Yes | Yes | Yes | No | No | No |
 
 Testnets: Base Sepolia (84532), Sepolia (11155111)
 
@@ -664,6 +665,7 @@ When transactions are submitted externally (e.g., via Bankr after using `--encod
 
 ### Tokens (use netp)
 - "Deploy a memecoin" → `netp token deploy --name "Cool Token" --symbol "COOL" --image "https://..." --chain-id 8453 --encode-only`
+- "Launch a memecoin on Robinhood Chain" → `netp token deploy --name "Cool Token" --symbol "COOL" --image "https://..." --chain-id 4663 --encode-only` (Robinhood Chain = 4663; ETH-native, so `--initial-buy` amounts are in ETH just like Base)
 - "Deploy with initial buy" → `netp token deploy --name "Cool Token" --symbol "COOL" --image "https://..." --initial-buy 0.1 --chain-id 8453 --encode-only`
 - "Get token info" → `netp token info --address 0x... --chain-id 8453 --json` (returns `tokenUrl` — the Net page where humans can view/buy the token)
 - "Share a token's Net page with a human" → `netp token info --address 0x... --chain-id 8453 --json` and read the `tokenUrl` field

--- a/packages/net-cli/README.md
+++ b/packages/net-cli/README.md
@@ -294,7 +294,7 @@ netp token deploy \
   [--animation <url>] \
   [--fid <number>] \
   [--private-key <0x...>] \
-  [--chain-id <8453|9745|143|999>] \
+  [--chain-id <8453|9745|143|999|4663>] \
   [--encode-only]
 ```
 
@@ -307,7 +307,7 @@ netp token deploy \
 - `--fid` (optional): Farcaster ID
 - `--initial-buy` (optional): ETH amount to swap for tokens on deploy (e.g., "0.001")
 - `--private-key` (optional): Private key. Can also be set via `NET_PRIVATE_KEY` environment variable
-- `--chain-id` (optional): Chain ID. Supported: Base (8453), Plasma (9745), Monad (143), HyperEVM (999)
+- `--chain-id` (optional): Chain ID. Supported: Base (8453), Plasma (9745), Monad (143), HyperEVM (999), Robinhood Chain (4663)
 - `--encode-only` (optional): Output transaction data as JSON instead of executing
 
 **Example:**
@@ -352,7 +352,7 @@ Get information about an existing Netr token.
 ```bash
 netp token info \
   --address <token-address> \
-  [--chain-id <8453|9745|143|999>] \
+  [--chain-id <8453|9745|143|999|4663>] \
   [--json]
 ```
 

--- a/packages/net-cli/package.json
+++ b/packages/net-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@net-protocol/cli",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "CLI tool for Net Protocol",
   "type": "module",
   "bin": {
@@ -49,11 +49,11 @@
   },
   "dependencies": {
     "@net-protocol/agents": "^0.1.0",
-    "@net-protocol/bazaar": "^0.2.3",
+    "@net-protocol/bazaar": "^0.2.4",
     "@net-protocol/chats": "^0.1.0",
-    "@net-protocol/core": "^0.1.9",
+    "@net-protocol/core": "^0.1.13",
     "@net-protocol/feeds": "^0.1.18",
-    "@net-protocol/netr": "^0.1.3",
+    "@net-protocol/netr": "^0.1.6",
     "@net-protocol/profiles": "^0.1.5",
     "@net-protocol/relay": "^0.1.3",
     "@net-protocol/score": "^0.1.9",

--- a/packages/net-netr/README.md
+++ b/packages/net-netr/README.md
@@ -202,7 +202,7 @@ if (isNetrSupportedChain(chainId)) {
 }
 
 // Get all supported chains
-const chains = getNetrSupportedChainIds(); // [8453, 9745, 143, 999]
+const chains = getNetrSupportedChainIds(); // [8453, 9745, 143, 999, 4663]
 ```
 
 ## Supported Chains
@@ -213,6 +213,7 @@ const chains = getNetrSupportedChainIds(); // [8453, 9745, 143, 999]
 | Plasma      | 9745     | ✅     |
 | Monad       | 143      | ✅     |
 | Hyperliquid | 999      | ✅     |
+| Robinhood   | 4663     | ✅     |
 
 ## Types
 

--- a/plugins/net-protocol/skills/net-protocol/SKILL.md
+++ b/plugins/net-protocol/skills/net-protocol/SKILL.md
@@ -26,10 +26,11 @@ Net Protocol is a decentralized onchain messaging and storage system on EVM chai
 - HyperEVM (999)
 - Plasma (9745)
 - Monad (143)
+- Robinhood (4663)
 - Base Sepolia (84532), Sepolia (11155111) - Testnets
 
 **Token Deployment Chains:**
-- Base (8453), Plasma (9745), Monad (143), HyperEVM (999)
+- Base (8453), Plasma (9745), Monad (143), HyperEVM (999), Robinhood Chain (4663)
 
 ## Personal Feeds
 
@@ -161,7 +162,7 @@ netp token deploy --name "My Token" --symbol "MTK" --image "https://..." --anima
 netp token info --address 0x... --chain-id 8453 --json
 ```
 
-Token deployment only works on Base (8453), Plasma (9745), Monad (143), and HyperEVM (999).
+Token deployment only works on Base (8453), Plasma (9745), Monad (143), HyperEVM (999), and Robinhood Chain (4663). Robinhood is an ETH-native Arbitrum L2, so its economics mirror Base (ETH gas, 0.0005 ETH mint price).
 
 ### Upvote Commands
 
@@ -318,7 +319,7 @@ Net Protocol uses the same contract addresses across all supported chains:
 ## Error Handling
 
 **"StoredDataNotFound"**: The key/operator combination doesn't exist
-**"Chain not supported"**: Token deployment only works on Base, Plasma, Monad, HyperEVM
+**"Chain not supported"**: Token deployment only works on Base, Plasma, Monad, HyperEVM, Robinhood
 **"Failed to generate salt"**: Check that all required parameters are provided
 **"Token not found"**: Wait for block confirmation before querying
 **Rate limits**: Add delays between RPC calls or use custom RPC URL

--- a/plugins/net-protocol/skills/net-protocol/references/contracts.md
+++ b/plugins/net-protocol/skills/net-protocol/references/contracts.md
@@ -29,6 +29,7 @@
 | Plasma | 9745 | `0x00000000CDaB5161815cD4005fAc11AC3a796F63` |
 | Monad | 143 | `0x00000000CDaB5161815cD4005fAc11AC3a796F63` |
 | HyperEVM | 999 | `0x000000C91A20BE8342B6D4dfc0947f1Ec5333BF6` |
+| Robinhood | 4663 | `0x00000000CDaB5161815cD4005fAc11AC3a796F63` |
 
 ## Supported Chains
 
@@ -43,6 +44,7 @@
 | HyperEVM | 999 | Mainnet |
 | Plasma | 9745 | Mainnet |
 | Monad | 143 | Mainnet |
+| Robinhood | 4663 | Mainnet |
 | Base Sepolia | 84532 | Testnet |
 | Sepolia | 11155111 | Testnet |
 
@@ -182,6 +184,7 @@ function extraStringData() external view returns (string memory)
 | Chain | Initial Tick | Approx Market Cap |
 |-------|--------------|-------------------|
 | Base (8453) | -230400 | ~$35k |
+| Robinhood (4663) | -230400 | ~$35k |
 | HyperEVM (999) | -177400 | - |
 | Plasma (9745) | -147200 | - |
 | Monad (143) | -115000 | - |

--- a/skill-references/tokens.md
+++ b/skill-references/tokens.md
@@ -20,8 +20,11 @@ Token deployment is available on select chains:
 | Plasma | 9745 | ✅ Supported |
 | Monad | 143 | ✅ Supported |
 | HyperEVM | 999 | ✅ Supported |
+| Robinhood Chain | 4663 | ✅ Supported |
 
 Other chains (Ethereum, Degen, etc.) support storage and messaging but not token deployment.
+
+**Robinhood Chain (4663)** is an ETH-native Arbitrum L2, so its launch economics mirror Base: native gas is ETH, the mint price is `0.0005 ETH`, and `--initial-buy` amounts are denominated in ETH. Nothing special is needed — just pass `--chain-id 4663`.
 
 ## Commands
 
@@ -37,7 +40,7 @@ netp token deploy \
   [--animation <url>] \
   [--fid <number>] \
   [--private-key <0x...>] \
-  [--chain-id <8453|9745|143|999>] \
+  [--chain-id <8453|9745|143|999|4663>] \
   [--encode-only] \
   [--initial-buy <eth>] \
   [--mint-price <wei>] \
@@ -151,7 +154,7 @@ Retrieve information about a deployed token:
 ```bash
 netp token info \
   --address <token-address> \
-  [--chain-id <8453|9745|143|999>] \
+  [--chain-id <8453|9745|143|999|4663>] \
   [--json]
 ```
 
@@ -204,6 +207,19 @@ netp token deploy \
   --initial-buy 0.5 \
   --chain-id 8453
 ```
+
+### Launch a Memecoin on Robinhood Chain
+```bash
+netp token deploy \
+  --name "Robinhood Rocket" \
+  --symbol "RHR" \
+  --image "https://example.com/rhr.png" \
+  --initial-buy 0.01 \
+  --chain-id 4663
+```
+Robinhood Chain is ETH-native, so `--initial-buy` is in ETH and the returned
+`value` (for `--encode-only`) is in wei — identical to Base. Share the token
+page at `https://netprotocol.app/app/token/robinhood/<lowercase-address>`.
 
 ### Community Token
 ```bash
@@ -259,7 +275,7 @@ Token deployment costs include:
 
 | Error | Cause | Solution |
 |-------|-------|----------|
-| "Unsupported chain" | Chain doesn't support tokens | Use Base, Plasma, Monad, or HyperEVM |
+| "Unsupported chain" | Chain doesn't support tokens | Use Base, Plasma, Monad, HyperEVM, or Robinhood (4663) |
 | "Invalid image URL" | Malformed URL | Use valid HTTPS URL |
 | "Insufficient funds" | Not enough ETH | Add ETH for gas + initial buy |
 | "Symbol too long" | Symbol exceeds limit | Use shorter symbol |

--- a/yarn.lock
+++ b/yarn.lock
@@ -1228,7 +1228,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@net-protocol/bazaar@npm:^0.2.3, @net-protocol/bazaar@workspace:packages/net-bazaar":
+"@net-protocol/bazaar@npm:^0.2.4, @net-protocol/bazaar@workspace:packages/net-bazaar":
   version: 0.0.0-use.local
   resolution: "@net-protocol/bazaar@workspace:packages/net-bazaar"
   dependencies:
@@ -1630,7 +1630,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@net-protocol/core@npm:*, @net-protocol/core@npm:^0.1.9, @net-protocol/core@workspace:packages/net-core":
+"@net-protocol/core@npm:*, @net-protocol/core@npm:^0.1.13, @net-protocol/core@npm:^0.1.9, @net-protocol/core@workspace:packages/net-core":
   version: 0.0.0-use.local
   resolution: "@net-protocol/core@workspace:packages/net-core"
   dependencies:
@@ -1701,7 +1701,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@net-protocol/netr@npm:*, @net-protocol/netr@npm:^0.1.3, @net-protocol/netr@workspace:packages/net-netr":
+"@net-protocol/netr@npm:*, @net-protocol/netr@npm:^0.1.6, @net-protocol/netr@workspace:packages/net-netr":
   version: 0.0.0-use.local
   resolution: "@net-protocol/netr@workspace:packages/net-netr"
   dependencies:


### PR DESCRIPTION
## Summary
Adds support for Robinhood Chain (4663) as a token deployment destination alongside existing chains (Base, Plasma, Monad, HyperEVM). Robinhood Chain is an ETH-native Arbitrum L2 with economics mirroring Base.

## Key Changes

- **Token deployment support**: Added Robinhood Chain (4663) to all supported chain lists and command documentation
- **Chain configuration**: Updated `--chain-id` parameter documentation to include `4663` across CLI commands (`token deploy`, `token info`)
- **Economics documentation**: Added explicit notes that Robinhood Chain is ETH-native with 0.0005 ETH mint price, matching Base's model
- **Contract addresses**: Added Robinhood Chain contract address (`0x00000000CDaB5161815cD4005fAc11AC3a796F63`) to contracts reference
- **Example commands**: Added memecoin deployment example for Robinhood Chain showing ETH-denominated `--initial-buy`
- **Package updates**: Bumped CLI version to 0.2.8 and updated dependencies:
  - `@net-protocol/bazaar`: 0.2.3 → 0.2.4
  - `@net-protocol/core`: 0.1.9 → 0.1.13
  - `@net-protocol/netr`: 0.1.3 → 0.1.6

## Documentation Updates

Updated across multiple documentation files:
- `skill-references/tokens.md`: Added Robinhood to deployment table and economics explanation
- `SKILL.md`: Added Robinhood to supported chains table and token page slug mapping
- `AGENTS.md`: Added Robinhood to supported chains lists
- `packages/net-netr/README.md`: Added Robinhood to supported chains table
- `plugins/net-protocol/skills/net-protocol/`: Updated skill documentation with Robinhood support
- `packages/net-cli/README.md`: Updated CLI documentation with Robinhood chain ID

## Notable Details

- Robinhood Chain uses the same contract address as Base and Monad
- Initial tick for Robinhood matches Base (~$35k market cap)
- Token page URL slug is `robinhood` (4663)
- No special configuration needed—users pass `--chain-id 4663` just like other chains

https://claude.ai/code/session_012LtiLm8T8Q4nR48DydaruS