### PR TITLE
Robinhood Chain (4663): bazaar config + fill remaining chain-list gaps

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,6 @@
 {
   "attribution": {
     "commit": "Co-Authored-By: Claude <noreply@anthropic.com>",
-    "pr": "🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+    "pr": ""
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,6 @@
+{
+  "attribution": {
+    "commit": "Co-Authored-By: Claude <noreply@anthropic.com>",
+    "pr": "🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+  }
+}

--- a/packages/net-bazaar/package.json
+++ b/packages/net-bazaar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@net-protocol/bazaar",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "SDK for Net Bazaar - a decentralized bazaar storing all orders onchain via Seaport",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/net-bazaar/src/__tests__/chainConfig.test.ts
+++ b/packages/net-bazaar/src/__tests__/chainConfig.test.ts
@@ -61,6 +61,23 @@ describe("chainConfig", () => {
       expect(config?.currencySymbol).toBe("eth");
     });
 
+    it("returns config for Robinhood with 0% fee, flexible-fee family, and USDG", () => {
+      const config = getBazaarChainConfig(4663);
+      expect(config).toBeDefined();
+      expect(config?.nftFeeBps).toBe(0);
+      expect(config?.erc20FeeBps).toBe(0);
+      expect(config?.bazaarAddress).toBe("0x000000058f3ade587388daf827174d0e6fc97595");
+      expect(config?.collectionOffersAddress).toBe("0x0000000f9c45efcff0f78d8b54aa6a40092d66dc");
+      expect(config?.erc20OffersAddress).toBe("0x0000000e23a89aa06f317306aa1ae231d3503082");
+      expect(config?.erc20BazaarAddress).toBe("0x00000006557e3629e2fc50bbad0c002b27cac492");
+      expect(config?.wrappedNativeCurrency?.symbol).toBe("WETH");
+      expect(config?.wrappedNativeCurrency?.address).toBe(
+        "0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73"
+      );
+      expect(config?.erc20QuoteToken?.symbol).toBe("USDG");
+      expect(config?.currencySymbol).toBe("eth");
+    });
+
     it("returns undefined for unsupported chain", () => {
       expect(getBazaarChainConfig(99999)).toBeUndefined();
     });
@@ -113,6 +130,13 @@ describe("chainConfig", () => {
       expect(usdc?.decimals).toBe(6);
     });
 
+    it("returns USDG for Robinhood", () => {
+      const usdg = getErc20QuoteToken(4663);
+      expect(usdg?.symbol).toBe("USDG");
+      expect(usdg?.address).toBe("0x5fc5360D0400a0Fd4f2af552ADD042D716F1d168");
+      expect(usdg?.decimals).toBe(6);
+    });
+
     it("returns undefined for chains without a configured quote token", () => {
       expect(getErc20QuoteToken(1)).toBeUndefined();
       expect(getErc20QuoteToken(84532)).toBeUndefined();
@@ -148,6 +172,11 @@ describe("chainConfig", () => {
     it("HyperEVM: 0% for NFT and ERC20", () => {
       expect(getNftFeeBps(999)).toBe(0);
       expect(getErc20FeeBps(999)).toBe(0);
+    });
+
+    it("Robinhood: 0% for NFT and ERC20", () => {
+      expect(getNftFeeBps(4663)).toBe(0);
+      expect(getErc20FeeBps(4663)).toBe(0);
     });
 
     it("default-fee chain (Degen): 5% NFT, 1% ERC20", () => {

--- a/packages/net-bazaar/src/chainConfig.ts
+++ b/packages/net-bazaar/src/chainConfig.ts
@@ -266,17 +266,35 @@ const BAZAAR_CHAIN_CONFIGS: Record<number, BazaarChainConfig> = {
   },
 
   // Robinhood Chain (ETH-native Arbitrum L2)
+  //
+  // Mirrors Base's posture: the flexible-fee bazaar family with 0% fees, plus
+  // ERC20 trading denominated in a stablecoin (USDG — Robinhood has no USDC).
+  //
+  // NOTE: these contracts must be deployed on 4663 before trading works. Seaport
+  // is already live, but the Net bazaar apps + Seaport zones are deployed via the
+  // CREATE2 replay in protocol/deployment-scripts (deploy-to-chain.mjs). See the
+  // Robinhood bazaar deployment checklist before publishing/advertising this.
   4663: {
-    bazaarAddress: DEFAULT_BAZAAR_ADDRESS,
-    collectionOffersAddress: DEFAULT_COLLECTION_OFFERS_ADDRESS,
+    // Flexible-fee family (same addresses Base/Ethereum/HyperEVM/MegaETH use)
+    bazaarAddress: "0x000000058f3ade587388daf827174d0e6fc97595",
+    collectionOffersAddress: "0x0000000f9c45efcff0f78d8b54aa6a40092d66dc",
+    erc20OffersAddress: "0x0000000e23a89aa06f317306aa1ae231d3503082",
+    erc20BazaarAddress: "0x00000006557e3629e2fc50bbad0c002b27cac492",
     seaportAddress: DEFAULT_SEAPORT_ADDRESS,
-    feeCollectorAddress: DEFAULT_FEE_COLLECTOR_ADDRESS,
-    nftFeeBps: DEFAULT_NFT_FEE_BPS,
+    feeCollectorAddress: "0x66547ff4f7206e291F7BC157b54C026Fc6660961",
+    nftFeeBps: 0, // 0% on Robinhood (matches Base)
+    erc20FeeBps: 0,
     wrappedNativeCurrency: {
       // WETH on Robinhood Chain (non-standard address; not the OP predeploy)
       address: "0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73",
       name: "Wrapped Ether",
       symbol: "WETH",
+    },
+    // ERC20 bazaar trades on Robinhood are priced in USDG (no USDC on this chain).
+    erc20QuoteToken: {
+      address: "0x5fc5360D0400a0Fd4f2af552ADD042D716F1d168",
+      symbol: "USDG",
+      decimals: 6,
     },
     currencySymbol: "eth",
   },

--- a/packages/net-cli/package.json
+++ b/packages/net-cli/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@net-protocol/agents": "^0.1.0",
-    "@net-protocol/bazaar": "^0.2.4",
+    "@net-protocol/bazaar": "^0.2.5",
     "@net-protocol/chats": "^0.1.0",
     "@net-protocol/core": "^0.1.13",
     "@net-protocol/feeds": "^0.1.18",

--- a/packages/net-cli/package.json
+++ b/packages/net-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@net-protocol/cli",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "CLI tool for Net Protocol",
   "type": "module",
   "bin": {

--- a/packages/net-cli/src/commands/token/deploy.ts
+++ b/packages/net-cli/src/commands/token/deploy.ts
@@ -141,7 +141,7 @@ export async function executeTokenDeploy(
 
   if (!isNetrSupportedChain(commonOptions.chainId)) {
     exitWithError(
-      `Chain ${commonOptions.chainId} is not supported for token deployment. Supported: Base (8453), Plasma (9745), Monad (143), HyperEVM (999)`
+      `Chain ${commonOptions.chainId} is not supported for token deployment. Supported: Base (8453), Plasma (9745), Monad (143), HyperEVM (999), Robinhood (4663)`
     );
   }
 

--- a/packages/net-core/README.md
+++ b/packages/net-core/README.md
@@ -120,6 +120,7 @@ const message = await client.getMessageAtIndex({
 - Plasma Chain (9745)
 - Monad Chain (143)
 - MegaETH (4326)
+- Robinhood Chain (4663)
 - Base Sepolia (84532) - testnet
 - Sepolia (11155111) - testnet
 

--- a/plugins/net-protocol/README.md
+++ b/plugins/net-protocol/README.md
@@ -98,6 +98,7 @@ Autonomous exploration of Net Protocol data:
 | HyperEVM | 999 | Messages, Storage, Tokens |
 | Plasma | 9745 | Messages, Storage, Tokens |
 | Monad | 143 | Messages, Storage, Tokens |
+| Robinhood | 4663 | Messages, Storage, Tokens |
 | Base Sepolia | 84532 | Messages, Storage (Testnet) |
 | Sepolia | 11155111 | Messages, Storage (Testnet) |
 

--- a/plugins/net-protocol/skills/net-protocol/references/sdk-patterns.md
+++ b/plugins/net-protocol/skills/net-protocol/references/sdk-patterns.md
@@ -202,7 +202,7 @@ if (isNetrSupportedChain(chainId)) {
 }
 
 // Get all supported chain IDs
-const chainIds = getNetrSupportedChainIds(); // [8453, 9745, 143, 999]
+const chainIds = getNetrSupportedChainIds(); // [8453, 9745, 143, 999, 4663]
 ```
 
 ### Token Information

--- a/skill-references/urls.md
+++ b/skill-references/urls.md
@@ -13,6 +13,7 @@ The web app lives at `https://netprotocol.app` (testnets at `https://testnets.ne
 | 143 | `monad` |
 | 999 | `hyperliquid` |
 | 4326 | `megaeth` |
+| 4663 | `robinhood` |
 | 5112 | `ham` |
 | 8453 | `base` |
 | 9745 | `plasma` |
@@ -31,6 +32,7 @@ Note: HyperEVM uses the slug `hyperliquid`, not `hyperevm`.
 | 130 | `https://uniscan.xyz` |
 | 143 | `https://monadscan.com` |
 | 999 | `https://hyperliquid.cloud.blockscout.com` |
+| 4663 | `https://robinhoodchain.blockscout.com` |
 | 5112 | `https://explorer.ham.fun` |
 | 8453 | `https://basescan.org` |
 | 9745 | `https://plasmascan.to` |

--- a/yarn.lock
+++ b/yarn.lock
@@ -1228,7 +1228,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@net-protocol/bazaar@npm:^0.2.4, @net-protocol/bazaar@workspace:packages/net-bazaar":
+"@net-protocol/bazaar@npm:^0.2.5, @net-protocol/bazaar@workspace:packages/net-bazaar":
   version: 0.0.0-use.local
   resolution: "@net-protocol/bazaar@workspace:packages/net-bazaar"
   dependencies:


### PR DESCRIPTION
Follow-up to #141 (which added Robinhood Chain token-deploy support and was merged). This PR covers bazaar configuration for Robinhood plus the remaining places that enumerate Plasma/HyperEVM but were still missing Robinhood.

## Bazaar config (net-bazaar 0.2.5)
Configures chain 4663 to mirror Base's bazaar posture:
- **Flexible-fee contract family** (same addresses Base/Ethereum/HyperEVM/MegaETH use), **0% NFT + ERC-20 fees**
- **ERC-20 trades denominated in USDG** `0x5fc5360D0400a0Fd4f2af552ADD042D716F1d168` (6 decimals, verified on-chain) — Robinhood has no USDC
- WETH `0x0Bd7D308…`, fee collector matches Base (unused at 0% fee)
- Added chainConfig tests (0% fees, flexible-fee addresses, USDG)

> ⚠️ The bazaar contracts are **not yet deployed on 4663** (Seaport is live; the Net bazaar apps + Seaport zones are not). Do not publish `@net-protocol/bazaar@0.2.5` / the cli release or flip the public bazaar docs until the suite is deployed via the CREATE2 replay. Tracked in the `robinhood-bazaar-deployment-plan.md` operator checklist (Net PR #871).

## Chain-list gap fixes (non-bazaar, already-live features)
Robinhood was missing from several spots that already list Plasma/HyperEVM for live token-deploy / storage / URL features:
- `net-cli .../token/deploy.ts`: add Robinhood (4663) to the "unsupported chain" error message
- `net-core/README.md` + `plugins/net-protocol/README.md`: supported-chains lists
- `sdk-patterns.md`: `getNetrSupportedChainIds()` comment now includes 4663
- `skill-references/urls.md`: add the `robinhood` slug (4663) + Blockscout explorer URL

## net-cli 0.2.9
- Bumps version to 0.2.9 (for the deploy.ts error-message fix)
- Raises `@net-protocol/bazaar` floor to `^0.2.5` so a fresh install resolves the Robinhood-configured bazaar SDK (lockfile updated to match)

## Attribution setting
Adds a repo-scoped `.claude/settings.json` (`attribution.commit` / `attribution.pr`) so Claude Code keeps a plain co-author trailer on commits but adds no "Generated with Claude Code" / session-URL text to PR descriptions.

## Not changed here (deferred to post-deploy)
Bazaar-support docs (`net-bazaar/README.md`, `skill-references/bazaar.md`, SKILL.md bazaar rows) are intentionally left until the contracts are live on 4663, so the public skill doesn't advertise a bazaar whose orders revert. The exact spots are enumerated in the deployment plan's post-deploy doc-flip step.