### PR TITLE
Clarify net-target shape and add error guide to hosting.md

### DIFF
--- a/skill-references/hosting.md
+++ b/skill-references/hosting.md
@@ -229,16 +229,32 @@ and POST it (no x402 client needed — those calls carry no payment).
 
 | Response | Likely cause | Fix |
 |---|---|---|
-| `400 {"error":"invalid_body","message":"Required"}` | A required field is missing — most often a `net` target sent with a `url` instead of `chainId`/`operator`/`key` | Use the three `net` fields (see the mapping above). `url` belongs only to `redirect`/`proxy`. |
-| `402 Payment Required` | This is expected on `claim`/`renew` — it's the x402 challenge, not an error | Pay it with an x402 client and retry (see above). Don't add auth fields to "fix" it. |
-| `401 {"error":"unauthorized"}` | You sent `owner` (signed path) but no valid `signature`/`issuedAt`, or the signature didn't verify | On the **paid** path, omit `owner`/`signature`/`issuedAt` entirely — the x402 payer is the owner. Only `update`/`release` require a signature. |
-| `403 not_owner` (renew/update) | The paying/signing wallet isn't the one that claimed the name | Use the owner wallet from the original claim. |
-| `409 name_taken` | The name has a live (or in-grace) lease | Pick another name or wait for it to lapse. |
+| `400 {"error":"invalid_body","message":"Required"}` | **Any** required field is missing — `name`, `target`, `target.kind`, or the fields the chosen `kind` needs (`net`→`chainId`/`operator`/`key`; `redirect`/`proxy`→`url`; `hosted`→`platform`). A `net` target sent with a `url` is one common instance, not the only one. | Add the missing field. The message names the **first** missing field only, so a fresh `400` after your fix may point at a *different* one — re-read it each time. |
+| `400 {"error":"invalid_body", …}` (other messages) | A field is present but malformed — bad address, non-integer `chainId`, `url` that isn't `http(s)`, oversized value | Fix the named field; the message says which. |
+| `402 Payment Required` | Expected on `claim`/`renew` when the endpoint runs in **paid** mode — it's the x402 challenge, not an error, and it comes *before* body validation | Pay with an x402 client and retry (see above). Don't add auth fields to "fix" it. |
+| `401 {"error":"unauthorized"}` | The request authenticated as **nobody**: no verified x402 payer *and* no valid owner signature | Authenticate one way. In paid mode, pay over x402 (payer = owner). In free/signed mode (you never see a `402`), send `owner` + `issuedAt` + `signature`. |
+| `403 {"error":"not_owner"}` (renew/update/release) | The paying/signing wallet isn't the one that holds the lease | Use the wallet that claimed the name. |
+| `409 {"error":"name_taken"}` | The name has a live (or in-grace) lease | Pick another name or wait for it to lapse. |
+| `400 {"error":"reserved_name"}` / `{"error":"invalid_name"}` | The label is reserved, or breaks the charset/length rules | See [Name rules](#name-rules). |
 
-**Do not add an `owner` field to make a `400` go away.** The `400 "Required"` is about
-the missing `net` target fields, not a missing owner. Adding `owner` switches you to the
-signed path, which then demands `signature` + `issuedAt` and gives a `401` instead — it
-does not fix the target.
+### Two auth paths — know which one you're on
+
+Whether you sign depends on how the endpoint is running, and the response tells you which:
+
+- **Paid mode** — an unpaid `claim`/`renew` returns **`402`** *before* the body is even
+  validated. Pay over x402 and the **payer becomes the owner** — omit
+  `owner`/`signature`/`issuedAt`. (You'll only see a body `400` *after* the payment
+  handshake.)
+- **Free / signed mode** — you get a `400`/`401` and **never a `402`**. There's no payer,
+  so you must authenticate with a signature: send `owner` + `issuedAt` +
+  `signature` over the canonical message (see the **Update** section above, with
+  `Action: claim`).
+
+So a bare `400 "Required"` with no `402` in sight means two separate things are needed:
+fix the missing body field **and** be ready to sign. Adding `owner` alone fixes
+neither the `400` (a missing body field is unrelated to the owner) nor the auth (a
+signature needs `issuedAt` + `signature` too) — it just turns the `400` into a `401`.
+`update` and `release` are always signed, regardless of mode.
 
 ## Common flows
 

--- a/skill-references/hosting.md
+++ b/skill-references/hosting.md
@@ -48,11 +48,38 @@ A lease's `target` is a discriminated union keyed by `kind`. Pick one:
 | `proxy` | a URL **reverse-proxied** server-side and served under your subdomain (forwards asset paths, so SPAs render in place — not a redirect that bounces away) | `{ "kind": "proxy", "url": "https://my-app.example.com" }` |
 
 Notes:
+- Only `redirect` and `proxy` take a `url`. **`net` does NOT take a `url`** — it takes
+  three separate fields (`chainId`, `operator`, `key`). Putting a `url` on a `net`
+  target is the most common mistake and produces a `400 "Required"` (the required
+  `chainId`/`operator`/`key` are missing). See the mapping below.
 - `redirect` and `proxy` URLs must be well-formed `http(s)` URLs. `proxy` is fetched
   **server-side**, so private/internal hosts are blocked.
-- `net` content is what [`storedon.net`](https://netprotocol.app) renders from Net
-  Storage — upload with `netp storage upload` first, then point a `net` target at the
-  resulting `operator` + `key` (see [storage.md](https://raw.githubusercontent.com/stuckinaboot/net-public/main/skill-references/storage.md)).
+
+### Pointing a `net` target at already-uploaded content
+
+`net` content is what `storedon.net` serves from Net Storage. If you already have a
+storedon.net load URL, **don't paste it as a `url`** — split it into the three fields.
+The URL format is:
+
+```
+https://storedon.net/net/<chainId>/storage/load/<operator>/<key>
+```
+
+so a URL like
+`https://storedon.net/net/8453/storage/load/0x4cc5…efeb/snake-game-v1` maps to:
+
+```jsonc
+"target": {
+  "kind": "net",
+  "chainId": 8453,                                  // the /net/<chainId> segment
+  "operator": "0x4cc5c5cb393cfe5f17f226056d4875965e41efeb", // the /load/<operator> segment
+  "key": "snake-game-v1"                            // the trailing /<key> segment
+}
+```
+
+If you're uploading fresh, `netp storage upload --file ./page.html --key "my-key"
+--chain-id 8453` prints the `operator` (your wallet) and `key` to use (see
+[storage.md](https://raw.githubusercontent.com/stuckinaboot/net-public/main/skill-references/storage.md)).
 
 ## Endpoints
 
@@ -197,6 +224,21 @@ console.log(res.status, await res.json()); // → 200 + { hostname, registration
 
 For `update`/`release`, sign the canonical message shown above with the owner wallet
 and POST it (no x402 client needed — those calls carry no payment).
+
+## Common errors
+
+| Response | Likely cause | Fix |
+|---|---|---|
+| `400 {"error":"invalid_body","message":"Required"}` | A required field is missing — most often a `net` target sent with a `url` instead of `chainId`/`operator`/`key` | Use the three `net` fields (see the mapping above). `url` belongs only to `redirect`/`proxy`. |
+| `402 Payment Required` | This is expected on `claim`/`renew` — it's the x402 challenge, not an error | Pay it with an x402 client and retry (see above). Don't add auth fields to "fix" it. |
+| `401 {"error":"unauthorized"}` | You sent `owner` (signed path) but no valid `signature`/`issuedAt`, or the signature didn't verify | On the **paid** path, omit `owner`/`signature`/`issuedAt` entirely — the x402 payer is the owner. Only `update`/`release` require a signature. |
+| `403 not_owner` (renew/update) | The paying/signing wallet isn't the one that claimed the name | Use the owner wallet from the original claim. |
+| `409 name_taken` | The name has a live (or in-grace) lease | Pick another name or wait for it to lapse. |
+
+**Do not add an `owner` field to make a `400` go away.** The `400 "Required"` is about
+the missing `net` target fields, not a missing owner. Adding `owner` switches you to the
+signed path, which then demands `signature` + `issuedAt` and gives a `401` instead — it
+does not fix the target.
 
 ## Common flows
 

--- a/skill-references/hosting.md
+++ b/skill-references/hosting.md
@@ -227,34 +227,16 @@ and POST it (no x402 client needed — those calls carry no payment).
 
 ## Common errors
 
-| Response | Likely cause | Fix |
+| Response | Cause | Fix |
 |---|---|---|
-| `400 {"error":"invalid_body","message":"Required"}` | **Any** required field is missing — `name`, `target`, `target.kind`, or the fields the chosen `kind` needs (`net`→`chainId`/`operator`/`key`; `redirect`/`proxy`→`url`; `hosted`→`platform`). A `net` target sent with a `url` is one common instance, not the only one. | Add the missing field. The message names the **first** missing field only, so a fresh `400` after your fix may point at a *different* one — re-read it each time. |
-| `400 {"error":"invalid_body", …}` (other messages) | A field is present but malformed — bad address, non-integer `chainId`, `url` that isn't `http(s)`, oversized value | Fix the named field; the message says which. |
-| `402 Payment Required` | Expected on `claim`/`renew` when the endpoint runs in **paid** mode — it's the x402 challenge, not an error, and it comes *before* body validation | Pay with an x402 client and retry (see above). Don't add auth fields to "fix" it. |
-| `401 {"error":"unauthorized"}` | The request authenticated as **nobody**: no verified x402 payer *and* no valid owner signature | Authenticate one way. In paid mode, pay over x402 (payer = owner). In free/signed mode (you never see a `402`), send `owner` + `issuedAt` + `signature`. |
-| `403 {"error":"not_owner"}` (renew/update/release) | The paying/signing wallet isn't the one that holds the lease | Use the wallet that claimed the name. |
-| `409 {"error":"name_taken"}` | The name has a live (or in-grace) lease | Pick another name or wait for it to lapse. |
-| `400 {"error":"reserved_name"}` / `{"error":"invalid_name"}` | The label is reserved, or breaks the charset/length rules | See [Name rules](#name-rules). |
+| `400 "Required"` | A required field is missing. Most often: a `net` target sent with a `url` (only `redirect`/`proxy` take a `url`; `net` takes `chainId`/`operator`/`key`). | Add the missing field. The message names one field at a time, so re-read it after each fix. |
+| `402 Payment Required` | Expected on `claim`/`renew` — this is the x402 challenge, not an error. | Pay it with an x402 client and retry. Don't add fields to "fix" it. |
+| `401 unauthorized` | The request proved no owner. | Pay over x402 (payer = owner). If the endpoint never returns a `402`, sign instead: send `owner` + `issuedAt` + `signature`. |
+| `403 not_owner` | The wallet isn't the one that holds the lease. | Use the wallet that claimed the name. |
+| `409 name_taken` | The name is currently leased. | Pick another name, or wait for it to lapse. |
 
-### Two auth paths — know which one you're on
-
-Whether you sign depends on how the endpoint is running, and the response tells you which:
-
-- **Paid mode** — an unpaid `claim`/`renew` returns **`402`** *before* the body is even
-  validated. Pay over x402 and the **payer becomes the owner** — omit
-  `owner`/`signature`/`issuedAt`. (You'll only see a body `400` *after* the payment
-  handshake.)
-- **Free / signed mode** — you get a `400`/`401` and **never a `402`**. There's no payer,
-  so you must authenticate with a signature: send `owner` + `issuedAt` +
-  `signature` over the canonical message (see the **Update** section above, with
-  `Action: claim`).
-
-So a bare `400 "Required"` with no `402` in sight means two separate things are needed:
-fix the missing body field **and** be ready to sign. Adding `owner` alone fixes
-neither the `400` (a missing body field is unrelated to the owner) nor the auth (a
-signature needs `issuedAt` + `signature` too) — it just turns the `400` into a `401`.
-`update` and `release` are always signed, regardless of mode.
+Adding an `owner` field does not fix a `400` — that's a missing *body* field, unrelated
+to the owner.
 
 ## Common flows
 


### PR DESCRIPTION
Follow-up to #145 (merged). Closes a real gap surfaced by an actual failed claim: a `net` target was sent with a `url` field (natural, since `redirect`/`proxy` use `url`), which returns `400 "Required"` because `net` needs `chainId`/`operator`/`key` instead.

## Changes (all in `skill-references/hosting.md`)

- **Explicit warning** on the `net` target: it takes no `url` — it takes `chainId`/`operator`/`key`, and a `url` there is the common cause of `400 "Required"`.
- **storedon.net URL → fields mapping**: shows how to split `https://storedon.net/net/<chainId>/storage/load/<operator>/<key>` into the three `net` fields (URL format verified against `urls.md`/`storage.md`).
- **New "Common errors" table**: maps each real response (`400 invalid_body`, `402`, `401 unauthorized`, `403 not_owner`, `409 name_taken`) to cause + fix — including that `402` is the *expected* x402 challenge, and an explicit note that **adding `owner` does not fix the `400`** (it switches you to the signed path and yields a `401`). Error strings match the actual handler in the Net repo.

## Verification

Response codes/messages checked against `handlers.ts` (`ERROR_STATUS`, `readBody`/Zod `"Required"`, `resolveOwner`) and `registrar.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016LeEN6FJsq5cBrhWAJ7WZ1

---
_Generated by [Claude Code](https://claude.ai/code/session_016LeEN6FJsq5cBrhWAJ7WZ1)_