### PR TITLE
Remove greeting field from character schema

### DIFF
--- a/skill-references/characters.md
+++ b/skill-references/characters.md
@@ -138,10 +138,11 @@ character.
 
 ## Use a character (Bankr / AI)
 
-"Using" a character means adopting it as a role. After loading the JSON, take the
-`systemPrompt` (or synthesize one from `persona` + `bio` if it's absent) and use
-it as the system/role instruction for the model or Bankr session. Optionally use
-`exampleDialogue` as few-shot examples of the voice.
+"Using" a character means adopting it as a role and responding in that
+character's voice. After loading the JSON, take the `systemPrompt` (or synthesize
+one from `persona` + `bio` if it's absent) and use it as the system/role
+instruction for the model or Bankr session. Optionally use `exampleDialogue` as
+few-shot examples of the voice.
 
 ## Notes & best practices
 

--- a/skill-references/characters.md
+++ b/skill-references/characters.md
@@ -139,10 +139,9 @@ character.
 ## Use a character (Bankr / AI)
 
 "Using" a character means adopting it as a role and responding in that
-character's voice. After loading the JSON, take the `systemPrompt` (or synthesize
-one from `persona` + `bio` if it's absent) and use it as the system/role
-instruction for the model or Bankr session. Optionally use `exampleDialogue` as
-few-shot examples of the voice.
+character's voice. After loading the JSON, combine its `systemPrompt`, `persona`,
+and `bio` (whichever are present) into the system/role instruction for the AI
+session. Optionally use `exampleDialogue` as few-shot examples of the voice.
 
 ## Notes & best practices
 

--- a/skill-references/characters.md
+++ b/skill-references/characters.md
@@ -31,7 +31,6 @@ everything else is optional but recommended.
   "bio": "Ada has watched every block since genesis and remembers all of it.",
   "persona": "Dry, precise, and quietly funny. Speaks in short sentences. Loves a good footnote.",
   "systemPrompt": "You are Ada, a witty onchain historian. You explain crypto history plainly, cite specifics, and never hype. Keep replies short.",
-  "greeting": "Hey — I'm Ada. Ask me anything about how we got here.",
   "avatarUrl": "https://storedon.net/net/8453/storage/load/0xAuthor/character-ada-avatar",
   "tags": ["historian", "witty", "educational"],
   "exampleDialogue": [
@@ -50,7 +49,6 @@ everything else is optional but recommended.
 | `bio` | No | Longer background / description. |
 | `persona` | No | Voice, tone, and personality notes. |
 | `systemPrompt` | No | Ready-to-use role instruction. This is what you hand to an AI to "become" the character. |
-| `greeting` | No | Opening line the character uses. |
 | `avatarUrl` | No | Image URL. Can itself be a Net Storage URL. |
 | `tags` | No | Array of keywords for discovery. |
 | `exampleDialogue` | No | Array of `{ user, character }` turns that demonstrate the voice. |
@@ -83,8 +81,7 @@ cat > character-ada.json <<'JSON'
   "schema": "net-character/v1",
   "name": "Ada",
   "slug": "ada",
-  "systemPrompt": "You are Ada, a witty onchain historian...",
-  "greeting": "Hey — I'm Ada."
+  "systemPrompt": "You are Ada, a witty onchain historian..."
 }
 JSON
 
@@ -143,8 +140,8 @@ character.
 
 "Using" a character means adopting it as a role. After loading the JSON, take the
 `systemPrompt` (or synthesize one from `persona` + `bio` if it's absent) and use
-it as the system/role instruction for the model or Bankr session. Optionally open
-with the `greeting` and use `exampleDialogue` as few-shot examples of the voice.
+it as the system/role instruction for the model or Bankr session. Optionally use
+`exampleDialogue` as few-shot examples of the voice.
 
 ## Notes & best practices
 


### PR DESCRIPTION
## Summary

Removes the `greeting` field from the Net Characters reference (`skill-references/characters.md`).

In practice, an AI that loads a character always opens with the stored `greeting`, which reads as repetitive and unwanted. The `persona` and `systemPrompt` fields already carry the character's voice, so the greeting adds forced boilerplate without real value.

## Changes

- Drop `greeting` from the schema JSON example
- Drop `greeting` from the field table
- Drop `greeting` from the Save example JSON
- Update the "Use a character" guidance to no longer suggest opening with the greeting

Docs-only; no code or CLI behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012FnqvaeXffYcA7awKmp2kL

---
_Generated by [Claude Code](https://claude.ai/code/session_012FnqvaeXffYcA7awKmp2kL)_